### PR TITLE
feat(rules): builder pur des transitions candidates (évaluation partielle tri-valuée)

### DIFF
--- a/packages/app/src/server/rules/__tests__/nextSteps.test.ts
+++ b/packages/app/src/server/rules/__tests__/nextSteps.test.ts
@@ -111,15 +111,13 @@ describe("loadRulesWithFallback", () => {
 		expect(loadRulesWithFallback(null)).toBe(loadRulesWithFallback("2027.1"));
 	});
 
-	// Critère d'acceptation : « ne throw jamais sur une version absente, vide ou
-	// inconnue » — S7 exige qu'une déclaration historique ne produise pas de 500.
 	it.each([
 		"constructor",
 		"toString",
 		"valueOf",
 		"__proto__",
 		"hasOwnProperty",
-	])("ne throw pas pour la version inconnue %o héritée d'Object.prototype", (version) => {
+	])("ne throw pas pour %o, version inconnue héritée d'Object.prototype — S7 interdit un 500 sur une déclaration historique", (version) => {
 		expect(() => loadRulesWithFallback(version)).not.toThrow();
 		expect(loadRulesWithFallback(version).version).toBe("2027.1");
 	});
@@ -459,12 +457,10 @@ describe("Kleene — un fait `null` est connu, seul un fait absent est indécis"
 		).toBeNull();
 	});
 
-	// Divergence assumée avec `evaluatePredicate` d'engine.ts, où `isNull` répond
-	// `true` sur un fait absent : à l'export, l'absence signifie « pas encore su ».
 	it.each([
 		"isNull",
 		"isNotNull",
-	] as const)("`%s` reste indécis quand la clé du fait est absente", (op) => {
+	] as const)("`%s` reste indécis sur une clé absente, là où engine.ts décide `true` — à l'export, l'absence signifie « pas encore su »", (op) => {
 		const guard: Predicate = { fact: "cancelledAt", op };
 
 		expect(guardOutcome(guard, KNOWN_FACTS)).toEqual(guard);

--- a/packages/app/src/server/rules/__tests__/nextSteps.test.ts
+++ b/packages/app/src/server/rules/__tests__/nextSteps.test.ts
@@ -1,0 +1,642 @@
+import { describe, expect, it } from "vitest";
+import type { DeclarationFsmStatus } from "~/modules/domain";
+import {
+	type Facts,
+	isKnownRulesVersion,
+	loadRules,
+	type Rules,
+} from "../engine";
+import {
+	DEFAULT_RULES_VERSION,
+	listNextTransitions,
+	loadRulesWithFallback,
+} from "../nextSteps";
+import type { Predicate } from "../schema";
+
+const bundled = loadRules(DEFAULT_RULES_VERSION);
+
+type SyntheticTransition = {
+	id: string;
+	action?: string;
+	from?: DeclarationFsmStatus[];
+	to?: DeclarationFsmStatus;
+	matchPayload?: Record<string, unknown>;
+	guard?: Predicate;
+};
+
+type SyntheticExtras = {
+	computations?: Rules["computations"];
+	thresholds?: Rules["thresholds"];
+};
+
+function makeRules(
+	transitions: SyntheticTransition[],
+	extras: SyntheticExtras = {},
+): Rules {
+	const built: Rules["transitions"] = transitions.map((transition) => ({
+		action: "act",
+		events: [],
+		from: ["draft"],
+		to: "demarche_completed",
+		...transition,
+	}));
+	return {
+		version: "test",
+		thresholds: extras.thresholds ?? {},
+		stages: [{ id: 1, name: "test" }],
+		states: [{ id: "draft", stage: 1 }],
+		computations: extras.computations,
+		transitions: built,
+	};
+}
+
+/** Runs a guard alone through `listNextTransitions` and returns its Kleene outcome: `"excluded"` (decided false), `null` (decided true) or the residual predicate (undecided). */
+function guardOutcome(
+	guard: Predicate | undefined,
+	facts: Facts,
+	extras: SyntheticExtras = {},
+): "excluded" | Predicate | null {
+	const [entry] = listNextTransitions(
+		makeRules([{ id: "t", guard }], extras),
+		"draft",
+		facts,
+	);
+	return entry === undefined ? "excluded" : entry.residualGuard;
+}
+
+const KNOWN_FACTS: Facts = { known: true };
+const TRUE_LEAF: Predicate = { fact: "known", op: "==", value: true };
+const FALSE_LEAF: Predicate = { fact: "known", op: "!=", value: true };
+const UNKNOWN_LEAF: Predicate = { fact: "future", op: "==", value: true };
+const OTHER_UNKNOWN_LEAF: Predicate = {
+	fact: "otherFuture",
+	op: "==",
+	value: false,
+};
+
+describe("isKnownRulesVersion", () => {
+	it("reconnaît la version embarquée", () => {
+		expect(isKnownRulesVersion("2027.1")).toBe(true);
+	});
+
+	it.each(["1999.9", "2027.2", ""])("rejette la version %o", (version) => {
+		expect(isKnownRulesVersion(version)).toBe(false);
+	});
+});
+
+describe("DEFAULT_RULES_VERSION", () => {
+	it("vaut 2027.1 et désigne une version embarquée", () => {
+		expect(DEFAULT_RULES_VERSION).toBe("2027.1");
+		expect(isKnownRulesVersion(DEFAULT_RULES_VERSION)).toBe(true);
+	});
+});
+
+describe("loadRulesWithFallback", () => {
+	it.each([
+		["null", null],
+		["undefined", undefined],
+		["chaîne vide", ""],
+		["version inconnue", "1999.9"],
+		["version future non embarquée", "2028.1"],
+	])("retombe sur 2027.1 pour %s", (_label, version) => {
+		expect(() => loadRulesWithFallback(version)).not.toThrow();
+		expect(loadRulesWithFallback(version).version).toBe("2027.1");
+	});
+
+	it("retourne le ruleset embarqué pour la version reconnue", () => {
+		expect(loadRulesWithFallback("2027.1")).toBe(bundled);
+	});
+
+	it("retourne le même ruleset pour une version absente et pour la version reconnue", () => {
+		expect(loadRulesWithFallback(null)).toBe(loadRulesWithFallback("2027.1"));
+	});
+
+	// Critère d'acceptation : « ne throw jamais sur une version absente, vide ou
+	// inconnue » — S7 exige qu'une déclaration historique ne produise pas de 500.
+	it.each([
+		"constructor",
+		"toString",
+		"valueOf",
+		"__proto__",
+		"hasOwnProperty",
+	])("ne throw pas pour la version inconnue %o héritée d'Object.prototype", (version) => {
+		expect(() => loadRulesWithFallback(version)).not.toThrow();
+		expect(loadRulesWithFallback(version).version).toBe("2027.1");
+	});
+});
+
+describe("listNextTransitions — scénarios normatifs du ruleset 2027.1", () => {
+	it("awaiting_compliance_path_choice avec CSE : 3 branches décidées, sans la variante sans CSE", () => {
+		expect(
+			listNextTransitions(bundled, "awaiting_compliance_path_choice", {
+				cseRequired: true,
+			}),
+		).toEqual([
+			{
+				id: "choose_path_initial_justify_with_cse",
+				action: "choose_compliance_path",
+				to: "awaiting_cse_opinion",
+				residualGuard: null,
+			},
+			{
+				id: "choose_path_initial_corrective_action",
+				action: "choose_compliance_path",
+				to: "corrective_actions_chosen",
+				residualGuard: null,
+			},
+			{
+				id: "choose_path_initial_joint_evaluation",
+				action: "choose_compliance_path",
+				to: "joint_evaluation_chosen",
+				residualGuard: null,
+			},
+		]);
+	});
+
+	it("corrective_actions_chosen avec CSE : 2 branches indécises, résidus dénudés", () => {
+		expect(
+			listNextTransitions(bundled, "corrective_actions_chosen", {
+				cseRequired: true,
+			}),
+		).toEqual([
+			{
+				id: "submit_second_declaration_persistent_gap",
+				action: "submit_second_declaration",
+				to: "awaiting_revision_choice",
+				residualGuard: { fact: "action.stillHasGap", op: "==", value: true },
+			},
+			{
+				id: "submit_second_declaration_resolved_with_cse",
+				action: "submit_second_declaration",
+				to: "awaiting_cse_opinion",
+				residualGuard: { fact: "action.stillHasGap", op: "==", value: false },
+			},
+		]);
+	});
+
+	it("corrective_actions_chosen sans CSE : la branche sans CSE remplace celle avec CSE", () => {
+		expect(
+			listNextTransitions(bundled, "corrective_actions_chosen", {
+				cseRequired: false,
+			}),
+		).toEqual([
+			{
+				id: "submit_second_declaration_persistent_gap",
+				action: "submit_second_declaration",
+				to: "awaiting_revision_choice",
+				residualGuard: { fact: "action.stillHasGap", op: "==", value: true },
+			},
+			{
+				id: "submit_second_declaration_resolved_without_cse",
+				action: "submit_second_declaration",
+				to: "demarche_completed",
+				residualGuard: { fact: "action.stillHasGap", op: "==", value: false },
+			},
+		]);
+	});
+
+	it("demarche_completed : submit_cse_opinion reste offerte, la liste n'est pas vide", () => {
+		expect(
+			listNextTransitions(bundled, "demarche_completed", { cseRequired: true }),
+		).toEqual([
+			{
+				id: "submit_cse_opinion",
+				action: "submit_cse_opinion",
+				to: "demarche_completed",
+				residualGuard: null,
+			},
+		]);
+	});
+
+	it.each(
+		bundled.states.map((state) => state.id),
+	)("sans aucun fait connu, l'état %s conserve toutes ses transitions dans l'ordre du ruleset", (status) => {
+		const expected = bundled.transitions.filter((transition) =>
+			transition.from.includes(status),
+		);
+		const actual = listNextTransitions(bundled, status, {});
+
+		expect(actual.map((entry) => entry.id)).toEqual(
+			expected.map((transition) => transition.id),
+		);
+		for (const [index, transition] of expected.entries()) {
+			expect(actual[index]?.residualGuard === null).toBe(
+				transition.guard === undefined,
+			);
+		}
+	});
+
+	it("ne déduplique ni par action ni par destination", () => {
+		const entries = listNextTransitions(
+			bundled,
+			"awaiting_revision_choice",
+			{},
+		);
+
+		expect(
+			entries.filter((entry) => entry.action === "submit_second_declaration"),
+		).toHaveLength(3);
+		expect(
+			entries.filter((entry) => entry.to === "awaiting_cse_opinion"),
+		).toHaveLength(2);
+		expect(
+			entries.filter((entry) => entry.to === "demarche_completed"),
+		).toHaveLength(2);
+	});
+
+	it("ne trie pas : l'ordre de déclaration du ruleset est restitué tel quel", () => {
+		const rules = makeRules([{ id: "zeta" }, { id: "alpha" }, { id: "mid" }]);
+
+		expect(
+			listNextTransitions(rules, "draft", {}).map((entry) => entry.id),
+		).toEqual(["zeta", "alpha", "mid"]);
+	});
+
+	it("ne mute ni le ruleset ni les faits reçus", () => {
+		const rulesSnapshot = JSON.stringify(bundled);
+		const facts: Facts = { cseRequired: true };
+
+		listNextTransitions(bundled, "corrective_actions_chosen", facts);
+
+		expect(JSON.stringify(bundled)).toBe(rulesSnapshot);
+		expect(facts).toEqual({ cseRequired: true });
+	});
+});
+
+describe("listNextTransitions — filtrage sur `from` et `matchPayload`", () => {
+	it("écarte les transitions dont `from` ne contient pas l'état courant", () => {
+		const rules = makeRules([
+			{ id: "from_draft", from: ["draft"] },
+			{ id: "from_elsewhere", from: ["demarche_completed"] },
+			{ id: "from_both", from: ["demarche_completed", "draft"] },
+		]);
+
+		expect(
+			listNextTransitions(rules, "draft", {}).map((entry) => entry.id),
+		).toEqual(["from_draft", "from_both"]);
+	});
+
+	it("n'exclut jamais sur `matchPayload`, même quand le payload connu contredit la variante", () => {
+		const rules = makeRules([
+			{ id: "justify", matchPayload: { path: "justify" } },
+			{ id: "corrective", matchPayload: { path: "corrective_action" } },
+			{ id: "no_payload" },
+		]);
+
+		expect(
+			listNextTransitions(rules, "draft", {
+				action: { path: "justify" },
+			}).map((entry) => entry.id),
+		).toEqual(["justify", "corrective", "no_payload"]);
+	});
+
+	it("offre les 3 variantes de choix du ruleset malgré un `action.path` connu", () => {
+		expect(
+			listNextTransitions(bundled, "awaiting_compliance_path_choice", {
+				cseRequired: true,
+				action: { path: "justify" },
+			}).map((entry) => entry.id),
+		).toEqual([
+			"choose_path_initial_justify_with_cse",
+			"choose_path_initial_corrective_action",
+			"choose_path_initial_joint_evaluation",
+		]);
+	});
+});
+
+describe("Kleene — feuilles `fact`", () => {
+	it("garde sans résidu une transition sans garde", () => {
+		expect(guardOutcome(undefined, KNOWN_FACTS)).toBeNull();
+	});
+
+	it("décide vrai quand le fait est connu et satisfait la comparaison", () => {
+		expect(guardOutcome(TRUE_LEAF, KNOWN_FACTS)).toBeNull();
+	});
+
+	it("écarte la transition quand le fait connu contredit la comparaison", () => {
+		expect(guardOutcome(FALSE_LEAF, KNOWN_FACTS)).toBe("excluded");
+	});
+
+	it("rend la feuille elle-même en résidu quand le fait est absent", () => {
+		expect(guardOutcome(UNKNOWN_LEAF, KNOWN_FACTS)).toEqual(UNKNOWN_LEAF);
+	});
+
+	it.each([
+		["==", 100, 100, true],
+		["==", 100, 42, false],
+		["!=", 100, 42, true],
+		["!=", 100, 100, false],
+		[">", 100, 42, true],
+		[">", 42, 100, false],
+		[">=", 100, 100, true],
+		[">=", 41, 42, false],
+		["<", 42, 100, true],
+		["<", 100, 42, false],
+		["<=", 100, 100, true],
+		["<=", 100, 42, false],
+	] as const)("applique l'opérateur %s (%d vs %d) comme le moteur", (op, factValue, compareValue, expected) => {
+		const guard = { fact: "workforce", op, value: compareValue } as Predicate;
+
+		expect(guardOutcome(guard, { workforce: factValue })).toBe(
+			expected ? null : "excluded",
+		);
+	});
+
+	it.each([
+		["appartenance vérifiée", "justify", null],
+		["appartenance refusée", "unknown_path", "excluded"],
+	])("applique l'opérateur `in` — %s", (_label, factValue, expected) => {
+		const guard: Predicate = {
+			fact: "path",
+			op: "in",
+			value: ["justify", "corrective_action"],
+		};
+
+		expect(guardOutcome(guard, { path: factValue })).toBe(expected);
+	});
+
+	it("résout `threshold` contre les seuils du ruleset", () => {
+		const guard: Predicate = {
+			fact: "workforce",
+			op: ">=",
+			threshold: "phase2SizeMin",
+		};
+		const extras: SyntheticExtras = { thresholds: { phase2SizeMin: 100 } };
+
+		expect(guardOutcome(guard, { workforce: 100 }, extras)).toBeNull();
+		expect(guardOutcome(guard, { workforce: 99 }, extras)).toBe("excluded");
+	});
+
+	it("décide faux quand le seuil nommé est absent du ruleset", () => {
+		const guard: Predicate = {
+			fact: "workforce",
+			op: ">=",
+			threshold: "absentThreshold",
+		};
+
+		expect(guardOutcome(guard, { workforce: 300 })).toBe("excluded");
+	});
+
+	it("décide faux plutôt que de lever sur un nœud de comparaison sans `value` ni `threshold`", () => {
+		const guard = { fact: "known", op: "==" } as unknown as Predicate;
+
+		expect(guardOutcome(guard, KNOWN_FACTS)).toBe("excluded");
+	});
+
+	it("résout les chemins pointés", () => {
+		const guard: Predicate = {
+			fact: "action.stillHasGap",
+			op: "==",
+			value: true,
+		};
+
+		expect(guardOutcome(guard, { action: { stillHasGap: true } })).toBeNull();
+		expect(guardOutcome(guard, { action: { stillHasGap: false } })).toBe(
+			"excluded",
+		);
+	});
+
+	it("rend indécis un chemin pointé traversant un intermédiaire nul ou absent", () => {
+		const guard: Predicate = {
+			fact: "action.stillHasGap",
+			op: "==",
+			value: true,
+		};
+
+		expect(guardOutcome(guard, { action: null })).toEqual(guard);
+		expect(guardOutcome(guard, {})).toEqual(guard);
+	});
+
+	it("lève sur un opérateur inconnu", () => {
+		const guard = {
+			fact: "known",
+			op: "~=",
+			value: true,
+		} as unknown as Predicate;
+
+		expect(() => guardOutcome(guard, KNOWN_FACTS)).toThrow(
+			'Unknown operator: "~="',
+		);
+	});
+
+	it("lève sur un nœud de prédicat non reconnu", () => {
+		const guard = {} as unknown as Predicate;
+
+		expect(() => guardOutcome(guard, KNOWN_FACTS)).toThrow(
+			"Unrecognized predicate node",
+		);
+	});
+});
+
+describe("Kleene — un fait `null` est connu, seul un fait absent est indécis", () => {
+	it("`isNull` décide vrai sur un fait explicitement nul", () => {
+		expect(
+			guardOutcome(
+				{ fact: "cancelledAt", op: "isNull" },
+				{ cancelledAt: null },
+			),
+		).toBeNull();
+		expect(
+			guardOutcome(
+				{ fact: "cancelledAt", op: "isNull" },
+				{ cancelledAt: "2027-01-01" },
+			),
+		).toBe("excluded");
+	});
+
+	it("`isNotNull` décide faux sur un fait explicitement nul", () => {
+		expect(
+			guardOutcome(
+				{ fact: "cancelledAt", op: "isNotNull" },
+				{ cancelledAt: null },
+			),
+		).toBe("excluded");
+		expect(
+			guardOutcome(
+				{ fact: "cancelledAt", op: "isNotNull" },
+				{ cancelledAt: "2027-01-01" },
+			),
+		).toBeNull();
+	});
+
+	// Divergence assumée avec `evaluatePredicate` d'engine.ts, où `isNull` répond
+	// `true` sur un fait absent : à l'export, l'absence signifie « pas encore su ».
+	it.each([
+		"isNull",
+		"isNotNull",
+	] as const)("`%s` reste indécis quand la clé du fait est absente", (op) => {
+		const guard: Predicate = { fact: "cancelledAt", op };
+
+		expect(guardOutcome(guard, KNOWN_FACTS)).toEqual(guard);
+	});
+
+	it("distingue un fait nul d'un fait absent dans une comparaison", () => {
+		const guard: Predicate = { fact: "gap", op: "==", value: null };
+
+		expect(guardOutcome(guard, { gap: null })).toBeNull();
+		expect(guardOutcome(guard, {})).toEqual(guard);
+	});
+});
+
+describe("Kleene — `all`", () => {
+	it.each([
+		["tous vrais", [TRUE_LEAF, TRUE_LEAF], null],
+		["un faux", [TRUE_LEAF, FALSE_LEAF], "excluded"],
+		["un faux prime sur un indécis", [FALSE_LEAF, UNKNOWN_LEAF], "excluded"],
+		["conjonction vide", [], null],
+	])("%s", (_label, children, expected) => {
+		expect(guardOutcome({ all: children as Predicate[] }, KNOWN_FACTS)).toBe(
+			expected,
+		);
+	});
+
+	it("élague les enfants vrais et dénude le résidu à un seul enfant", () => {
+		expect(
+			guardOutcome({ all: [UNKNOWN_LEAF, TRUE_LEAF] }, KNOWN_FACTS),
+		).toEqual(UNKNOWN_LEAF);
+	});
+
+	it("conserve un `all` quand plusieurs enfants restent indécis", () => {
+		expect(
+			guardOutcome(
+				{ all: [TRUE_LEAF, UNKNOWN_LEAF, OTHER_UNKNOWN_LEAF] },
+				KNOWN_FACTS,
+			),
+		).toEqual({ all: [UNKNOWN_LEAF, OTHER_UNKNOWN_LEAF] });
+	});
+});
+
+describe("Kleene — `any`", () => {
+	it.each([
+		["tous faux", [FALSE_LEAF, FALSE_LEAF], "excluded"],
+		["un vrai", [FALSE_LEAF, TRUE_LEAF], null],
+		["un vrai prime sur un indécis", [TRUE_LEAF, UNKNOWN_LEAF], null],
+		["disjonction vide", [], "excluded"],
+	])("%s", (_label, children, expected) => {
+		expect(guardOutcome({ any: children as Predicate[] }, KNOWN_FACTS)).toBe(
+			expected,
+		);
+	});
+
+	it("élague les enfants faux et dénude le résidu à un seul enfant", () => {
+		expect(
+			guardOutcome({ any: [FALSE_LEAF, UNKNOWN_LEAF] }, KNOWN_FACTS),
+		).toEqual(UNKNOWN_LEAF);
+	});
+
+	it("conserve un `any` quand plusieurs enfants restent indécis", () => {
+		expect(
+			guardOutcome(
+				{ any: [FALSE_LEAF, UNKNOWN_LEAF, OTHER_UNKNOWN_LEAF] },
+				KNOWN_FACTS,
+			),
+		).toEqual({ any: [UNKNOWN_LEAF, OTHER_UNKNOWN_LEAF] });
+	});
+});
+
+describe("Kleene — `not`", () => {
+	it("inverse un enfant décidé", () => {
+		expect(guardOutcome({ not: TRUE_LEAF }, KNOWN_FACTS)).toBe("excluded");
+		expect(guardOutcome({ not: FALSE_LEAF }, KNOWN_FACTS)).toBeNull();
+	});
+
+	it("laisse l'indécis indécis et enveloppe son résidu", () => {
+		expect(guardOutcome({ not: UNKNOWN_LEAF }, KNOWN_FACTS)).toEqual({
+			not: UNKNOWN_LEAF,
+		});
+	});
+
+	it("enveloppe le résidu déjà élagué de son enfant", () => {
+		expect(
+			guardOutcome({ not: { all: [TRUE_LEAF, UNKNOWN_LEAF] } }, KNOWN_FACTS),
+		).toEqual({ not: UNKNOWN_LEAF });
+	});
+});
+
+describe("Kleene — `compute`", () => {
+	const computations: Rules["computations"] = {
+		decidedTrue: TRUE_LEAF,
+		decidedFalse: FALSE_LEAF,
+		undecided: { all: [TRUE_LEAF, UNKNOWN_LEAF] },
+		chained: { compute: "undecided" },
+	};
+
+	it("décide comme la computation résolue", () => {
+		expect(
+			guardOutcome({ compute: "decidedTrue" }, KNOWN_FACTS, { computations }),
+		).toBeNull();
+		expect(
+			guardOutcome({ compute: "decidedFalse" }, KNOWN_FACTS, { computations }),
+		).toBe("excluded");
+	});
+
+	it("rend le nœud `compute` lui-même en résidu, sans déplier la computation", () => {
+		expect(
+			guardOutcome({ compute: "undecided" }, KNOWN_FACTS, { computations }),
+		).toEqual({ compute: "undecided" });
+	});
+
+	it("rend le nœud `compute` le plus externe pour une computation chaînée", () => {
+		expect(
+			guardOutcome({ compute: "chained" }, KNOWN_FACTS, { computations }),
+		).toEqual({ compute: "chained" });
+	});
+
+	it("lève sur une computation inconnue", () => {
+		expect(() =>
+			guardOutcome({ compute: "absente" }, KNOWN_FACTS, { computations }),
+		).toThrow('Unknown computation: "absente"');
+	});
+
+	it("lève sur une computation inconnue quand le ruleset n'en déclare aucune", () => {
+		expect(() => guardOutcome({ compute: "absente" }, KNOWN_FACTS)).toThrow(
+			'Unknown computation: "absente"',
+		);
+	});
+
+	it("décide les gardes composées de `compute` du ruleset 2027.1", () => {
+		const facts: Facts = {
+			workforce: 300,
+			indicatorGCalculated: true,
+			gap: 10,
+			hasCse: true,
+		};
+
+		expect(
+			listNextTransitions(bundled, "draft", facts).map((entry) => entry.id),
+		).toEqual(["submit_to_compliance_path_choice"]);
+	});
+
+	it("remonte des résidus `compute` et `not` depuis draft sans faits connus", () => {
+		expect(listNextTransitions(bundled, "draft", {})).toEqual([
+			{
+				id: "submit_to_compliance_path_choice",
+				action: "submit",
+				to: "awaiting_compliance_path_choice",
+				residualGuard: { compute: "phase2Required" },
+			},
+			{
+				id: "submit_to_cse_opinion_directly",
+				action: "submit",
+				to: "awaiting_cse_opinion",
+				residualGuard: {
+					all: [
+						{ not: { compute: "phase2Required" } },
+						{ compute: "cseRequired" },
+					],
+				},
+			},
+			{
+				id: "submit_to_demarche_completed_directly",
+				action: "submit",
+				to: "demarche_completed",
+				residualGuard: {
+					all: [
+						{ not: { compute: "phase2Required" } },
+						{ not: { compute: "cseRequired" } },
+					],
+				},
+			},
+		]);
+	});
+});

--- a/packages/app/src/server/rules/engine.ts
+++ b/packages/app/src/server/rules/engine.ts
@@ -190,7 +190,7 @@ const BUNDLED_VERSIONS: Record<string, unknown> = {
 };
 
 export function isKnownRulesVersion(version: string): boolean {
-	return version in BUNDLED_VERSIONS;
+	return Object.hasOwn(BUNDLED_VERSIONS, version);
 }
 
 export function loadRules(version: string): Rules {

--- a/packages/app/src/server/rules/engine.ts
+++ b/packages/app/src/server/rules/engine.ts
@@ -189,6 +189,10 @@ const BUNDLED_VERSIONS: Record<string, unknown> = {
 	"2027.1": rawV20271,
 };
 
+export function isKnownRulesVersion(version: string): boolean {
+	return version in BUNDLED_VERSIONS;
+}
+
 export function loadRules(version: string): Rules {
 	const cached = cache.get(version);
 	if (cached) return cached;

--- a/packages/app/src/server/rules/nextSteps.ts
+++ b/packages/app/src/server/rules/nextSteps.ts
@@ -174,7 +174,8 @@ export function listNextTransitions(
 			id: transition.id,
 			action: transition.action,
 			to: transition.to,
-			residualGuard: evaluation.value === "unknown" ? evaluation.residual : null,
+			residualGuard:
+				evaluation.value === "unknown" ? evaluation.residual : null,
 		});
 	}
 	return candidates;

--- a/packages/app/src/server/rules/nextSteps.ts
+++ b/packages/app/src/server/rules/nextSteps.ts
@@ -1,0 +1,181 @@
+import type { DeclarationFsmStatus } from "~/modules/domain";
+import {
+	type Facts,
+	isKnownRulesVersion,
+	loadRules,
+	type Rules,
+} from "./engine";
+import type { Predicate } from "./schema";
+
+export const DEFAULT_RULES_VERSION = "2027.1";
+
+export type NextTransition = {
+	id: string;
+	action: string;
+	to: DeclarationFsmStatus;
+	/** Guard branches left undecided by the known facts, pruned of everything already decided. `null` when the guard is fully decided or absent. */
+	residualGuard: Predicate | null;
+};
+
+type Kleene = true | false | "unknown";
+
+type Evaluation = { value: Kleene; residual: Predicate | null };
+
+type EvaluationContext = {
+	facts: Facts;
+	computations: Record<string, unknown>;
+	thresholds: Record<string, number>;
+};
+
+const DECIDED_TRUE: Evaluation = { value: true, residual: null };
+const DECIDED_FALSE: Evaluation = { value: false, residual: null };
+
+function decided(value: boolean): Evaluation {
+	return value ? DECIDED_TRUE : DECIDED_FALSE;
+}
+
+function resolveFactValue(facts: Facts, path: string): unknown {
+	const parts = path.split(".");
+	let current: unknown = facts;
+	for (const part of parts) {
+		if (current === null || current === undefined) return undefined;
+		current = (current as Record<string, unknown>)[part];
+	}
+	return current;
+}
+
+function resolveCompareValue(
+	node: Record<string, unknown>,
+	thresholds: Record<string, number>,
+): number | string | boolean | null | undefined {
+	if ("value" in node) return node.value as number | string | boolean | null;
+	if ("threshold" in node && typeof node.threshold === "string") {
+		return thresholds[node.threshold];
+	}
+	return undefined;
+}
+
+function pruneResiduals(
+	kind: "all" | "any",
+	undecided: Evaluation[],
+): Predicate | null {
+	const residuals = undecided
+		.map((child) => child.residual)
+		.filter((residual): residual is Predicate => residual !== null);
+	const [first] = residuals;
+	if (first === undefined) return null;
+	if (residuals.length === 1) return first;
+	return kind === "all" ? { all: residuals } : { any: residuals };
+}
+
+function evaluateNode(node: unknown, ctx: EvaluationContext): Evaluation {
+	if (node === null || node === undefined) return DECIDED_TRUE;
+	const n = node as Record<string, unknown>;
+
+	if ("all" in n && Array.isArray(n.all)) {
+		const children = n.all.map((child) => evaluateNode(child, ctx));
+		if (children.some((child) => child.value === false)) return DECIDED_FALSE;
+		const undecided = children.filter((child) => child.value === "unknown");
+		if (undecided.length === 0) return DECIDED_TRUE;
+		return { value: "unknown", residual: pruneResiduals("all", undecided) };
+	}
+
+	if ("any" in n && Array.isArray(n.any)) {
+		const children = n.any.map((child) => evaluateNode(child, ctx));
+		if (children.some((child) => child.value === true)) return DECIDED_TRUE;
+		const undecided = children.filter((child) => child.value === "unknown");
+		if (undecided.length === 0) return DECIDED_FALSE;
+		return { value: "unknown", residual: pruneResiduals("any", undecided) };
+	}
+
+	if ("not" in n) {
+		const inner = evaluateNode(n.not, ctx);
+		if (inner.value !== "unknown") return decided(!inner.value);
+		return {
+			value: "unknown",
+			residual:
+				inner.residual === null ? null : ({ not: inner.residual } as Predicate),
+		};
+	}
+
+	if ("compute" in n && typeof n.compute === "string") {
+		const computation = ctx.computations[n.compute];
+		if (computation === undefined) {
+			throw new Error(`Unknown computation: "${n.compute}"`);
+		}
+		const inner = evaluateNode(computation, ctx);
+		if (inner.value !== "unknown") return decided(inner.value);
+		return { value: "unknown", residual: n as Predicate };
+	}
+
+	if ("fact" in n && typeof n.fact === "string") {
+		const factValue = resolveFactValue(ctx.facts, n.fact);
+		if (factValue === undefined) {
+			return { value: "unknown", residual: n as Predicate };
+		}
+
+		const op = n.op as string;
+		if (op === "isNull") return decided(factValue === null);
+		if (op === "isNotNull") return decided(factValue !== null);
+
+		const compareTarget = resolveCompareValue(n, ctx.thresholds);
+
+		switch (op) {
+			case "==":
+				return decided(factValue === compareTarget);
+			case "!=":
+				return decided(factValue !== compareTarget);
+			case ">":
+				return decided((factValue as number) > (compareTarget as number));
+			case ">=":
+				return decided((factValue as number) >= (compareTarget as number));
+			case "<":
+				return decided((factValue as number) < (compareTarget as number));
+			case "<=":
+				return decided((factValue as number) <= (compareTarget as number));
+			case "in":
+				return decided(Array.isArray(n.value) && n.value.includes(factValue));
+			default:
+				throw new Error(`Unknown operator: "${op}"`);
+		}
+	}
+
+	throw new Error(`Unrecognized predicate node: ${JSON.stringify(n)}`);
+}
+
+export function loadRulesWithFallback(
+	version: string | null | undefined,
+): Rules {
+	if (!version || !isKnownRulesVersion(version)) {
+		return loadRules(DEFAULT_RULES_VERSION);
+	}
+	return loadRules(version);
+}
+
+export function listNextTransitions(
+	rules: Rules,
+	status: DeclarationFsmStatus,
+	knownFacts: Facts,
+): NextTransition[] {
+	const ctx: EvaluationContext = {
+		facts: knownFacts,
+		computations: (rules.computations ?? {}) as Record<string, unknown>,
+		thresholds: rules.thresholds,
+	};
+
+	const candidates: NextTransition[] = [];
+	for (const transition of rules.transitions) {
+		if (!transition.from.includes(status)) continue;
+
+		const evaluation = evaluateNode(transition.guard, ctx);
+		if (evaluation.value === false) continue;
+
+		candidates.push({
+			id: transition.id,
+			action: transition.action,
+			to: transition.to,
+			residualGuard: evaluation.value === "unknown" ? evaluation.residual : null,
+		});
+	}
+	return candidates;
+}


### PR DESCRIPTION
Closes #4327

## Résumé

Ajoute la brique **pure** qui répond à « quelles transitions sont possibles depuis l'état X ? », que le moteur de règles ne savait pas faire — `engine.ts` ne savait qu'**appliquer** une action (`applyAction`).

La difficulté du ticket : au moment de l'export, certains faits des gardes sont **connus** (l'entreprise a-t-elle un CSE ?), d'autres ne le seront qu'au moment de l'action future (l'écart persistera-t-il après les actions correctives ?). D'où une évaluation **partielle**.

### `packages/app/src/server/rules/nextSteps.ts` (création, 182 lignes)

- **`listNextTransitions(rules, status, knownFacts)`** — filtre les transitions du ruleset sur `from`, évalue leur garde en **logique de Kleene tri-valuée** (`true` / `false` / `"unknown"`) contre les faits connus, écarte celles décidées fausses, conserve les indécises. `matchPayload` n'est jamais un critère d'exclusion (ce sont des variantes de choix utilisateur, donc autant de branches offertes). L'ordre du ruleset — qui est l'ordre de priorité métier d'`applyAction` — est préservé, sans tri ni déduplication.
- **`residualGuard`** — pour une garde indécise, le résidu **élagué** : les branches déjà décidées disparaissent, et un `all`/`any` réduit à un seul enfant est rendu **nu** plutôt qu'enveloppé. Ce résidu est ce qui permettra au consommateur (ticket suivant) de rendre la condition en texte.
- **`loadRulesWithFallback(version)`** — retombe sur `2027.1` pour une version absente, vide ou inconnue, **sans jamais throw**. C'est le contrat du scénario S7 : une déclaration historique ne doit ni provoquer un `500`, ni disparaître silencieusement de l'export.

Un fait présent mais valant explicitement `null` est **connu** (`isNull` peut répondre `true`) ; seule l'**absence de clé** vaut `"unknown"`. C'est la divergence délibérée avec `evaluatePredicate` d'`engine.ts`, qui confond les deux — et c'est elle qui rend les faits `action.*` (typiquement `action.stillHasGap`) indécis à l'export, comme voulu.

### `packages/app/src/server/rules/engine.ts` (+4 lignes)

Un seul export additif, `isKnownRulesVersion`. `loadRules`, `applyAction`, `evaluateComputation` et le cache sont strictement inchangés.

## Vérification

Un défaut a été trouvé **dans le snippet prescrit par le ticket lui-même** (§1) et corrigé :

```ts
return version in BUNDLED_VERSIONS;          // avant
return Object.hasOwn(BUNDLED_VERSIONS, version);  // après
```

`in` remonte la chaîne de prototypes. `isKnownRulesVersion` répondait donc `true` pour `"constructor"`, `"toString"`, `"valueOf"`, `"hasOwnProperty"` et `"__proto__"` ; le fallback appelait alors `loadRules(version)`, dont le garde-fou `if (!raw) throw` ne rattrapait rien puisque `BUNDLED_VERSIONS["constructor"]` est *truthy* — et le flux atteignait `RulesSchema.parse(Object)`.

**Avant** : `loadRulesWithFallback("__proto__")` → `ZodError`, en contradiction directe avec le critère « ne throw **jamais** ».
**Après** : retourne le ruleset `2027.1`. Les 5 cas sont verrouillés par test.

## Test plan

`packages/app/src/server/rules/__tests__/nextSteps.test.ts` — 87 tests, écrits par `tu-dev`.

- Les **6 scénarios normatifs** du ticket : 3 entrées depuis `awaiting_compliance_path_choice` avec CSE (`justify_without_cse` écartée), 2 depuis `corrective_actions_chosen` avec CSE (`resolved_without_cse` écartée), la bascule symétrique sans CSE, `submit_cse_opinion` bien présente depuis `demarche_completed`, aucune transition écartée avec `knownFacts = {}`, et les 5 formes de `loadRulesWithFallback`.
- La **table de Kleene** complète (`all` / `any` / `not` × décidé / indécis), l'élagage et le dénudage du résidu, le résidu d'un `{ compute }` indécis, `null` connu vs clé absente, l'ordre de sortie, et `matchPayload` non exclusif.

Couverture `nextSteps.ts` : **100 % lignes, 100 % fonctions**, 97,6 % branches. Suite complète : **5536 tests verts** (449 fichiers), aucune régression. Typecheck, lint et format verts.

Pas de test E2E : brique serveur pure, sans I/O ni UI (aucun `.tsx`/`.scss` touché — gate visuelle sans objet).

## Revue qualité

`validator`, `structural-auditor` et `security-auditor` sont passés (`rgaa-auditor` sans objet, aucun fichier UI). Deux points relevés sont **laissés hors de cette PR à dessein**, parce que les corriger contredirait un critère d'acceptation explicite du ticket (« le reste du moteur est inchangé ») — ils méritent un ticket de suite :

1. **Duplication assumée** — `resolveFactValue` / `resolveCompareValue` de `nextSteps.ts` sont les jumeaux de `getNestedValue` / `resolveCompareValue` d'`engine.ts`. À terme, les hisser dans un module privé partagé éviterait qu'un futur changement de format de seuil ne diverge entre l'évaluateur booléen et l'évaluateur tri-valué. L'évaluateur lui-même, en revanche, **ne doit pas** être fusionné : le type de retour, l'élagage du résidu et la sémantique `isNull` divergent pour de bonnes raisons.
2. **`loadRules` n'est pas gardé** — il indexe `BUNDLED_VERSIONS[version]` sans `Object.hasOwn`, donc `loadRules("__proto__")` throw une `ZodError` au lieu du `Unknown rules version` attendu. Pré-existant, non exploitable (la version vient d'une colonne DB dont le défaut est `"2027.1"`, sans chemin d'écriture client) et sans effet de bord — le flux throw dans les deux cas. Le garde mériterait néanmoins d'être porté dans `loadRules` plutôt que confié à chaque appelant.

## Périmètre

`v2027.1.json`, `schema.ts`, le FSM et `modules/export/` sont intacts. Le câblage dans l'API SUIT est le ticket suivant.
