### PR TITLE
Représentation équilibrée — écran d'assujettissement : enregistrement du choix non-assujetti et pré-remplissage

### DIFF
--- a/packages/app/src/app/declaration-representation/page.tsx
+++ b/packages/app/src/app/declaration-representation/page.tsx
@@ -30,5 +30,13 @@ export default async function RepresentationHomePage() {
 		redirect(stepHref(currentStep));
 	}
 
-	return <SubjectionScreen campaignYear={campaignYear} />;
+	return (
+		<SubjectionScreen
+			campaignYear={campaignYear}
+			initialAnswer={
+				declaration?.status === "not_subject" ? "not_concerned" : undefined
+			}
+			year={year}
+		/>
+	);
 }

--- a/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
+++ b/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
@@ -1,32 +1,47 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useId } from "react";
 import { Controller } from "react-hook-form";
 import { useZodForm } from "~/modules/shared/useZodForm";
+import { api } from "~/trpc/react";
 import { subjectionSchema } from "./schemas";
 import { stepHref } from "./steps";
 
 type SubjectionScreenProps = {
 	campaignYear: number;
+	initialAnswer?: "concerned" | "not_concerned";
+	year: number;
 };
 
-export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
+export function SubjectionScreen({
+	campaignYear,
+	initialAnswer,
+	year,
+}: SubjectionScreenProps) {
 	const router = useRouter();
 	const legendId = useId();
 	const messagesId = useId();
 
 	const form = useZodForm(subjectionSchema, {
-		defaultValues: { answer: null },
+		defaultValues: { answer: initialAnswer ?? null },
 	});
 
 	const answer = form.watch("answer");
 
+	const declareNotSubjectMutation =
+		api.representationDeclaration.declareNotSubject.useMutation({
+			onSuccess: () => {
+				router.push("/mon-espace");
+			},
+		});
+
 	const onSubmit = form.handleSubmit((data) => {
 		if (data.answer === "concerned") {
 			router.push(stepHref(1));
+			return;
 		}
+		declareNotSubjectMutation.mutate({ year });
 	});
 
 	return (
@@ -139,15 +154,25 @@ export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
 					</div>
 				) : null}
 
+				{declareNotSubjectMutation.error ? (
+					<div className="fr-alert fr-alert--error fr-alert--sm" role="alert">
+						<p>{declareNotSubjectMutation.error.message}</p>
+					</div>
+				) : null}
+
 				{/* fr-btns-group--icon-right: without it, DSFR 1.14 treats any
 				    icon-carrying .fr-btn in a group as icon-only and clamps it to
 				    2.5rem, truncating the "Suivant" label. */}
 				<ul className="fr-btns-group fr-btns-group--inline fr-btns-group--icon-right fr-btns-group--right fr-mt-4w">
 					{answer === "not_concerned" ? (
 						<li>
-							<Link className="fr-btn" href="/mon-espace">
+							<button
+								className="fr-btn"
+								disabled={declareNotSubjectMutation.isPending}
+								type="submit"
+							>
 								Valider
-							</Link>
+							</button>
 						</li>
 					) : (
 						<li>

--- a/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
+++ b/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
@@ -7,10 +7,11 @@ import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 import { subjectionSchema } from "./schemas";
 import { stepHref } from "./steps";
+import type { SubjectionAnswer } from "./types";
 
 type SubjectionScreenProps = {
 	campaignYear: number;
-	initialAnswer?: "concerned" | "not_concerned";
+	initialAnswer?: SubjectionAnswer;
 	year: number;
 };
 

--- a/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
@@ -34,6 +34,15 @@ vi.mock("~/trpc/react", () => ({
 				useMutation: () => ({ mutate: vi.fn(), isPending: false }),
 			},
 		},
+		representationDeclaration: {
+			declareNotSubject: {
+				useMutation: () => ({
+					mutate: vi.fn(),
+					isPending: false,
+					error: null,
+				}),
+			},
+		},
 	},
 }));
 
@@ -69,15 +78,19 @@ function mockFunnelState({
 	campaignOpen = true,
 	currentStep,
 	draft,
+	status,
 }: {
 	campaignOpen?: boolean;
 	currentStep?: number;
 	draft?: unknown;
+	status?: string;
 } = {}) {
 	getDeclaration.mockResolvedValue({
 		campaignOpen,
 		declaration:
-			currentStep === undefined ? null : { currentStep, draft: draft ?? null },
+			currentStep === undefined
+				? null
+				: { currentStep, draft: draft ?? null, status },
 	} as never);
 }
 
@@ -137,6 +150,34 @@ describe("RepresentationHomePage", () => {
 		render(await RepresentationHomePage());
 
 		expect(mockRedirect).not.toHaveBeenCalled();
+	});
+
+	it("pre-fills the subjection screen for a company already declared out of scope (T3-S2)", async () => {
+		mockFunnelState({ currentStep: 0, status: "not_subject" });
+
+		render(await RepresentationHomePage());
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole("radio", {
+				name: /Moins de 1 000 salariés sur au moins un exercice/,
+			}),
+		).toBeChecked();
+		expect(
+			screen.getByText(/Vous n'êtes pas assujetti à la publication/),
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Valider" })).toBeInTheDocument();
+	});
+
+	it("leaves the subjection screen blank for a draft that has not reached a step", async () => {
+		mockFunnelState({ currentStep: 0, status: "draft" });
+
+		render(await RepresentationHomePage());
+
+		for (const radio of screen.getAllByRole("radio")) {
+			expect(radio).not.toBeChecked();
+		}
+		expect(screen.getByRole("button", { name: "Suivant" })).toBeInTheDocument();
 	});
 
 	it("resumes an existing draft at its current step (S21)", async () => {

--- a/packages/app/src/modules/declaration-representation/__tests__/SubjectionScreen.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/SubjectionScreen.test.tsx
@@ -1,11 +1,18 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { push, apiAccess } = vi.hoisted(() => ({
-	push: vi.fn(),
-	apiAccess: vi.fn(),
-}));
+const { push, declareNotSubjectMutate, declareNotSubjectState } = vi.hoisted(
+	() => ({
+		push: vi.fn(),
+		declareNotSubjectMutate: vi.fn(),
+		declareNotSubjectState: {
+			error: null as { message: string } | null,
+			isPending: false,
+			onSuccess: undefined as (() => void) | undefined,
+		},
+	}),
+);
 
 vi.mock("next/navigation", () => ({
 	usePathname: vi.fn(),
@@ -17,32 +24,45 @@ vi.mock("next/navigation", () => ({
 	}),
 }));
 
-// The subjection answer is deliberately not persisted: any access to the tRPC
-// client from this screen is a product regression, not an implementation detail.
 vi.mock("~/trpc/react", () => ({
-	api: new Proxy(
-		{},
-		{
-			get: (_target, property) => {
-				apiAccess(property);
-				return undefined;
+	api: {
+		representationDeclaration: {
+			declareNotSubject: {
+				useMutation: ({ onSuccess }: { onSuccess: () => void }) => {
+					declareNotSubjectState.onSuccess = onSuccess;
+					return {
+						error: declareNotSubjectState.error,
+						isPending: declareNotSubjectState.isPending,
+						mutate: declareNotSubjectMutate,
+					};
+				},
 			},
 		},
-	),
+	},
 }));
 
+import {
+	REPRESENTATION_CAMPAIGN_YEAR,
+	REPRESENTATION_YEAR,
+} from "~/modules/declaration-representation/__tests__/fixtures";
 import { SubjectionScreen } from "../SubjectionScreen";
 
-const CAMPAIGN_YEAR = 2026;
 const STEP_1_HREF = "/declaration-representation/etape/1";
+const MY_SPACE_HREF = "/mon-espace";
 const SELECTION_ERROR = "Veuillez sélectionner une option pour continuer.";
 const NOT_CONCERNED_INFO = /Vous n'êtes pas assujetti à la publication/;
 const SUBJECTION_QUESTION =
 	/Indiquez si votre entreprise emploie au moins 1 000 salariés/;
 const SUBJECTION_FIELDSET_NAME = /Nombre de salariés de l'entreprise/;
 
-function renderScreen() {
-	return render(<SubjectionScreen campaignYear={CAMPAIGN_YEAR} />);
+function renderScreen(initialAnswer?: "concerned" | "not_concerned") {
+	return render(
+		<SubjectionScreen
+			campaignYear={REPRESENTATION_CAMPAIGN_YEAR}
+			initialAnswer={initialAnswer}
+			year={REPRESENTATION_YEAR}
+		/>,
+	);
 }
 
 function concernedRadio() {
@@ -61,9 +81,16 @@ function nextButton() {
 	return screen.getByRole("button", { name: "Suivant" });
 }
 
+function validateButton() {
+	return screen.getByRole("button", { name: "Valider" });
+}
+
 beforeEach(() => {
 	push.mockReset();
-	apiAccess.mockReset();
+	declareNotSubjectMutate.mockReset();
+	declareNotSubjectState.error = null;
+	declareNotSubjectState.isPending = false;
+	declareNotSubjectState.onSuccess = undefined;
 });
 
 describe("SubjectionScreen — rendering", () => {
@@ -73,7 +100,7 @@ describe("SubjectionScreen — rendering", () => {
 		expect(
 			screen.getByRole("heading", {
 				level: 1,
-				name: `Démarche des indicateurs de représentation ${CAMPAIGN_YEAR}`,
+				name: `Démarche des indicateurs de représentation ${REPRESENTATION_CAMPAIGN_YEAR}`,
 			}),
 		).toBeInTheDocument();
 		expect(
@@ -136,6 +163,7 @@ describe("SubjectionScreen — no answer selected", () => {
 
 		expect(screen.getByText(SELECTION_ERROR)).toBeInTheDocument();
 		expect(push).not.toHaveBeenCalled();
+		expect(declareNotSubjectMutate).not.toHaveBeenCalled();
 	});
 
 	it("keeps the way forward after rejecting the question", async () => {
@@ -182,33 +210,63 @@ describe("SubjectionScreen — no answer selected", () => {
 });
 
 describe("SubjectionScreen — company concerned", () => {
-	it("enters the funnel at the first step", async () => {
+	it("enters the funnel at the first step without recording anything", async () => {
 		renderScreen();
 
 		await userEvent.click(concernedRadio());
 		await userEvent.click(nextButton());
 
 		expect(push).toHaveBeenCalledWith(STEP_1_HREF);
+		expect(declareNotSubjectMutate).not.toHaveBeenCalled();
 		expect(screen.queryByText(SELECTION_ERROR)).not.toBeInTheDocument();
 		expect(screen.queryByText(NOT_CONCERNED_INFO)).not.toBeInTheDocument();
 	});
 });
 
-describe("SubjectionScreen — company not concerned", () => {
-	it("explains the exemption and closes the démarche without entering the funnel", async () => {
+describe("SubjectionScreen — company not concerned (T3-S1)", () => {
+	it("explains the exemption and swaps the funnel entry for a validation", async () => {
 		renderScreen();
 
 		await userEvent.click(notConcernedRadio());
 
 		expect(screen.getByText(NOT_CONCERNED_INFO)).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "Valider" })).toHaveAttribute(
-			"href",
-			"/mon-espace",
-		);
+		expect(validateButton()).toBeInTheDocument();
 		expect(
 			screen.queryByRole("button", { name: "Suivant" }),
 		).not.toBeInTheDocument();
 		expect(push).not.toHaveBeenCalled();
+		expect(declareNotSubjectMutate).not.toHaveBeenCalled();
+	});
+
+	it("records the exemption for the reference year on validation", async () => {
+		renderScreen();
+
+		await userEvent.click(notConcernedRadio());
+		await userEvent.click(validateButton());
+
+		expect(declareNotSubjectMutate).toHaveBeenCalledWith({
+			year: REPRESENTATION_YEAR,
+		});
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("closes the démarche back to Mon espace once the exemption is recorded", () => {
+		renderScreen("not_concerned");
+
+		act(() => declareNotSubjectState.onSuccess?.());
+
+		expect(push).toHaveBeenCalledWith(MY_SPACE_HREF);
+	});
+
+	it("holds the validation while the recording is in flight", async () => {
+		declareNotSubjectState.isPending = true;
+		renderScreen("not_concerned");
+
+		expect(validateButton()).toBeDisabled();
+
+		await userEvent.click(validateButton());
+
+		expect(declareNotSubjectMutate).not.toHaveBeenCalled();
 	});
 
 	it("restores the funnel entry when the answer is changed back", async () => {
@@ -219,28 +277,60 @@ describe("SubjectionScreen — company not concerned", () => {
 
 		expect(screen.queryByText(NOT_CONCERNED_INFO)).not.toBeInTheDocument();
 		expect(
-			screen.queryByRole("link", { name: "Valider" }),
+			screen.queryByRole("button", { name: "Valider" }),
 		).not.toBeInTheDocument();
 		expect(nextButton()).toBeInTheDocument();
 	});
 });
 
-describe("SubjectionScreen — no persistence", () => {
-	it("never stores the answer, whichever option is submitted", async () => {
-		const { unmount } = renderScreen();
+describe("SubjectionScreen — recording failure (T3-S4)", () => {
+	it("surfaces the failure without leaving the screen", () => {
+		declareNotSubjectState.error = {
+			message: "La campagne de déclaration est fermée.",
+		};
+		renderScreen("not_concerned");
 
-		await userEvent.click(nextButton());
-		await userEvent.click(concernedRadio());
-		await userEvent.click(nextButton());
-		unmount();
-
-		renderScreen();
-		await userEvent.click(notConcernedRadio());
-
-		expect(apiAccess).not.toHaveBeenCalled();
+		const alert = screen.getByRole("alert");
+		expect(alert).toHaveTextContent("La campagne de déclaration est fermée.");
+		expect(alert).toHaveClass("fr-alert--error");
+		expect(push).not.toHaveBeenCalled();
 	});
 
-	it("asks the question again on every visit", async () => {
+	it("keeps the validation available for a retry", async () => {
+		declareNotSubjectState.error = { message: "Une erreur est survenue." };
+		renderScreen("not_concerned");
+
+		await userEvent.click(validateButton());
+
+		expect(declareNotSubjectMutate).toHaveBeenCalledWith({
+			year: REPRESENTATION_YEAR,
+		});
+	});
+});
+
+describe("SubjectionScreen — returning declarant (T3-S2)", () => {
+	it("pre-fills the recorded exemption without recording it again", () => {
+		renderScreen("not_concerned");
+
+		expect(notConcernedRadio()).toBeChecked();
+		expect(concernedRadio()).not.toBeChecked();
+		expect(screen.getByText(NOT_CONCERNED_INFO)).toBeInTheDocument();
+		expect(validateButton()).toBeEnabled();
+		expect(declareNotSubjectMutate).not.toHaveBeenCalled();
+	});
+
+	it("lets the declarant switch to the funnel without recording anything (T3-S3)", async () => {
+		renderScreen("not_concerned");
+
+		await userEvent.click(concernedRadio());
+		await userEvent.click(nextButton());
+
+		expect(push).toHaveBeenCalledWith(STEP_1_HREF);
+		expect(declareNotSubjectMutate).not.toHaveBeenCalled();
+		expect(screen.queryByText(NOT_CONCERNED_INFO)).not.toBeInTheDocument();
+	});
+
+	it("asks the question again when nothing was recorded", async () => {
 		const { unmount } = renderScreen();
 		await userEvent.click(concernedRadio());
 		unmount();

--- a/packages/app/src/modules/declaration-representation/index.ts
+++ b/packages/app/src/modules/declaration-representation/index.ts
@@ -57,6 +57,7 @@ export type {
 	RepresentationDeclarationRow,
 	RepresentationDraft,
 	RepresentationStepSlug,
+	SubjectionAnswer,
 	SubmitRepresentationInput,
 } from "./types";
 export {

--- a/packages/app/src/modules/declaration-representation/types.ts
+++ b/packages/app/src/modules/declaration-representation/types.ts
@@ -7,6 +7,7 @@ import type {
 	publicationSchema,
 	referencePeriodSchema,
 	representationDraftSchema,
+	subjectionSchema,
 	submitRepresentationSchema,
 } from "./schemas";
 
@@ -17,6 +18,9 @@ export type RepresentationDeclarationRow = Omit<
 
 export type ReferencePeriodInput = z.infer<
 	ReturnType<typeof referencePeriodSchema>
+>;
+export type SubjectionAnswer = NonNullable<
+	z.infer<typeof subjectionSchema>["answer"]
 >;
 export type ExecutivesInput = z.infer<typeof executivesSchema>;
 export type MembersInput = z.infer<typeof membersSchema>;


### PR DESCRIPTION
Closes #4352

## Résumé

L'écran d'assujettissement de `/declaration-representation` enregistre désormais le choix « Moins de 1 000 salariés sur au moins un exercice » via la mutation `representationDeclaration.declareNotSubject`, au lieu d'un simple lien vers `/mon-espace`. L'écran se pré-remplit également au retour d'un utilisateur dont le statut est `not_subject` (réversibilité).

### Changements

- `app/declaration-representation/page.tsx` : passe `year` et `initialAnswer` (dérivé de `declaration?.status === "not_subject"`) à `SubjectionScreen`.
- `modules/declaration-representation/SubjectionScreen.tsx` :
  - le `Link` « Valider » devient un `<button type="submit">` déclenchant `declareNotSubject.mutate({ year })`
  - bouton désactivé pendant l'envoi ; alerte `fr-alert--error` en cas d'échec (pas de redirection)
  - succès → redirection directe vers `/mon-espace` (ni email, ni écran de confirmation, décision produit de l'epic)
  - le choix « 1 000 salariés ou plus » reste inchangé (navigation vers l'étape 1, sans écriture serveur)
- `modules/declaration-representation/types.ts` + `index.ts` : type `SubjectionAnswer` dérivé du schéma Zod (évite la duplication du littéral).

### Test plan

- [x] `pnpm typecheck` vert
- [x] `pnpm lint:check` / `pnpm format:check` verts
- [x] `pnpm test` vert (5486/5486, dont les nouveaux scénarios T3-S1 à T3-S4 ajoutés par `tu-dev`)
- [ ] `functional-validator` (scénarios PO rejoués sur dev server)

### Note accessibilité

Le gate `rgaa-auditor` local n'a pas pu s'exécuter dans cette session (plugin ultra11y non installé) ; la gate statique `a11y-gate` de `a11y.yaml` s'exécutera automatiquement sur cette PR et sera vérifiée avant `gh pr ready`.