### PR TITLE
API SUIT — Prochaines_etapes_possibles dans l'objet Parcours + OpenAPI

### DIFF
--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -114,7 +114,7 @@ const nullIndicators = {
 	}>,
 };
 
-// The #4328 cases differ from the fixtures above by a handful of columns only,
+// These cases differ from the fixtures above by a handful of columns only,
 // so they go through a factory and spell out just what they exercise.
 function declarationRow(overrides: Record<string, unknown> = {}) {
 	return {

--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+	GAP_PERSISTS_CONDITION,
+	GAP_RESOLVED_CONDITION,
+	STAGE_LABELS,
+} from "./helpers/nextStepLabels";
 import { RELOCATED_ROOT_KEYS } from "./helpers/parcoursKeys";
 
 const mockFetchSubmitted = vi.fn().mockResolvedValue([]);
@@ -109,6 +114,49 @@ const nullIndicators = {
 	}>,
 };
 
+// The #4328 cases differ from the fixtures above by a handful of columns only,
+// so they go through a factory and spell out just what they exercise.
+function declarationRow(overrides: Record<string, unknown> = {}) {
+	return {
+		declarationId: "decl-1",
+		siren: "123456789",
+		year: 2027,
+		status: "awaiting_compliance_path_choice",
+		firstDeclarationPathChoice: null,
+		secondDeclarationPathChoice: null,
+		totalWomen: 100,
+		totalMen: 150,
+		submittedAt: null,
+		firstDeclarationPathChoiceAt: null,
+		secondDeclarationPathChoiceAt: null,
+		secondDeclarationSubmittedAt: null,
+		jointEvaluationSubmittedAt: null,
+		cseOpinionCompletedAt: null,
+		demarcheCompletedAt: null,
+		complianceProcessRequired: false,
+		complianceProcessRevisionRequired: false,
+		cseRequired: true,
+		indicatorGRequired: false,
+		rulesVersion: "2027.1",
+		secondDeclReferencePeriodStart: null,
+		secondDeclReferencePeriodEnd: null,
+		createdAt: new Date("2027-03-15T10:00:00Z"),
+		updatedAt: new Date("2027-03-15T12:00:00Z"),
+		cancelledAt: null,
+		companyName: "ACME Corp",
+		workforceEma: "250.00",
+		nafCode: "62.02",
+		address: "1 rue test",
+		hasCse: true,
+		declarantFirstName: "Jean",
+		declarantLastName: "Dupont",
+		declarantEmail: "jean@acme.fr",
+		declarantPhone: "0612345678",
+		...nullIndicators,
+		...overrides,
+	};
+}
+
 describe("GET /api/v1/export/declarations", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -213,7 +261,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "111111111",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 50,
@@ -234,6 +282,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-01-01T00:00:00Z"),
 				updatedAt: new Date("2027-01-01T00:00:00Z"),
+				cancelledAt: null,
 				companyName: "Test",
 				workforceEma: "100.00",
 				nafCode: "62.01",
@@ -249,7 +298,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-2",
 				siren: "222222222",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 60,
@@ -270,6 +319,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-01-02T00:00:00Z"),
 				updatedAt: new Date("2027-01-02T00:00:00Z"),
+				cancelledAt: null,
 				companyName: "Test2",
 				workforceEma: "200.00",
 				nafCode: "62.02",
@@ -303,7 +353,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -324,6 +374,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -375,7 +426,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "432491777",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 30,
@@ -396,6 +447,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "70.00",
 				nafCode: "62.02",
@@ -427,7 +479,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "999999999",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 10,
@@ -448,6 +500,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "Hors GIP",
 				workforceEma: null,
 				nafCode: "62.02",
@@ -482,7 +535,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -503,6 +556,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -584,7 +638,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -605,6 +659,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -663,7 +718,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -684,6 +739,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -730,7 +786,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -751,6 +807,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -807,7 +864,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -828,6 +885,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -868,7 +926,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -889,6 +947,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -936,7 +995,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -957,6 +1016,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -993,7 +1053,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -1014,6 +1074,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -1104,6 +1165,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-10-15T14:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -1203,7 +1265,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -1224,6 +1286,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -1278,7 +1341,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: null,
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -1299,6 +1362,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -1329,7 +1393,7 @@ describe("GET /api/v1/export/declarations", () => {
 				declarationId: "decl-1",
 				siren: "123456789",
 				year: 2027,
-				status: "submitted",
+				status: "awaiting_compliance_path_choice",
 				firstDeclarationPathChoice: "corrective_action",
 				secondDeclarationPathChoice: null,
 				totalWomen: 100,
@@ -1350,6 +1414,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-04-01T10:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -1428,6 +1493,7 @@ describe("GET /api/v1/export/declarations", () => {
 				secondDeclReferencePeriodEnd: null,
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				cancelledAt: null,
 				companyName: "ACME Corp",
 				workforceEma: "250.00",
 				nafCode: "62.02",
@@ -1451,5 +1517,149 @@ describe("GET /api/v1/export/declarations", () => {
 		const body = await response.json();
 		expect(body.Declarations[0].Seconde_declaration.Statut).toBe(false);
 		expect(body.Declarations[0].Date_seconde_declaration).toBeNull();
+	});
+
+	describe("Parcours.Prochaines_etapes_possibles (#4328)", () => {
+		async function exportedDeclarations(rows: Record<string, unknown>[]) {
+			mockFetchSubmitted.mockResolvedValue(rows);
+			const { GET } = await import("~/app/api/v1/export/declarations/route");
+			const response = await GET(
+				gatewayForwardedRequest(
+					"http://localhost/api/v1/export/declarations?date_begin=2027-03-15",
+				),
+			);
+
+			expect(response.status).toBe(200);
+			return response.json();
+		}
+
+		it("serialises the three compliance paths of a CSE-bound company as the last Parcours key (S3)", async () => {
+			const body = await exportedDeclarations([
+				declarationRow({
+					status: "awaiting_compliance_path_choice",
+					cseRequired: true,
+				}),
+			]);
+			const { Parcours } = body.Declarations[0];
+
+			expect(Object.keys(Parcours).at(-1)).toBe("Prochaines_etapes_possibles");
+			expect(
+				Parcours.Prochaines_etapes_possibles.map(
+					(step: { Identifiant_transition: string }) =>
+						step.Identifiant_transition,
+				),
+			).toEqual([
+				"choose_path_initial_justify_with_cse",
+				"choose_path_initial_corrective_action",
+				"choose_path_initial_joint_evaluation",
+			]);
+			for (const step of Parcours.Prochaines_etapes_possibles) {
+				expect(step).not.toHaveProperty("Condition");
+			}
+		});
+
+		it("keeps the Condition of an undecided guard through JSON serialisation (S4)", async () => {
+			const body = await exportedDeclarations([
+				declarationRow({
+					status: "corrective_actions_chosen",
+					cseRequired: true,
+				}),
+			]);
+
+			expect(body.Declarations[0].Parcours.Prochaines_etapes_possibles).toEqual(
+				[
+					{
+						Identifiant_transition: "submit_second_declaration_persistent_gap",
+						Action: "submit_second_declaration",
+						Etat_cible: "awaiting_revision_choice",
+						Libelle: STAGE_LABELS.revisionChoice,
+						Condition: GAP_PERSISTS_CONDITION,
+					},
+					{
+						Identifiant_transition:
+							"submit_second_declaration_resolved_with_cse",
+						Action: "submit_second_declaration",
+						Etat_cible: "awaiting_cse_opinion",
+						Libelle: STAGE_LABELS.cseOpinion,
+						Condition: GAP_RESOLVED_CONDITION,
+					},
+				],
+			);
+		});
+
+		it("exports an empty array for a cancelled declaration, with no redeclare step invented (S5)", async () => {
+			const body = await exportedDeclarations([
+				declarationRow({
+					status: "corrective_actions_chosen",
+					cancelledAt: new Date("2027-04-15T08:00:00Z"),
+				}),
+			]);
+			const decl = body.Declarations[0];
+
+			expect(decl.Parcours.Prochaines_etapes_possibles).toEqual([]);
+			expect(decl.Parcours.Annulee).toBe(true);
+			expect(decl.Date_annulation).toBe("2027-04-15T08:00:00.000Z");
+			expect(decl.Parcours.Statut).toBe("corrective_actions_chosen");
+		});
+
+		it("keeps offering the CSE opinion on a completed démarche (S6)", async () => {
+			const body = await exportedDeclarations([
+				declarationRow({ status: "demarche_completed", cseRequired: true }),
+			]);
+			const { Parcours } = body.Declarations[0];
+
+			expect(Parcours.Annulee).toBe(false);
+			expect(Parcours.Prochaines_etapes_possibles).toEqual([
+				{
+					Identifiant_transition: "submit_cse_opinion",
+					Action: "submit_cse_opinion",
+					Etat_cible: "demarche_completed",
+					Libelle: STAGE_LABELS.completion,
+				},
+			]);
+		});
+
+		it("answers 200 with both declarations when the stored rules version is missing or unknown, without rewriting it (S7)", async () => {
+			const body = await exportedDeclarations([
+				declarationRow({
+					declarationId: "decl-null-version",
+					status: "corrective_actions_chosen",
+					rulesVersion: null,
+				}),
+				declarationRow({
+					declarationId: "decl-unknown-version",
+					siren: "987654321",
+					status: "corrective_actions_chosen",
+					rulesVersion: "1999.0",
+				}),
+			]);
+			const [nullVersion, unknownVersion] = body.Declarations;
+
+			expect(body.Nombre).toBe(2);
+			expect(nullVersion.Parcours.Version_regles).toBeNull();
+			expect(unknownVersion.Parcours.Version_regles).toBe("1999.0");
+			expect(nullVersion.Parcours.Prochaines_etapes_possibles).not.toHaveLength(
+				0,
+			);
+			expect(unknownVersion.Parcours.Prochaines_etapes_possibles).toEqual(
+				nullVersion.Parcours.Prochaines_etapes_possibles,
+			);
+		});
+
+		it("leaves the envelope and the payload root untouched (S10)", async () => {
+			const body = await exportedDeclarations([declarationRow()]);
+
+			expect(Object.keys(body)).toEqual([
+				"Date_debut",
+				"Date_fin",
+				"Nombre",
+				"Declarations",
+			]);
+			expect(body.Date_debut).toBe("2027-03-15");
+			expect(body.Date_fin).toBe("2027-03-16");
+			expect(body.Declarations[0]).not.toHaveProperty(
+				"Prochaines_etapes_possibles",
+			);
+		});
 	});
 });

--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -1519,7 +1519,7 @@ describe("GET /api/v1/export/declarations", () => {
 		expect(body.Declarations[0].Date_seconde_declaration).toBeNull();
 	});
 
-	describe("Parcours.Prochaines_etapes_possibles (#4328)", () => {
+	describe("Parcours.Prochaines_etapes_possibles", () => {
 		async function exportedDeclarations(rows: Record<string, unknown>[]) {
 			mockFetchSubmitted.mockResolvedValue(rows);
 			const { GET } = await import("~/app/api/v1/export/declarations/route");

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { DeclarationFsmStatus } from "~/modules/domain";
 import type { CseRow, IndicatorGEntry } from "../fetchDeclarations";
 import {
 	assembleDeclaration,
@@ -7,6 +8,11 @@ import {
 	buildIndicators,
 } from "../fetchDeclarations";
 import type { RawHistoryEntry } from "../queries";
+import {
+	GAP_PERSISTS_CONDITION,
+	GAP_RESOLVED_CONDITION,
+	STAGE_LABELS,
+} from "./helpers/nextStepLabels";
 import { PARCOURS_KEYS, RELOCATED_ROOT_KEYS } from "./helpers/parcoursKeys";
 
 // Minimal DeclarationRow used by buildIndicators / assembleDeclaration
@@ -405,6 +411,26 @@ describe("assembleDeclaration", () => {
 			Avis_CSE_requis: false,
 			Indicateur_G_requis: true,
 			Version_regles: "2027.1",
+			Prochaines_etapes_possibles: [
+				{
+					Identifiant_transition: "choose_path_initial_justify_without_cse",
+					Action: "choose_compliance_path",
+					Etat_cible: "demarche_completed",
+					Libelle: STAGE_LABELS.completion,
+				},
+				{
+					Identifiant_transition: "choose_path_initial_corrective_action",
+					Action: "choose_compliance_path",
+					Etat_cible: "corrective_actions_chosen",
+					Libelle: STAGE_LABELS.correctiveActions,
+				},
+				{
+					Identifiant_transition: "choose_path_initial_joint_evaluation",
+					Action: "choose_compliance_path",
+					Etat_cible: "joint_evaluation_chosen",
+					Libelle: STAGE_LABELS.jointEvaluation,
+				},
+			],
 		});
 	});
 
@@ -1324,5 +1350,171 @@ describe("assembleDeclaration — compliance flags", () => {
 		const result = assembleDeclaration(row, significantInitial, []);
 
 		expect(result.Parcours.Parcours_de_conformite_revision_requis).toBe(false);
+	});
+});
+
+describe("assembleDeclaration — Parcours.Prochaines_etapes_possibles (#4328)", () => {
+	// baseRow narrows status to its own literal; these cases walk the whole FSM.
+	type RowOverrides = Omit<Partial<typeof baseRow>, "status"> & {
+		status?: DeclarationFsmStatus;
+	};
+
+	function rowWith(overrides: RowOverrides) {
+		return { ...baseRow, ...overrides };
+	}
+
+	function stepsOf(overrides: RowOverrides) {
+		return assembleDeclaration(rowWith(overrides), [], []).Parcours
+			.Prochaines_etapes_possibles;
+	}
+
+	function transitionIds(overrides: RowOverrides) {
+		return stepsOf(overrides).map((step) => step.Identifiant_transition);
+	}
+
+	it("offers the three compliance paths of a CSE-bound company, none conditional (S3)", () => {
+		const steps = stepsOf({
+			status: "awaiting_compliance_path_choice",
+			cseRequired: true,
+		});
+
+		expect(steps).toEqual([
+			{
+				Identifiant_transition: "choose_path_initial_justify_with_cse",
+				Action: "choose_compliance_path",
+				Etat_cible: "awaiting_cse_opinion",
+				Libelle: STAGE_LABELS.cseOpinion,
+			},
+			{
+				Identifiant_transition: "choose_path_initial_corrective_action",
+				Action: "choose_compliance_path",
+				Etat_cible: "corrective_actions_chosen",
+				Libelle: STAGE_LABELS.correctiveActions,
+			},
+			{
+				Identifiant_transition: "choose_path_initial_joint_evaluation",
+				Action: "choose_compliance_path",
+				Etat_cible: "joint_evaluation_chosen",
+				Libelle: STAGE_LABELS.jointEvaluation,
+			},
+		]);
+		for (const step of steps) {
+			expect(step).not.toHaveProperty("Condition");
+		}
+	});
+
+	it("drops the without-CSE first choice when the CSE opinion is required (S3)", () => {
+		expect(
+			transitionIds({
+				status: "awaiting_compliance_path_choice",
+				cseRequired: true,
+			}),
+		).not.toContain("choose_path_initial_justify_without_cse");
+	});
+
+	it("splits the second declaration on the gap that is not known yet (S4)", () => {
+		const steps = stepsOf({
+			status: "corrective_actions_chosen",
+			cseRequired: true,
+		});
+
+		expect(steps).toEqual([
+			{
+				Identifiant_transition: "submit_second_declaration_persistent_gap",
+				Action: "submit_second_declaration",
+				Etat_cible: "awaiting_revision_choice",
+				Libelle: STAGE_LABELS.revisionChoice,
+				Condition: GAP_PERSISTS_CONDITION,
+			},
+			{
+				Identifiant_transition: "submit_second_declaration_resolved_with_cse",
+				Action: "submit_second_declaration",
+				Etat_cible: "awaiting_cse_opinion",
+				Libelle: STAGE_LABELS.cseOpinion,
+				Condition: GAP_RESOLVED_CONDITION,
+			},
+		]);
+	});
+
+	it("drops the resolved-without-CSE variant the stored CSE fact decides false (S4)", () => {
+		expect(
+			transitionIds({
+				status: "corrective_actions_chosen",
+				cseRequired: true,
+			}),
+		).not.toContain("submit_second_declaration_resolved_without_cse");
+	});
+
+	it("empties the steps of a cancelled declaration while keeping its last status (S5)", () => {
+		const result = assembleDeclaration(
+			rowWith({
+				status: "corrective_actions_chosen",
+				cseRequired: true,
+				cancelledAt: new Date("2027-04-15T08:00:00Z"),
+			}),
+			[],
+			[],
+		);
+
+		expect(result.Parcours.Prochaines_etapes_possibles).toEqual([]);
+		expect(result.Parcours.Annulee).toBe(true);
+		expect(result.Date_annulation).toBe("2027-04-15T08:00:00.000Z");
+		expect(result.Parcours.Statut).toBe("corrective_actions_chosen");
+	});
+
+	it("still offers the CSE opinion on a completed démarche that was not cancelled (S6)", () => {
+		const result = assembleDeclaration(
+			rowWith({ status: "demarche_completed", cseRequired: true }),
+			[],
+			[],
+		);
+
+		expect(result.Parcours.Prochaines_etapes_possibles).toEqual([
+			{
+				Identifiant_transition: "submit_cse_opinion",
+				Action: "submit_cse_opinion",
+				Etat_cible: "demarche_completed",
+				Libelle: STAGE_LABELS.completion,
+			},
+		]);
+		expect(result.Parcours.Annulee).toBe(false);
+	});
+
+	// The column is NOT NULL in the schema, so only an unknown version reaches
+	// this boundary; the null case is pinned on buildNextStepsPayload itself.
+	it("derives the steps from the fallback ruleset for an unknown stored version, without rewriting Version_regles (S7)", () => {
+		const result = assembleDeclaration(
+			rowWith({ status: "corrective_actions_chosen", rulesVersion: "1999.0" }),
+			[],
+			[],
+		);
+
+		expect(result.Parcours.Version_regles).toBe("1999.0");
+		expect(result.Parcours.Prochaines_etapes_possibles).toEqual(
+			stepsOf({ status: "corrective_actions_chosen" }),
+		);
+		expect(result.Parcours.Prochaines_etapes_possibles).not.toHaveLength(0);
+	});
+
+	it("filters on the stored cseRequired column, never on one recomputed from hasCse and the headcount", () => {
+		// A 250-employee company with a CSE would recompute to cseRequired=true;
+		// a 70-employee one without a CSE to false. The stored column wins both ways.
+		expect(
+			transitionIds({
+				status: "awaiting_compliance_path_choice",
+				cseRequired: false,
+				hasCse: true,
+				workforceEma: "250.00",
+			}),
+		).toContain("choose_path_initial_justify_without_cse");
+
+		expect(
+			transitionIds({
+				status: "awaiting_compliance_path_choice",
+				cseRequired: true,
+				hasCse: false,
+				workforceEma: "70.00",
+			}),
+		).toContain("choose_path_initial_justify_with_cse");
 	});
 });

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -1353,7 +1353,7 @@ describe("assembleDeclaration — compliance flags", () => {
 	});
 });
 
-describe("assembleDeclaration — Parcours.Prochaines_etapes_possibles (#4328)", () => {
+describe("assembleDeclaration — Parcours.Prochaines_etapes_possibles", () => {
 	// baseRow narrows status to its own literal; these cases walk the whole FSM.
 	type RowOverrides = Omit<Partial<typeof baseRow>, "status"> & {
 		status?: DeclarationFsmStatus;

--- a/packages/app/src/modules/export/__tests__/helpers/nextStepLabels.ts
+++ b/packages/app/src/modules/export/__tests__/helpers/nextStepLabels.ts
@@ -1,4 +1,4 @@
-// The v2027.1 stage names and the two gap conditions #4328 pins verbatim.
+// The v2027.1 stage names and the two gap conditions, verbatim.
 // Shared so the payload unit test and the assembled-declaration test cannot
 // drift on the wording the SUIT contract promises.
 export const STAGE_LABELS = {

--- a/packages/app/src/modules/export/__tests__/helpers/nextStepLabels.ts
+++ b/packages/app/src/modules/export/__tests__/helpers/nextStepLabels.ts
@@ -1,0 +1,15 @@
+// The v2027.1 stage names and the two gap conditions #4328 pins verbatim.
+// Shared so the payload unit test and the assembled-declaration test cannot
+// drift on the wording the SUIT contract promises.
+export const STAGE_LABELS = {
+	compliancePathChoice:
+		"(1ère déclaration) Choix du parcours de mise en conformité",
+	correctiveActions: "Actions correctives et seconde déclaration",
+	revisionChoice: "(2e déclaration) Choix du parcours de mise en conformité",
+	jointEvaluation: "Évaluation conjointe des rémunérations",
+	cseOpinion: "Déposer le ou les avis CSE",
+	completion: "Finalisation - Démarche des indicateurs de rémunération",
+} as const;
+
+export const GAP_PERSISTS_CONDITION = "si l'écart persiste (≥ 5 %)";
+export const GAP_RESOLVED_CONDITION = "si l'écart est résorbé (< 5 %)";

--- a/packages/app/src/modules/export/__tests__/helpers/nextStepLabels.ts
+++ b/packages/app/src/modules/export/__tests__/helpers/nextStepLabels.ts
@@ -1,6 +1,4 @@
-// The v2027.1 stage names and the two gap conditions, verbatim.
-// Shared so the payload unit test and the assembled-declaration test cannot
-// drift on the wording the SUIT contract promises.
+// Shared verbatim so both test suites cannot drift on the wording the SUIT contract promises.
 export const STAGE_LABELS = {
 	compliancePathChoice:
 		"(1ère déclaration) Choix du parcours de mise en conformité",

--- a/packages/app/src/modules/export/__tests__/helpers/parcoursKeys.ts
+++ b/packages/app/src/modules/export/__tests__/helpers/parcoursKeys.ts
@@ -12,6 +12,7 @@ export const PARCOURS_KEYS = [
 	"Avis_CSE_requis",
 	"Indicateur_G_requis",
 	"Version_regles",
+	"Prochaines_etapes_possibles",
 ] as const;
 
 // The keys #4326 moved out of the root and into Parcours. Tranche_effectif,

--- a/packages/app/src/modules/export/__tests__/openapi.test.ts
+++ b/packages/app/src/modules/export/__tests__/openapi.test.ts
@@ -205,6 +205,59 @@ describe("openApiSpec", () => {
 		});
 	});
 
+	describe("Prochaines_etapes_possibles schema (#4328)", () => {
+		const stepsSchema =
+			openApiSpec.paths["/api/v1/export/declarations"].get.responses["200"]
+				.content["application/json"].schema.properties.Declarations.items
+				.properties.Parcours.properties.Prochaines_etapes_possibles;
+
+		it("declares an array of objects", () => {
+			expect(stepsSchema.type).toBe("array");
+			expect(stepsSchema.items.type).toBe("object");
+		});
+
+		it("lists exactly the five keys a step carries", () => {
+			expect(Object.keys(stepsSchema.items.properties)).toEqual([
+				"Identifiant_transition",
+				"Action",
+				"Etat_cible",
+				"Libelle",
+				"Condition",
+			]);
+		});
+
+		it("requires everything but Condition, which stays optional", () => {
+			expect(stepsSchema.items.required).toEqual([
+				"Identifiant_transition",
+				"Action",
+				"Etat_cible",
+				"Libelle",
+			]);
+			expect(stepsSchema.items.required).not.toContain("Condition");
+		});
+
+		it("mirrors Etat_cible on DECLARATION_FSM_STATUSES", () => {
+			const etatCible = stepsSchema.items.properties.Etat_cible;
+
+			expect(etatCible.type).toBe("string");
+			expect(etatCible.enum).toEqual([...DECLARATION_FSM_STATUSES]);
+		});
+
+		it("declares Libelle as a nullable string", () => {
+			expect(stepsSchema.items.properties.Libelle.type).toEqual([
+				"string",
+				"null",
+			]);
+		});
+
+		it("documents the array and every step key with a French description", () => {
+			expect(stepsSchema.description).toBeTruthy();
+			for (const property of Object.values(stepsSchema.items.properties)) {
+				expect(property.description).toBeTruthy();
+			}
+		});
+	});
+
 	describe("Statut field (declaration FSM status)", () => {
 		const declarationSchema =
 			openApiSpec.paths["/api/v1/export/declarations"].get.responses["200"]

--- a/packages/app/src/modules/export/__tests__/openapi.test.ts
+++ b/packages/app/src/modules/export/__tests__/openapi.test.ts
@@ -205,7 +205,7 @@ describe("openApiSpec", () => {
 		});
 	});
 
-	describe("Prochaines_etapes_possibles schema (#4328)", () => {
+	describe("Prochaines_etapes_possibles schema", () => {
 		const stepsSchema =
 			openApiSpec.paths["/api/v1/export/declarations"].get.responses["200"]
 				.content["application/json"].schema.properties.Declarations.items

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -349,6 +349,7 @@ export function assembleDeclaration(
 	const jointEvaluationFile = mostRecent(jointEvaluationFiles);
 
 	const flags = deriveExportFlags(row, indicatorGEntries);
+	const cancelled = isCancelled(row);
 
 	// Obligation regime uses the exact value; the segmentation bucket uses the floored one.
 	const gipWorkforce = parseGipWorkforce(row.workforceEma);
@@ -374,7 +375,7 @@ export function assembleDeclaration(
 				getObligationWorkforce(gipWorkforce),
 			),
 			Statut: row.status,
-			Annulee: isCancelled(row),
+			Annulee: cancelled,
 			Parcours_de_conformite_requis: flags.complianceProcessRequired,
 			Parcours_de_conformite_revision_requis:
 				flags.complianceProcessRevisionRequired,
@@ -385,7 +386,7 @@ export function assembleDeclaration(
 				status: row.status,
 				rulesVersion: row.rulesVersion,
 				cseRequired: row.cseRequired,
-				cancelled: isCancelled(row),
+				cancelled,
 			}),
 		},
 		Date_creation: row.createdAt?.toISOString() ?? null,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -46,6 +46,7 @@ import {
 	INDICATOR_F_HOURLY_THRESHOLD_LABELS,
 	INDICATOR_F_HOURLY_WOMEN_LABELS,
 } from "./shared/apiLabels";
+import { buildNextStepsPayload } from "./shared/nextStepsPayload";
 import { getStatusHistoryLabel } from "./shared/statusHistoryLabels";
 
 function deriveExportFlags(
@@ -380,6 +381,12 @@ export function assembleDeclaration(
 			Avis_CSE_requis: row.cseRequired,
 			Indicateur_G_requis: flags.indicatorGRequired,
 			Version_regles: row.rulesVersion,
+			Prochaines_etapes_possibles: buildNextStepsPayload({
+				status: row.status,
+				rulesVersion: row.rulesVersion,
+				cseRequired: row.cseRequired,
+				cancelled: isCancelled(row),
+			}),
 		},
 		Date_creation: row.createdAt?.toISOString() ?? null,
 		Date_modification: row.updatedAt?.toISOString() ?? null,

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -312,6 +312,46 @@ const declarationSchema = {
 					description:
 						"Version du moteur de règles métier utilisée à la soumission.",
 				},
+				Prochaines_etapes_possibles: {
+					type: "array",
+					description:
+						"Liste des transitions offertes depuis le statut courant, dérivée du ruleset versionné. `Identifiant_transition` est stable et destiné au diff côté SUIT ; `Libelle` est l'intitulé de l'étape d'arrivée ; `Condition`, quand elle est présente, décrit le fait encore inconnu qui départagera les variantes. Tableau vide si la déclaration est annulée.",
+					items: {
+						type: "object",
+						properties: {
+							Identifiant_transition: {
+								type: "string",
+								description:
+									"Identifiant stable de la transition dans le ruleset — sert au diff côté SUIT.",
+							},
+							Action: {
+								type: "string",
+								description: "Action déclenchant la transition.",
+							},
+							Etat_cible: {
+								type: "string",
+								enum: [...DECLARATION_FSM_STATUSES],
+								description: "Statut atteint si la transition est exécutée.",
+							},
+							Libelle: {
+								type: ["string", "null"],
+								description:
+									"Intitulé du stage de l'étape d'arrivée. `null` si l'état cible n'appartient à aucun stage.",
+							},
+							Condition: {
+								type: "string",
+								description:
+									"Fait encore inconnu qui départagera les variantes, présent uniquement quand la garde est indécise.",
+							},
+						},
+						required: [
+							"Identifiant_transition",
+							"Action",
+							"Etat_cible",
+							"Libelle",
+						],
+					},
+				},
 			},
 		},
 		Date_creation: { type: ["string", "null"], format: "date-time" },

--- a/packages/app/src/modules/export/shared/__tests__/nextStepsPayload.test.ts
+++ b/packages/app/src/modules/export/shared/__tests__/nextStepsPayload.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	GAP_PERSISTS_CONDITION,
+	GAP_RESOLVED_CONDITION,
+	STAGE_LABELS,
+} from "~/modules/export/__tests__/helpers/nextStepLabels";
+import type { Rules } from "~/server/rules/engine";
+import { loadRulesWithFallback } from "~/server/rules/nextSteps";
+import type { Predicate } from "~/server/rules/schema";
+import { buildNextStepsPayload } from "../nextStepsPayload";
+
+// Substituting the ruleset (the real engine still derives the residual) is the
+// only way to reach the rendering branches the bundled 2027.1 never produces:
+// a stage-less target state and residual leaves other than `action.stillHasGap`.
+vi.mock("~/server/rules/nextSteps", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("~/server/rules/nextSteps")>();
+	return {
+		...actual,
+		loadRulesWithFallback: vi.fn(actual.loadRulesWithFallback),
+	};
+});
+
+type PayloadInput = Parameters<typeof buildNextStepsPayload>[0];
+
+function stepsFor(overrides: Partial<PayloadInput> = {}) {
+	return buildNextStepsPayload({
+		status: "awaiting_compliance_path_choice",
+		rulesVersion: "2027.1",
+		cseRequired: true,
+		cancelled: false,
+		...overrides,
+	});
+}
+
+describe("buildNextStepsPayload — ruleset 2027.1", () => {
+	it("offers the three compliance paths of a CSE-bound company, none conditional (S3)", () => {
+		const steps = stepsFor({ status: "awaiting_compliance_path_choice" });
+
+		expect(steps).toEqual([
+			{
+				Identifiant_transition: "choose_path_initial_justify_with_cse",
+				Action: "choose_compliance_path",
+				Etat_cible: "awaiting_cse_opinion",
+				Libelle: STAGE_LABELS.cseOpinion,
+			},
+			{
+				Identifiant_transition: "choose_path_initial_corrective_action",
+				Action: "choose_compliance_path",
+				Etat_cible: "corrective_actions_chosen",
+				Libelle: STAGE_LABELS.correctiveActions,
+			},
+			{
+				Identifiant_transition: "choose_path_initial_joint_evaluation",
+				Action: "choose_compliance_path",
+				Etat_cible: "joint_evaluation_chosen",
+				Libelle: STAGE_LABELS.jointEvaluation,
+			},
+		]);
+	});
+
+	it("omits the Condition key entirely on a decided guard rather than setting it undefined (S3)", () => {
+		for (const step of stepsFor({
+			status: "awaiting_compliance_path_choice",
+		})) {
+			expect(step).not.toHaveProperty("Condition");
+		}
+	});
+
+	it("drops the without-CSE variant when the CSE opinion is required (S3)", () => {
+		expect(
+			stepsFor({ status: "awaiting_compliance_path_choice" }).map(
+				(step) => step.Identifiant_transition,
+			),
+		).not.toContain("choose_path_initial_justify_without_cse");
+	});
+
+	it("splits the second declaration on the gap that is not known yet (S4)", () => {
+		const steps = stepsFor({ status: "corrective_actions_chosen" });
+
+		expect(steps).toEqual([
+			{
+				Identifiant_transition: "submit_second_declaration_persistent_gap",
+				Action: "submit_second_declaration",
+				Etat_cible: "awaiting_revision_choice",
+				Libelle: STAGE_LABELS.revisionChoice,
+				Condition: GAP_PERSISTS_CONDITION,
+			},
+			{
+				Identifiant_transition: "submit_second_declaration_resolved_with_cse",
+				Action: "submit_second_declaration",
+				Etat_cible: "awaiting_cse_opinion",
+				Libelle: STAGE_LABELS.cseOpinion,
+				Condition: GAP_RESOLVED_CONDITION,
+			},
+		]);
+	});
+
+	it("drops the resolved-without-CSE variant, decided false by the known CSE fact (S4)", () => {
+		expect(
+			stepsFor({ status: "corrective_actions_chosen" }).map(
+				(step) => step.Identifiant_transition,
+			),
+		).not.toContain("submit_second_declaration_resolved_without_cse");
+	});
+
+	it("labels a step with the stage of the target state, not of the current one (S4)", () => {
+		const [persistentGap] = stepsFor({ status: "corrective_actions_chosen" });
+
+		expect(persistentGap?.Libelle).toBe(STAGE_LABELS.revisionChoice);
+		expect(persistentGap?.Libelle).not.toBe(STAGE_LABELS.correctiveActions);
+	});
+
+	it.each([
+		"draft",
+		"awaiting_compliance_path_choice",
+		"corrective_actions_chosen",
+		"demarche_completed",
+	] as const)("returns no step at all for a cancelled %s declaration (S5)", (status) => {
+		expect(stepsFor({ status, cancelled: true })).toEqual([]);
+	});
+
+	it("still offers the CSE opinion once the démarche is completed (S6)", () => {
+		const steps = stepsFor({ status: "demarche_completed" });
+
+		expect(steps).toEqual([
+			{
+				Identifiant_transition: "submit_cse_opinion",
+				Action: "submit_cse_opinion",
+				Etat_cible: "demarche_completed",
+				Libelle: STAGE_LABELS.completion,
+			},
+		]);
+	});
+
+	it("renders a composite residual with a parenthesised composite child and a bare leaf", () => {
+		expect(stepsFor({ status: "draft" })).toEqual([
+			{
+				Identifiant_transition: "submit_to_compliance_path_choice",
+				Action: "submit",
+				Etat_cible: "awaiting_compliance_path_choice",
+				Libelle: STAGE_LABELS.compliancePathChoice,
+				Condition: "si phase2Required",
+			},
+			{
+				Identifiant_transition: "submit_to_cse_opinion_directly",
+				Action: "submit",
+				Etat_cible: "awaiting_cse_opinion",
+				Libelle: STAGE_LABELS.cseOpinion,
+				Condition: "si (non (phase2Required)) et cseRequired",
+			},
+			{
+				Identifiant_transition: "submit_to_demarche_completed_directly",
+				Action: "submit",
+				Etat_cible: "demarche_completed",
+				Libelle: STAGE_LABELS.completion,
+				Condition: "si (non (phase2Required)) et (non (cseRequired))",
+			},
+		]);
+	});
+});
+
+describe("buildNextStepsPayload — unknown rules version (S7)", () => {
+	const reference = stepsFor({ status: "corrective_actions_chosen" });
+
+	it.each([
+		null,
+		"9999.9",
+	])("falls back on 2027.1 for the version %s without throwing", (rulesVersion) => {
+		expect(() =>
+			stepsFor({ status: "corrective_actions_chosen", rulesVersion }),
+		).not.toThrow();
+		expect(
+			stepsFor({ status: "corrective_actions_chosen", rulesVersion }),
+		).toEqual(reference);
+	});
+});
+
+describe("buildNextStepsPayload — rendering of a substituted ruleset", () => {
+	const undecidedGuard: Predicate = {
+		all: [
+			{
+				all: [
+					{ fact: "cseOpinionAt", op: "isNull" },
+					{ fact: "jointEvaluationAt", op: "isNotNull" },
+				],
+			},
+			{
+				any: [
+					{ fact: "gap", op: ">", value: 10 },
+					{ fact: "workforce", op: ">=", threshold: "phase2SizeMin" },
+				],
+			},
+			{ fact: "firstPath", op: "==", value: "justify" },
+			{ fact: "secondPath", op: "!=", value: "joint_evaluation" },
+			{ fact: "action.stillHasGap", op: "!=", value: true },
+			{ fact: "action.stillHasGap", op: "==", value: null },
+		],
+	};
+
+	const renderingRules: Rules = {
+		version: "test",
+		thresholds: { gapAlertPercent: 5, phase2SizeMin: 100 },
+		stages: [{ id: 1, name: "Étape nommée" }],
+		states: [
+			{ id: "draft", stage: 1 },
+			{ id: "awaiting_cse_opinion", stage: null },
+			{ id: "demarche_completed", stage: 99 },
+		],
+		transitions: [
+			{
+				id: "render_residual",
+				from: ["draft"],
+				action: "probe",
+				to: "draft",
+				guard: undecidedGuard,
+				events: [],
+			},
+			{
+				id: "target_state_without_stage",
+				from: ["draft"],
+				action: "probe",
+				to: "awaiting_cse_opinion",
+				events: [],
+			},
+			{
+				id: "target_stage_absent_from_stages",
+				from: ["draft"],
+				action: "probe",
+				to: "demarche_completed",
+				events: [],
+			},
+			{
+				id: "target_state_absent_from_states",
+				from: ["draft"],
+				action: "probe",
+				to: "corrective_actions_chosen",
+				events: [],
+			},
+		],
+	};
+
+	function substitutedSteps() {
+		vi.mocked(loadRulesWithFallback).mockReturnValueOnce(renderingRules);
+		return stepsFor({ status: "draft" });
+	}
+
+	it("renders every residual node kind, parenthesising the composite children only", () => {
+		const [residual] = substitutedSteps();
+
+		expect(residual?.Condition).toBe(
+			"si (cseOpinionAt est nul et jointEvaluationAt est renseigné) et (gap > 10 ou workforce >= 100) et firstPath = justify et secondPath ≠ joint_evaluation et action.stillHasGap ≠ true et action.stillHasGap = null",
+		);
+	});
+
+	it("labels a step null when the target state carries no stage", () => {
+		expect(
+			substitutedSteps().find(
+				(step) => step.Identifiant_transition === "target_state_without_stage",
+			)?.Libelle,
+		).toBeNull();
+	});
+
+	it("labels a step null when the stage of the target state is not declared", () => {
+		expect(
+			substitutedSteps().find(
+				(step) =>
+					step.Identifiant_transition === "target_stage_absent_from_stages",
+			)?.Libelle,
+		).toBeNull();
+	});
+
+	it("labels a step null when the target state itself is not declared", () => {
+		expect(
+			substitutedSteps().find(
+				(step) =>
+					step.Identifiant_transition === "target_state_absent_from_states",
+			)?.Libelle,
+		).toBeNull();
+	});
+
+	// 2027.1 pins gapAlertPercent at 5, so only a shifted threshold tells an
+	// interpolated seuil apart from a hardcoded literal.
+	const shiftedThresholdRules: Rules = {
+		...renderingRules,
+		thresholds: { gapAlertPercent: 8, phase2SizeMin: 100 },
+		transitions: [
+			{
+				id: "persistent_gap",
+				from: ["draft"],
+				action: "probe",
+				to: "draft",
+				guard: { fact: "action.stillHasGap", op: "==", value: true },
+				events: [],
+			},
+			{
+				id: "resolved_gap",
+				from: ["draft"],
+				action: "probe",
+				to: "draft",
+				guard: { fact: "action.stillHasGap", op: "==", value: false },
+				events: [],
+			},
+		],
+	};
+
+	it.each([
+		["persistent_gap", "si l'écart persiste (≥ 8 %)"],
+		["resolved_gap", "si l'écart est résorbé (< 8 %)"],
+	])("interpolates the gap threshold of the ruleset into %s", (id, condition) => {
+		vi.mocked(loadRulesWithFallback).mockReturnValueOnce(shiftedThresholdRules);
+
+		expect(
+			stepsFor({ status: "draft" }).find(
+				(step) => step.Identifiant_transition === id,
+			)?.Condition,
+		).toBe(condition);
+	});
+});

--- a/packages/app/src/modules/export/shared/__tests__/nextStepsPayload.test.ts
+++ b/packages/app/src/modules/export/shared/__tests__/nextStepsPayload.test.ts
@@ -10,9 +10,7 @@ import { loadRulesWithFallback } from "~/server/rules/nextSteps";
 import type { Predicate } from "~/server/rules/schema";
 import { buildNextStepsPayload } from "../nextStepsPayload";
 
-// Substituting the ruleset (the real engine still derives the residual) is the
-// only way to reach the rendering branches the bundled 2027.1 never produces:
-// a stage-less target state and residual leaves other than `action.stillHasGap`.
+// Substituting the ruleset is the only way to reach rendering branches the bundled 2027.1 never produces.
 vi.mock("~/server/rules/nextSteps", async (importOriginal) => {
 	const actual =
 		await importOriginal<typeof import("~/server/rules/nextSteps")>();
@@ -280,8 +278,7 @@ describe("buildNextStepsPayload — rendering of a substituted ruleset", () => {
 		).toBeNull();
 	});
 
-	// 2027.1 pins gapAlertPercent at 5, so only a shifted threshold tells an
-	// interpolated seuil apart from a hardcoded literal.
+	// 2027.1 pins gapAlertPercent at 5, so only a shifted threshold proves the seuil is interpolated.
 	const shiftedThresholdRules: Rules = {
 		...renderingRules,
 		thresholds: { gapAlertPercent: 8, phase2SizeMin: 100 },

--- a/packages/app/src/modules/export/shared/nextStepsPayload.ts
+++ b/packages/app/src/modules/export/shared/nextStepsPayload.ts
@@ -1,0 +1,107 @@
+import type { DeclarationFsmStatus } from "~/modules/domain";
+import type { Rules } from "~/server/rules/engine";
+import {
+	listNextTransitions,
+	loadRulesWithFallback,
+	type NextTransition,
+} from "~/server/rules/nextSteps";
+import type { Predicate } from "~/server/rules/schema";
+
+export type NextStepPayload = {
+	Identifiant_transition: string;
+	Action: string;
+	Etat_cible: DeclarationFsmStatus;
+	Libelle: string | null;
+	Condition?: string;
+};
+
+function isCompositePredicate(node: Predicate): boolean {
+	return "all" in node || "any" in node || "not" in node;
+}
+
+function renderFragment(
+	node: Predicate,
+	thresholds: Record<string, number>,
+): string {
+	if ("all" in node) {
+		return node.all.map((child) => renderChild(child, thresholds)).join(" et ");
+	}
+	if ("any" in node) {
+		return node.any.map((child) => renderChild(child, thresholds)).join(" ou ");
+	}
+	if ("not" in node) {
+		return `non (${renderFragment(node.not, thresholds)})`;
+	}
+	if ("compute" in node) {
+		return node.compute;
+	}
+
+	const { fact, op } = node;
+	if (op === "isNull") return `${fact} est nul`;
+	if (op === "isNotNull") return `${fact} est renseigné`;
+
+	if (fact === "action.stillHasGap" && op === "==" && "value" in node) {
+		if (node.value === true) {
+			return `l'écart persiste (≥ ${thresholds.gapAlertPercent} %)`;
+		}
+		if (node.value === false) {
+			return `l'écart est résorbé (< ${thresholds.gapAlertPercent} %)`;
+		}
+	}
+
+	const symbol = op === "==" ? "=" : op === "!=" ? "≠" : op;
+	const target = "value" in node ? node.value : thresholds[node.threshold];
+	return `${fact} ${symbol} ${target}`;
+}
+
+function renderChild(
+	node: Predicate,
+	thresholds: Record<string, number>,
+): string {
+	const fragment = renderFragment(node, thresholds);
+	return isCompositePredicate(node) ? `(${fragment})` : fragment;
+}
+
+function resolveTargetStageLabel(
+	rules: Rules,
+	targetStatus: DeclarationFsmStatus,
+): string | null {
+	const state = rules.states.find((s) => s.id === targetStatus);
+	if (state?.stage == null) return null;
+	return rules.stages.find((stage) => stage.id === state.stage)?.name ?? null;
+}
+
+function toNextStepPayload(
+	transition: NextTransition,
+	rules: Rules,
+): NextStepPayload {
+	const base: NextStepPayload = {
+		Identifiant_transition: transition.id,
+		Action: transition.action,
+		Etat_cible: transition.to,
+		Libelle: resolveTargetStageLabel(rules, transition.to),
+	};
+
+	if (transition.residualGuard === null) return base;
+
+	return {
+		...base,
+		Condition: `si ${renderFragment(transition.residualGuard, rules.thresholds)}`,
+	};
+}
+
+export function buildNextStepsPayload(input: {
+	status: DeclarationFsmStatus;
+	rulesVersion: string | null;
+	cseRequired: boolean;
+	cancelled: boolean;
+}): NextStepPayload[] {
+	if (input.cancelled) return [];
+
+	const rules = loadRulesWithFallback(input.rulesVersion);
+	const transitions = listNextTransitions(rules, input.status, {
+		cseRequired: input.cseRequired,
+	});
+
+	return transitions.map((transition) => toNextStepPayload(transition, rules));
+}


### PR DESCRIPTION
Closes #4328

## Résumé

Câble `Parcours.Prochaines_etapes_possibles` dans le payload d'export SUIT : chaque déclaration exportée expose désormais la liste des prochaines étapes réellement offertes à l'entreprise, dérivée du ruleset FSM versionné (`listNextTransitions` de #4327), avec leur condition en clair quand l'issue dépend d'un fait pas encore connu.

- `shared/nextStepsPayload.ts` (nouveau) : `buildNextStepsPayload` — court-circuit `[]` sur annulation, mapping `Libelle` = stage de l'état **cible**, rendu déterministe de `Condition` (seuil interpolé depuis `rules.thresholds.gapAlertPercent`, jamais codé en dur), omission de la clé `Condition` (pas `undefined`) quand la garde est décidée.
- `fetchDeclarations.ts` : câblage dans `assembleDeclaration`, `cseRequired` pris depuis la colonne stockée (`row.cseRequired`), jamais recalculé.
- `openapi.ts` : documentation du nouveau champ (tableau d'objets à 5 clés, `Condition` optionnelle).

Divergence assumée (§5 du ticket) : une déclaration non annulée au statut `demarche_completed` expose `submit_cse_opinion` (tableau non vide) — le dépôt d'un avis CSE supplémentaire reste ouvert, contrairement à l'arbitrage initial du cadrage technique de l'epic.

## Test plan

- Tests unitaires ajoutés par `tu-dev` : couverture 100% de `buildNextStepsPayload` (annulation, mapping libellé, tous les cas de `renderFragment`, seuil interpolé), scénarios S3/S4/S5/S6/S7 dans `fetchDeclarations.test.ts` + `exportApi.test.ts` (cardinalités exactes du ticket), S8 (schéma OpenAPI) dans `openapi.test.ts`.
- Non-régression S10 vérifiée : payload `/export/representations`, fenêtre de sélection par dates, authentification et codes d'erreur inchangés.
- `pnpm typecheck`, `pnpm test`, `pnpm lint:check`, `pnpm format:check` verts.

Aucune UI touchée (API machine-to-machine) — pas de screenshot, pas de gate visuelle.
