### PR TITLE
Doc SUIT — section « Interprétation des champs et cycle de vie »

### DIFF
--- a/docs/SUIT-API.md
+++ b/docs/SUIT-API.md
@@ -54,6 +54,91 @@ curl -OJ "$BASE_URL/files/<fileId>" \
 
 Le `fileId` est renvoyé par l'endpoint `/files`.
 
+## Interprétation des champs et cycle de vie
+
+Cette section décrit comment lire les champs déduits du parcours de la déclaration (`Parcours`, exposé par `/export/declarations`). Elle ne concerne **pas** `/export/representations`, dont le payload est indépendant.
+
+### Cycle de vie : les 8 états et leurs transitions
+
+Le champ `Parcours.Statut` suit une machine à états (FSM) versionnée (`Parcours.Version_regles`). Le tableau ci-dessous liste, pour chaque état source, les transitions possibles — dérivé du ruleset en vigueur (`v2027.1.json`) :
+
+| État source | Action | État cible | Condition |
+| --- | --- | --- | --- |
+| `draft` | `submit` | `awaiting_compliance_path_choice` | effectif ≥ 100 et indicateur G calculé et écart ≥ 5 % |
+| `draft` | `submit` | `awaiting_cse_opinion` | non (effectif ≥ 100 et indicateur G calculé et écart ≥ 5 %) et CSE requis |
+| `draft` | `submit` | `demarche_completed` | non (effectif ≥ 100 et indicateur G calculé et écart ≥ 5 %) et non CSE requis |
+| `awaiting_compliance_path_choice` | `choose_compliance_path` (justify) | `awaiting_cse_opinion` | CSE requis |
+| `awaiting_compliance_path_choice` | `choose_compliance_path` (justify) | `demarche_completed` | CSE non requis |
+| `awaiting_compliance_path_choice` | `choose_compliance_path` (corrective_action) | `corrective_actions_chosen` | — |
+| `awaiting_compliance_path_choice` | `choose_compliance_path` (joint_evaluation) | `joint_evaluation_chosen` | — |
+| `corrective_actions_chosen` | `submit_second_declaration` | `awaiting_revision_choice` | l'écart persiste (≥ 5 %) |
+| `corrective_actions_chosen` | `submit_second_declaration` | `awaiting_cse_opinion` | l'écart est résorbé (< 5 %) et CSE requis |
+| `corrective_actions_chosen` | `submit_second_declaration` | `demarche_completed` | l'écart est résorbé (< 5 %) et CSE non requis |
+| `joint_evaluation_chosen` | `submit_joint_evaluation` | `awaiting_cse_opinion` | CSE requis |
+| `joint_evaluation_chosen` | `submit_joint_evaluation` | `demarche_completed` | CSE non requis |
+| `awaiting_revision_choice` | `submit_second_declaration` | `awaiting_revision_choice` | l'écart persiste (≥ 5 %) |
+| `awaiting_revision_choice` | `submit_second_declaration` | `awaiting_cse_opinion` | l'écart est résorbé (< 5 %) et CSE requis |
+| `awaiting_revision_choice` | `submit_second_declaration` | `demarche_completed` | l'écart est résorbé (< 5 %) et CSE non requis |
+| `awaiting_revision_choice` | `choose_compliance_path` (justify) | `awaiting_cse_opinion` | CSE requis |
+| `awaiting_revision_choice` | `choose_compliance_path` (justify) | `demarche_completed` | CSE non requis |
+| `awaiting_revision_choice` | `choose_compliance_path` (joint_evaluation) | `revised_joint_evaluation_chosen` | — |
+| `revised_joint_evaluation_chosen` | `submit_joint_evaluation` | `awaiting_cse_opinion` | CSE requis |
+| `revised_joint_evaluation_chosen` | `submit_joint_evaluation` | `demarche_completed` | CSE non requis |
+| `awaiting_cse_opinion` | `submit_cse_opinion` | `demarche_completed` | — |
+| `awaiting_cse_opinion` | `sync_cse_requirement` | `demarche_completed` | CSE non requis (le besoin d'avis CSE disparaît en cours de route) |
+| `demarche_completed` | `submit_cse_opinion` | `demarche_completed` | — |
+
+⚠️ `demarche_completed` n'est **pas** un cul-de-sac : `submit_cse_opinion` y reste disponible sans garde, un avis CSE supplémentaire pouvant être déposé jusqu'à 4 fois par an même une fois la démarche finalisée.
+
+### `Parcours.Prochaines_etapes_possibles`
+
+Ce tableau liste les transitions offertes depuis `Parcours.Statut`, calculées à l'export. Chaque entrée porte 5 clés :
+
+| Clé | Description |
+| --- | --- |
+| `Identifiant_transition` | Identifiant **stable** de la transition dans le ruleset — destiné au diff côté SUIT (comparer les identifiants d'un export à l'autre plutôt que reconstruire l'état). |
+| `Action` | L'action qui déclenche la transition. |
+| `Etat_cible` | Le statut atteint si la transition est exécutée. |
+| `Libelle` | L'intitulé du stage de l'étape **d'arrivée** (`null` si l'état cible n'appartient à aucun stage). |
+| `Condition` | N'apparaît que lorsqu'un fait n'est **pas encore connu** au moment de l'export (garde indécise) — décrit alors ce qui départagera les variantes. Absente quand la garde est déjà tranchée. |
+
+`Prochaines_etapes_possibles` vaut `[]` pour une déclaration annulée — aucune étape n'est proposée.
+
+### Sémantique de l'effectif
+
+`Parcours.Effectif` est l'effectif **GIP EMA arrondi à l'entier inférieur** — jamais l'effectif déclaré par l'entreprise. Ne pas le confondre avec `Effectif_F_rem_annuelle_globale` / `Effectif_H_rem_annuelle_globale` (à la racine du payload), qui sont des effectifs **déclarés** par l'entreprise et ne fondent aucun assujettissement.
+
+Deux lectures de la taille de l'entreprise coexistent :
+
+- `Parcours.Regime_obligations` — le **paquet d'obligations** applicable : `voluntary` (< 50, volontariat), `mandatory` (assujettissement standard) ou `mandatory_with_compliance` (assujettissement avec parcours de conformité).
+- `Parcours.Tranche_effectif` — le **bucket de segmentation** : `<50`, `50-99`, `100-149`, `150-249`, `250+`.
+
+Quand l'effectif GIP est inconnu, `Tranche_effectif` vaut `null` (jamais replié sur `<50`), tandis que `Regime_obligations` relève alors du volontariat.
+
+### Masquage de `CSE_existant`
+
+`CSE_existant` vaut `null` — et non `false` — pour les entreprises sous le seuil CSE (100 salariés) : l'information n'est simplement **pas exportée** pour ces entreprises, elle n'est pas absente au sens d'un CSE inexistant. Ne pas interpréter `null` comme « pas de CSE ».
+
+### Flags d'obligation figés vs statut évolutif
+
+`Parcours.Parcours_de_conformite_requis`, `Parcours_de_conformite_revision_requis`, `Avis_CSE_requis` et `Indicateur_G_requis` sont des prédicats **calculés à la soumission et figés** : ils ne changent jamais au fil de l'avancement de la démarche.
+
+`Parcours.Statut`, à l'inverse, **évolue** à chaque transition FSM. Confondre les deux fait croire à tort qu'une obligation a disparu alors que la démarche a simplement avancé.
+
+### Interprétation des annulations
+
+Une déclaration annulée **remonte dans l'export**, sur la fenêtre de sa date d'annulation (`Date_annulation`). `Date_annulation != null` **prime** sur `Statut` : l'annulation ne fait pas transiter le FSM, `Parcours.Statut` reste figé à sa valeur d'avant annulation. `Parcours.Annulee` est le booléen explicite à utiliser pour détecter l'annulation. `Parcours.Prochaines_etapes_possibles` vaut alors `[]` — aucune étape « redéclarer » n'est proposée, cette transition n'existant pas dans le parcours.
+
+### Périmètre du cycle de vie
+
+Le cycle de vie décrit ci-dessus (FSM, `Prochaines_etapes_possibles`) ne concerne **que** le parcours rémunération, exposé par `/export/declarations`. Il ne s'applique pas à `/export/representations`, dont le payload est indépendant et inchangé.
+
+## Rupture de compatibilité — version 3.0.0
+
+La version `3.0.0` de l'API constitue une **rupture de compatibilité** : les données déduites du parcours (année, effectif, statut, flags d'obligation, version des règles) ont quitté la racine du payload pour l'objet `Parcours`, sans doublon déprécié. L'URL reste inchangée : `/api/v1/export/declarations` — aucun `/api/v2` n'est introduit.
+
+⚠️ La mise en service doit être **coordonnée avec l'équipe SUIT avant déploiement** (bascule simultanée côté consommateur).
+
 ## Réponses d'erreur
 
 | Code | Cause |

--- a/packages/app/src/modules/export/__tests__/openapi.test.ts
+++ b/packages/app/src/modules/export/__tests__/openapi.test.ts
@@ -362,4 +362,25 @@ describe("openApiSpec", () => {
 			);
 		});
 	});
+
+	describe("breaking-change notice on the declarations endpoint (#4329)", () => {
+		const { description } =
+			openApiSpec.paths["/api/v1/export/declarations"].get;
+		const [major] = openApiSpec.info.version.split(".");
+
+		it("announces the breaking change of the declared major version", () => {
+			expect(description).toContain("rupture de compatibilité");
+			expect(description).toContain(`majeure ${major}`);
+		});
+
+		it("names the Parcours object that carries the relocated keys", () => {
+			expect(description).toContain("Parcours");
+		});
+
+		it("keeps every documented path on the v1 prefix the notice promises", () => {
+			for (const path of Object.keys(openApiSpec.paths)) {
+				expect(path).toMatch(/^\/api\/v1\//);
+			}
+		});
+	});
 });

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -724,7 +724,7 @@ export const openApiSpec = {
 				summary:
 					"Lister les déclarations par date de soumission ou d'annulation",
 				description:
-					"Retourne les déclarations dont la date de mise à jour (`Date_modification`, pour les déclarations actives soumises) ou la date d'annulation (`Date_annulation`, pour les déclarations annulées) est comprise dans l'intervalle [`date_begin`, `date_end`[. Inclut les indicateurs A–G, la seconde déclaration, les avis CSE et le champ `Date_annulation` (renseigné si la déclaration est annulée). Les libellés des champs reprennent ceux du fichier GIP MDS.",
+					"Retourne les déclarations dont la date de mise à jour (`Date_modification`, pour les déclarations actives soumises) ou la date d'annulation (`Date_annulation`, pour les déclarations annulées) est comprise dans l'intervalle [`date_begin`, `date_end`[. Inclut les indicateurs A–G, la seconde déclaration, les avis CSE et le champ `Date_annulation` (renseigné si la déclaration est annulée). Les libellés des champs reprennent ceux du fichier GIP MDS. Version majeure 3.0.0 : rupture de compatibilité — les données déduites du parcours (année, effectif, statut, flags d'obligation, version des règles) sont regroupées sous l'objet `Parcours`, sans doublon déprécié à la racine. L'URL reste inchangée (`/api/v1/export/declarations`, aucun `/api/v2`) ; la mise en service doit être coordonnée avec l'équipe SUIT avant déploiement.",
 				parameters: [
 					{
 						name: "date_begin",


### PR DESCRIPTION
Closes #4329

## Résumé

Ajoute à `docs/SUIT-API.md` la section « Interprétation des champs et cycle de vie » (entre « Endpoints » et « Réponses d'erreur ») : tableau des 8 états FSM × transitions × conditions dérivé de `v2027.1.json`, sémantique des 5 clés de `Parcours.Prochaines_etapes_possibles`, sémantique de l'effectif (GIP EMA floored vs déclaré), masquage de `CSE_existant` sous le seuil CSE, distinction flags d'obligation figés / statut évolutif, règle d'interprétation des annulations, et périmètre limité au FSM rémunération (hors `/export/representations`).

Annonce également la rupture de compatibilité `3.0.0` (regroupement sous `Parcours`, URL inchangée, bascule à coordonner avec l'équipe SUIT) — dans `docs/SUIT-API.md` et dans la `description` de l'endpoint `GET /export/declarations` de `openapi.ts`.

Aucun code applicatif modifié en dehors de cette description d'endpoint (aucun schéma de champ touché).

## Test plan

- [x] `pnpm typecheck` vert
- [x] `pnpm test` vert (suite complète, 450 fichiers / 5597 tests — délégué à `tu-dev`, 3 tests ajoutés dans `openapi.test.ts` pour couvrir la présence de l'annonce de rupture de compatibilité dans la description, avec revert-verify)
- [x] `pnpm lint:check` / `pnpm format:check` verts sur les fichiers du diff
- [x] Relecture de la section doc contre `v2027.1.json` (23 lignes du tableau FSM, une par couple état source × transition, `demarche_completed` → `submit_cse_opinion` explicitement mentionné)