### PR TITLE
fix(representation): réaligne les champs de pourcentage

### DIFF
--- a/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.module.scss
+++ b/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.module.scss
@@ -25,6 +25,7 @@
 .inputWithUnit :global(.fr-input) {
 	flex: 1 1 auto;
 	min-width: 0;
+	text-align: right;
 }
 
 .unit {
@@ -36,4 +37,11 @@
 
 .hint:global(.fr-message) {
 	margin-top: 1rem;
+	margin-left: 0.5rem;
+}
+
+.trailingContent {
+	display: flex;
+	height: 2.5rem;
+	align-items: center;
 }

--- a/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.tsx
@@ -157,7 +157,9 @@ export function PercentagePairFields({
 							</div>
 						</div>
 					</div>
-					{trailingContent ? <div>{trailingContent}</div> : null}
+					{trailingContent ? (
+						<div className={styles.trailingContent}>{trailingContent}</div>
+					) : null}
 				</div>
 			</div>
 			{hint ? (

--- a/packages/app/src/modules/declaration-representation/steps/Step3Members.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step3Members.tsx
@@ -198,13 +198,17 @@ export function Step3Members() {
 						legend="Indiquez le pourcentage de représentation des femmes et des hommes parmi les membres des instances dirigeantes."
 						onChange={handlePercentageChange}
 						readOnly={isReadOnly}
+						trailingContent={
+							<div aria-atomic="true" aria-live="polite">
+								{decidedVerdict ? (
+									<ComplianceBadge verdict={decidedVerdict} />
+								) : null}
+							</div>
+						}
 						values={percentageValues}
 					/>
 				</div>
 			) : null}
-			<div aria-atomic="true" aria-live="polite" className="fr-mt-2w">
-				{decidedVerdict ? <ComplianceBadge verdict={decidedVerdict} /> : null}
-			</div>
 
 			<section className="fr-accordion fr-mt-4w">
 				<h3 className="fr-accordion__title">


### PR DESCRIPTION
## Résumé

- aligne les valeurs de pourcentage à droite
- réaligne le message informatif avec les champs
- centre verticalement le badge de conformité sur les champs des étapes 2 et 3

## Vérifications

- 115 tests Vitest ciblés
- contrôle Biome
- typecheck TypeScript

Closes #4321