### PR TITLE
Représentation équilibrée — affichage Non-assujetti sur Mon espace

### DIFF
--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
@@ -163,6 +163,11 @@
 	gap: 0.5rem;
 }
 
+// Not-subject message
+.notSubjectMessage {
+	color: var(--text-title-grey);
+}
+
 // Help section
 .helpSection {
 	display: flex;

--- a/packages/app/src/modules/my-space/DeclarationStepLabel.ts
+++ b/packages/app/src/modules/my-space/DeclarationStepLabel.ts
@@ -21,11 +21,16 @@ const PROCESS_STEP_LABELS: Record<DeclarationFsmStatus, string> = {
 };
 
 const REPRESENTATION_START_LABEL = "Vérification de l'assujettissement";
+const REPRESENTATION_NOT_SUBJECT_LABEL = "Non-assujetti";
 
 function getRepresentationStepLabel(
 	status: DeclarationStatus,
 	currentStep: number,
+	notSubject: boolean,
 ): string {
+	if (notSubject) {
+		return REPRESENTATION_NOT_SUBJECT_LABEL;
+	}
 	if (status === "done") {
 		return "Finalisation - Démarche des indicateurs de représentation";
 	}
@@ -42,9 +47,10 @@ export function getDeclarationProcessStepLabel(d: {
 	fsmStatus: DeclarationFsmStatus | null;
 	status: DeclarationStatus;
 	currentStep: number;
+	notSubject: boolean;
 }): string {
 	if (d.type === "representation") {
-		return getRepresentationStepLabel(d.status, d.currentStep);
+		return getRepresentationStepLabel(d.status, d.currentStep, d.notSubject);
 	}
 	return PROCESS_STEP_LABELS[d.fsmStatus ?? "draft"];
 }

--- a/packages/app/src/modules/my-space/DeclarationStepLabel.ts
+++ b/packages/app/src/modules/my-space/DeclarationStepLabel.ts
@@ -21,7 +21,6 @@ const PROCESS_STEP_LABELS: Record<DeclarationFsmStatus, string> = {
 };
 
 const REPRESENTATION_START_LABEL = "Vérification de l'assujettissement";
-const REPRESENTATION_NOT_SUBJECT_LABEL = "Non-assujetti";
 
 function getRepresentationStepLabel(
 	status: DeclarationStatus,
@@ -29,7 +28,7 @@ function getRepresentationStepLabel(
 	notSubject: boolean,
 ): string {
 	if (notSubject) {
-		return REPRESENTATION_NOT_SUBJECT_LABEL;
+		return "Non-assujetti";
 	}
 	if (status === "done") {
 		return "Finalisation - Démarche des indicateurs de représentation";

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -46,6 +46,7 @@ function getDeadlineCell(
 	representationCampaign: RepresentationCampaign,
 ): string {
 	if (declaration.type === "representation") {
+		if (declaration.notSubject) return "-";
 		return formatShortDate(representationCampaign.declarationDeadline);
 	}
 	const deadline = getDeclarationProcessStepDeadline(

--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -24,7 +24,7 @@ function resourceSubtitle(declaration: DeclarationItem): string {
 function getRepresentationResources(
 	declaration: DeclarationItem,
 ): DocumentResource[] {
-	if (declaration.status !== "done") return [];
+	if (declaration.status !== "done" || declaration.notSubject) return [];
 	const referenceYear = getReferenceYearFor(declaration.year);
 	return [
 		{

--- a/packages/app/src/modules/my-space/RepresentationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/RepresentationProcessPanel.tsx
@@ -31,7 +31,7 @@ type StepStatus = "pending" | "current" | "complete";
 
 function getStepStatuses(
 	variant: RepresentationPanelVariant,
-): [StepStatus, StepStatus] {
+): [StepStatus, StepStatus | null] {
 	switch (variant) {
 		case "start":
 			return ["current", "pending"];
@@ -40,11 +40,13 @@ function getStepStatuses(
 		case "submitted":
 		case "closed":
 			return ["complete", "complete"];
+		case "not_subject":
+			return ["complete", null];
 	}
 }
 
 function getCtaLabel(variant: RepresentationPanelVariant): string {
-	if (variant === "start") return "Commencer";
+	if (variant === "start" || variant === "not_subject") return "Commencer";
 	if (variant === "draft") return "Reprendre";
 	return "Voir la déclaration";
 }
@@ -88,14 +90,17 @@ export function RepresentationProcessPanel({
 							campaignYear={campaignYear}
 							lastActionDate={lastActionDate}
 						/>
-						<RixainAlert />
+						{variant !== "not_subject" && <RixainAlert />}
 						<div className={`${styles.stepper} fr-mb-4w`}>
 							<Step1Row status={step1} />
-							<Step2Row
-								deadline={campaign.declarationDeadline}
-								status={step2}
-							/>
+							{step2 !== null && (
+								<Step2Row
+									deadline={campaign.declarationDeadline}
+									status={step2}
+								/>
+							)}
 						</div>
+						{variant === "not_subject" && <NotSubjectMessage />}
 						{variant === "closed" && <ClosedMessage />}
 					</div>
 					<div>
@@ -274,6 +279,17 @@ function ClosedMessage() {
 		<div className={styles.closedMessage}>
 			<p className="fr-text--bold fr-mb-0">Démarche close</p>
 			<p className="fr-mb-0">Cette démarche est terminée.</p>
+		</div>
+	);
+}
+
+function NotSubjectMessage() {
+	return (
+		<div className="fr-background-alt--blue-france fr-p-4w">
+			<p className="fr-mb-0">
+				Vous n'êtes pas assujetti à la publication et à la déclaration des
+				écarts éventuels de représentation entre les femmes et les hommes.
+			</p>
 		</div>
 	);
 }

--- a/packages/app/src/modules/my-space/RepresentationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/RepresentationProcessPanel.tsx
@@ -286,7 +286,7 @@ function ClosedMessage() {
 function NotSubjectMessage() {
 	return (
 		<div className="fr-background-alt--blue-france fr-p-4w">
-			<p className="fr-mb-0">
+			<p className={`fr-mb-0 ${styles.notSubjectMessage}`}>
 				Vous n'êtes pas assujetti à la publication et à la déclaration des
 				écarts éventuels de représentation entre les femmes et les hommes.
 			</p>

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -64,6 +64,7 @@ function makeDeclaration(
 		cseRequired: false,
 		hasJointEvaluationFile: false,
 		hasPrefillData: false,
+		notSubject: false,
 		...overrides,
 	};
 }

--- a/packages/app/src/modules/my-space/__tests__/DeclarationStepLabel.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationStepLabel.test.ts
@@ -13,6 +13,7 @@ function remuneration(fsmStatus: DeclarationFsmStatus | null) {
 		fsmStatus,
 		status: "in_progress" as DeclarationStatus,
 		currentStep: 1,
+		notSubject: false,
 	};
 }
 
@@ -22,6 +23,7 @@ function representation(status: DeclarationStatus, currentStep: number) {
 		fsmStatus: null,
 		status,
 		currentStep,
+		notSubject: false,
 	};
 }
 
@@ -105,6 +107,26 @@ describe("getDeclarationProcessStepLabel", () => {
 			expect(
 				getDeclarationProcessStepLabel(representation("in_progress", 0)),
 			).toBe(REPRESENTATION_START_LABEL);
+		});
+
+		describe("not subject", () => {
+			const settledStates: Array<[DeclarationStatus, number]> = [
+				["done", 0],
+				["to_complete", 0],
+				["in_progress", 3],
+				["done", 5],
+			];
+
+			for (const [status, currentStep] of settledStates) {
+				it(`returns "Non-assujetti" whatever the progression (${status}, step ${currentStep})`, () => {
+					expect(
+						getDeclarationProcessStepLabel({
+							...representation(status, currentStep),
+							notSubject: true,
+						}),
+					).toBe("Non-assujetti");
+				});
+			}
 		});
 
 		it("returns the completion label for a submitted démarche", () => {

--- a/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
@@ -25,6 +25,7 @@ const NO_COMPLIANCE = {
 	cseRequired: false,
 	hasJointEvaluationFile: false,
 	hasPrefillData: false,
+	notSubject: false,
 } as const;
 
 const declarations: DeclarationItem[] = [
@@ -219,6 +220,42 @@ describe("DeclarationsSection", () => {
 				"Écarts de représentation - Instances dirigeantes",
 			),
 		).toBeInTheDocument();
+	});
+
+	it("renders the whole not-subject representation row: no step, no deadline, no resource", () => {
+		renderSection({
+			declarations: [
+				{
+					type: "representation",
+					siren: SIREN,
+					year: currentYear,
+					status: "done",
+					currentStep: 0,
+					updatedAt: new Date("2026-02-10"),
+					...NO_COMPLIANCE,
+					notSubject: true,
+				},
+			],
+		});
+		const [currentTable] = screen.getAllByRole("table");
+		const [, notSubjectRow] = within(currentTable as HTMLElement).getAllByRole(
+			"row",
+		);
+		const cells = within(notSubjectRow as HTMLElement).getAllByRole("cell");
+
+		expect(cells.map((cell) => cell.textContent)).toEqual([
+			"Représentation",
+			String(currentYear),
+			"Non-assujetti",
+			"-",
+			"Effectué",
+			"Aucune",
+		]);
+		expect(
+			within(notSubjectRow as HTMLElement).queryByRole("button", {
+				name: /^Documents/,
+			}),
+		).not.toBeInTheDocument();
 	});
 
 	it("takes the representation deadline from the campaign, not from a fixed 1st of March", () => {

--- a/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
@@ -55,6 +55,7 @@ function makeDeclaration({
 		cseRequired: false,
 		hasJointEvaluationFile: false,
 		hasPrefillData: false,
+		notSubject: false,
 		...overrides,
 	};
 
@@ -124,6 +125,16 @@ describe("getDocumentResourceCount", () => {
 		expect(
 			getDocumentResourceCount(makeDeclaration({ type: "representation" })),
 		).toBe(1);
+	});
+
+	// A not-subject démarche is settled ("done") but produces no récépissé — the
+	// PDF route would 404 on a declaration that was never filled.
+	it("counts no resource for a settled representation declaration that is not subject", () => {
+		expect(
+			getDocumentResourceCount(
+				makeDeclaration({ type: "representation", notSubject: true }),
+			),
+		).toBe(0);
 	});
 
 	it.each(
@@ -236,6 +247,15 @@ describe("DocumentsPanel", () => {
 			type: "representation",
 			fsmStatus: "draft",
 			currentStep: 1,
+		});
+
+		expect(links()).toHaveLength(0);
+	});
+
+	it("offers no representation document when the company is not subject", () => {
+		const { links } = renderPanel({
+			type: "representation",
+			notSubject: true,
 		});
 
 		expect(links()).toHaveLength(0);

--- a/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
@@ -127,8 +127,7 @@ describe("getDocumentResourceCount", () => {
 		).toBe(1);
 	});
 
-	// A not-subject démarche is settled ("done") but produces no récépissé — the
-	// PDF route would 404 on a declaration that was never filled.
+	// Settled ("done") but never filled: the récépissé PDF route would 404.
 	it("counts no resource for a settled representation declaration that is not subject", () => {
 		expect(
 			getDocumentResourceCount(

--- a/packages/app/src/modules/my-space/__tests__/RepresentationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/RepresentationProcessPanel.test.tsx
@@ -56,8 +56,7 @@ const SUBMITTED = makeDeclaration({
 	status: "done",
 	currentStep: TOTAL_REPRESENTATION_STEPS,
 });
-// The funnel resets a not-subject row to step 0 while the router still maps it
-// to "done": the discriminant, not the progression, settles the démarche.
+// A not-subject row is reset to step 0 yet mapped "done": the flag settles it.
 const NOT_SUBJECT = makeDeclaration({
 	status: "done",
 	currentStep: 0,

--- a/packages/app/src/modules/my-space/__tests__/RepresentationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/RepresentationProcessPanel.test.tsx
@@ -46,6 +46,7 @@ function makeDeclaration(
 		cseRequired: false,
 		hasJointEvaluationFile: false,
 		hasPrefillData: false,
+		notSubject: false,
 		...overrides,
 	};
 }
@@ -55,6 +56,16 @@ const SUBMITTED = makeDeclaration({
 	status: "done",
 	currentStep: TOTAL_REPRESENTATION_STEPS,
 });
+// The funnel resets a not-subject row to step 0 while the router still maps it
+// to "done": the discriminant, not the progression, settles the démarche.
+const NOT_SUBJECT = makeDeclaration({
+	status: "done",
+	currentStep: 0,
+	notSubject: true,
+});
+
+const NOT_SUBJECT_MESSAGE =
+	"Vous n'êtes pas assujetti à la publication et à la déclaration des écarts éventuels de représentation entre les femmes et les hommes.";
 
 function renderPanel({
 	campaign = OPEN_CAMPAIGN,
@@ -233,12 +244,50 @@ describe("RepresentationProcessPanel", () => {
 		});
 	});
 
+	describe("variant: not_subject", () => {
+		it('renders a "Commencer" CTA pointing back to the funnel entry point', () => {
+			const { dialog } = renderPanel({ declaration: NOT_SUBJECT });
+			const cta = getCta(dialog);
+			expect(cta).toHaveTextContent(/^Commencer$/);
+			expect(cta).toHaveAttribute("href", REPRESENTATION_FUNNEL_ROOT);
+		});
+
+		it("keeps the subjection check as the only step, done, with no deadline", () => {
+			const { panel } = renderPanel({ declaration: NOT_SUBJECT });
+			expect(panel.getAllByText("Étape terminée")).toHaveLength(1);
+			expect(panel.queryByText("Étape en cours")).not.toBeInTheDocument();
+			expect(panel.queryByText("Étape à venir")).not.toBeInTheDocument();
+			expect(
+				panel.getByText("Vérification de l'assujettissement"),
+			).toBeInTheDocument();
+			expect(
+				panel.queryByText("Déclaration des écarts de représentation"),
+			).not.toBeInTheDocument();
+			expect(
+				panel.queryByText("Écarts de représentation"),
+			).not.toBeInTheDocument();
+			expect(panel.queryByText(/^Échéance :/)).not.toBeInTheDocument();
+		});
+
+		it("states the company is not subject, without the Rixain reminder", () => {
+			const { panel } = renderPanel({ declaration: NOT_SUBJECT });
+			expect(panel.getByText(NOT_SUBJECT_MESSAGE)).toBeInTheDocument();
+			expect(panel.queryByText(/loi Rixain/)).not.toBeInTheDocument();
+		});
+
+		it("does not announce the démarche as closed while the campaign is open", () => {
+			const { panel } = renderPanel({ declaration: NOT_SUBJECT });
+			expect(panel.queryByText("Démarche close")).not.toBeInTheDocument();
+		});
+	});
+
 	describe("campaign closed", () => {
 		const declarations: Array<[string, DeclarationItem | undefined]> = [
 			["no démarche", undefined],
 			["an untouched démarche", makeDeclaration()],
 			["a draft", DRAFT],
 			["a submitted démarche", SUBMITTED],
+			["a not-subject démarche", NOT_SUBJECT],
 		];
 
 		for (const [label, declaration] of declarations) {
@@ -251,6 +300,7 @@ describe("RepresentationProcessPanel", () => {
 				expect(
 					panel.getByText("Cette démarche est terminée."),
 				).toBeInTheDocument();
+				expect(panel.queryByText(NOT_SUBJECT_MESSAGE)).not.toBeInTheDocument();
 				const cta = getCta(dialog);
 				expect(cta).toHaveTextContent(/^Voir la déclaration$/);
 				expect(cta).toHaveAttribute("href", RECAP_HREF);

--- a/packages/app/src/modules/my-space/__tests__/buildDeclarationList.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/buildDeclarationList.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { buildDeclarationList } from "../buildDeclarationList";
+import {
+	buildDeclarationList,
+	type DbDeclaration,
+} from "../buildDeclarationList";
+import type { DeclarationType } from "../types";
 
 const SIREN = "532847196";
 const EMPTY_DECLARATION = {
@@ -13,63 +17,64 @@ const EMPTY_DECLARATION = {
 	hasPrefillData: false,
 	notSubject: false,
 };
-const PLACEHOLDER_ROW = { ...EMPTY_DECLARATION, fsmStatus: null };
+
+function makeDbDeclaration(
+	overrides: Partial<DbDeclaration> = {},
+): DbDeclaration {
+	return {
+		type: "remuneration",
+		year: 2026,
+		status: "done",
+		fsmStatus: "demarche_completed",
+		currentStep: 6,
+		updatedAt: null,
+		...EMPTY_DECLARATION,
+		...overrides,
+	};
+}
+
+function placeholderRow(type: DeclarationType, year = 2026) {
+	return {
+		type,
+		siren: SIREN,
+		year,
+		status: "to_complete",
+		fsmStatus: null,
+		currentStep: 0,
+		updatedAt: null,
+		...EMPTY_DECLARATION,
+	};
+}
+
+const NOT_SUBJECT: Partial<DbDeclaration> = {
+	type: "representation",
+	status: "done",
+	fsmStatus: null,
+	currentStep: 0,
+	notSubject: true,
+};
 
 describe("buildDeclarationList", () => {
 	it("returns two rows (remuneration + representation) for the current year when no DB records exist", () => {
 		const result = buildDeclarationList(SIREN, [], 2026);
 
 		expect(result).toEqual([
-			{
-				type: "remuneration",
-				siren: SIREN,
-				year: 2026,
-				status: "to_complete",
-				currentStep: 0,
-				updatedAt: null,
-				...PLACEHOLDER_ROW,
-			},
-			{
-				type: "representation",
-				siren: SIREN,
-				year: 2026,
-				status: "to_complete",
-				currentStep: 0,
-				updatedAt: null,
-				...PLACEHOLDER_ROW,
-			},
+			placeholderRow("remuneration"),
+			placeholderRow("representation"),
 		]);
 	});
 
 	it("uses DB data for remuneration when a record exists for the current year", () => {
-		const updatedAt = new Date("2026-02-15");
-		const result = buildDeclarationList(
-			SIREN,
-			[
-				{
-					type: "remuneration",
-					year: 2026,
-					status: "in_progress",
-					fsmStatus: "draft",
-					currentStep: 3,
-					updatedAt,
-					...EMPTY_DECLARATION,
-				},
-			],
-			2026,
-		);
-
-		expect(result).toHaveLength(2);
-		expect(result[0]).toEqual({
-			type: "remuneration",
-			siren: SIREN,
-			year: 2026,
+		const record = makeDbDeclaration({
 			status: "in_progress",
 			fsmStatus: "draft",
 			currentStep: 3,
-			updatedAt,
-			...EMPTY_DECLARATION,
+			updatedAt: new Date("2026-02-15"),
 		});
+		const result = buildDeclarationList(SIREN, [record], 2026);
+
+		expect(result).toHaveLength(2);
+		expect(result[0]).toEqual({ ...record, siren: SIREN });
 		expect(result[1]).toMatchObject({
 			type: "representation",
 			year: 2026,
@@ -82,17 +87,7 @@ describe("buildDeclarationList", () => {
 		const updatedAt2025 = new Date("2025-06-01");
 		const result = buildDeclarationList(
 			SIREN,
-			[
-				{
-					type: "remuneration",
-					year: 2025,
-					status: "done",
-					fsmStatus: "demarche_completed",
-					currentStep: 6,
-					updatedAt: updatedAt2025,
-					...EMPTY_DECLARATION,
-				},
-			],
+			[makeDbDeclaration({ year: 2025, updatedAt: updatedAt2025 })],
 			2026,
 		);
 
@@ -121,33 +116,9 @@ describe("buildDeclarationList", () => {
 		const result = buildDeclarationList(
 			SIREN,
 			[
-				{
-					type: "remuneration",
-					year: 2023,
-					status: "done",
-					fsmStatus: "demarche_completed",
-					currentStep: 6,
-					updatedAt: null,
-					...EMPTY_DECLARATION,
-				},
-				{
-					type: "remuneration",
-					year: 2025,
-					status: "done",
-					fsmStatus: "demarche_completed",
-					currentStep: 6,
-					updatedAt: null,
-					...EMPTY_DECLARATION,
-				},
-				{
-					type: "remuneration",
-					year: 2024,
-					status: "done",
-					fsmStatus: "demarche_completed",
-					currentStep: 6,
-					updatedAt: null,
-					...EMPTY_DECLARATION,
-				},
+				makeDbDeclaration({ year: 2023 }),
+				makeDbDeclaration({ year: 2025 }),
+				makeDbDeclaration({ year: 2024 }),
 			],
 			2026,
 		);
@@ -161,28 +132,14 @@ describe("buildDeclarationList", () => {
 	});
 
 	it("merges current year DB record with expected types", () => {
-		const updatedAt = new Date("2026-01-10");
 		const result = buildDeclarationList(
 			SIREN,
 			[
-				{
-					type: "remuneration",
-					year: 2026,
-					status: "done",
+				makeDbDeclaration({
 					fsmStatus: "awaiting_compliance_path_choice",
-					currentStep: 6,
-					updatedAt,
-					...EMPTY_DECLARATION,
-				},
-				{
-					type: "remuneration",
-					year: 2025,
-					status: "done",
-					fsmStatus: "demarche_completed",
-					currentStep: 6,
-					updatedAt: null,
-					...EMPTY_DECLARATION,
-				},
+					updatedAt: new Date("2026-01-10"),
+				}),
+				makeDbDeclaration({ year: 2025 }),
 			],
 			2026,
 		);
@@ -220,17 +177,7 @@ describe("buildDeclarationList", () => {
 	it("omits the current year representation row when visibility is denied", () => {
 		const result = buildDeclarationList(SIREN, [], 2026, new Set(), false);
 
-		expect(result).toEqual([
-			{
-				type: "remuneration",
-				siren: SIREN,
-				year: 2026,
-				status: "to_complete",
-				currentStep: 0,
-				updatedAt: null,
-				...PLACEHOLDER_ROW,
-			},
-		]);
+		expect(result).toEqual([placeholderRow("remuneration")]);
 	});
 
 	it("keeps the remuneration prefill flag when representation is hidden", () => {
@@ -250,52 +197,29 @@ describe("buildDeclarationList", () => {
 	});
 
 	it("keeps an existing representation draft visible when visibility is denied", () => {
-		const updatedAt = new Date("2026-03-02");
+		const record = makeDbDeclaration({
+			type: "representation",
+			status: "in_progress",
+			fsmStatus: "draft",
+			currentStep: 2,
+			updatedAt: new Date("2026-03-02"),
+		});
 		const result = buildDeclarationList(
 			SIREN,
-			[
-				{
-					type: "representation",
-					year: 2026,
-					status: "in_progress",
-					fsmStatus: "draft",
-					currentStep: 2,
-					updatedAt,
-					...EMPTY_DECLARATION,
-				},
-			],
+			[record],
 			2026,
 			new Set(),
 			false,
 		);
 
 		expect(result).toHaveLength(2);
-		expect(result[1]).toEqual({
-			type: "representation",
-			siren: SIREN,
-			year: 2026,
-			status: "in_progress",
-			fsmStatus: "draft",
-			currentStep: 2,
-			updatedAt,
-			...EMPTY_DECLARATION,
-		});
+		expect(result[1]).toEqual({ ...record, siren: SIREN });
 	});
 
 	it("keeps a submitted representation declaration visible when visibility is denied", () => {
 		const result = buildDeclarationList(
 			SIREN,
-			[
-				{
-					type: "representation",
-					year: 2026,
-					status: "done",
-					fsmStatus: "demarche_completed",
-					currentStep: 6,
-					updatedAt: null,
-					...EMPTY_DECLARATION,
-				},
-			],
+			[makeDbDeclaration({ type: "representation" })],
 			2026,
 			new Set(),
 			false,
@@ -313,17 +237,7 @@ describe("buildDeclarationList", () => {
 	it("keeps previous year representation declarations visible when visibility is denied", () => {
 		const result = buildDeclarationList(
 			SIREN,
-			[
-				{
-					type: "representation",
-					year: 2025,
-					status: "done",
-					fsmStatus: "demarche_completed",
-					currentStep: 6,
-					updatedAt: null,
-					...EMPTY_DECLARATION,
-				},
-			],
+			[makeDbDeclaration({ type: "representation", year: 2025 })],
 			2026,
 			new Set(),
 			false,
@@ -342,16 +256,10 @@ describe("buildDeclarationList", () => {
 		const result = buildDeclarationList(
 			SIREN,
 			[
-				{
-					type: "remuneration",
-					year: 2026,
-					status: "done",
+				makeDbDeclaration({
 					fsmStatus: "awaiting_cse_opinion",
-					currentStep: 6,
-					updatedAt: null,
-					...EMPTY_DECLARATION,
 					cseRequired: true,
-				},
+				}),
 			],
 			2026,
 		);
@@ -367,18 +275,7 @@ describe("buildDeclarationList", () => {
 	it("propagates notSubject from a current year representation record", () => {
 		const result = buildDeclarationList(
 			SIREN,
-			[
-				{
-					type: "representation",
-					year: 2026,
-					status: "done",
-					fsmStatus: null,
-					currentStep: 0,
-					updatedAt: null,
-					...EMPTY_DECLARATION,
-					notSubject: true,
-				},
-			],
+			[makeDbDeclaration(NOT_SUBJECT)],
 			2026,
 		);
 
@@ -398,18 +295,7 @@ describe("buildDeclarationList", () => {
 	it("propagates notSubject from a previous year representation record", () => {
 		const result = buildDeclarationList(
 			SIREN,
-			[
-				{
-					type: "representation",
-					year: 2025,
-					status: "done",
-					fsmStatus: null,
-					currentStep: 0,
-					updatedAt: null,
-					...EMPTY_DECLARATION,
-					notSubject: true,
-				},
-			],
+			[makeDbDeclaration({ ...NOT_SUBJECT, year: 2025 })],
 			2026,
 		);
 

--- a/packages/app/src/modules/my-space/__tests__/buildDeclarationList.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/buildDeclarationList.test.ts
@@ -11,6 +11,7 @@ const EMPTY_DECLARATION = {
 	cseRequired: false,
 	hasJointEvaluationFile: false,
 	hasPrefillData: false,
+	notSubject: false,
 };
 const PLACEHOLDER_ROW = { ...EMPTY_DECLARATION, fsmStatus: null };
 
@@ -360,6 +361,62 @@ describe("buildDeclarationList", () => {
 			year: 2026,
 			fsmStatus: "awaiting_cse_opinion",
 			cseRequired: true,
+		});
+	});
+
+	it("propagates notSubject from a current year representation record", () => {
+		const result = buildDeclarationList(
+			SIREN,
+			[
+				{
+					type: "representation",
+					year: 2026,
+					status: "done",
+					fsmStatus: null,
+					currentStep: 0,
+					updatedAt: null,
+					...EMPTY_DECLARATION,
+					notSubject: true,
+				},
+			],
+			2026,
+		);
+
+		expect(result[1]).toMatchObject({
+			type: "representation",
+			year: 2026,
+			status: "done",
+			notSubject: true,
+		});
+		expect(result[0]).toMatchObject({
+			type: "remuneration",
+			year: 2026,
+			notSubject: false,
+		});
+	});
+
+	it("propagates notSubject from a previous year representation record", () => {
+		const result = buildDeclarationList(
+			SIREN,
+			[
+				{
+					type: "representation",
+					year: 2025,
+					status: "done",
+					fsmStatus: null,
+					currentStep: 0,
+					updatedAt: null,
+					...EMPTY_DECLARATION,
+					notSubject: true,
+				},
+			],
+			2026,
+		);
+
+		expect(result[2]).toMatchObject({
+			type: "representation",
+			year: 2025,
+			notSubject: true,
 		});
 	});
 });

--- a/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
@@ -43,6 +43,7 @@ function makeDeclaration(
 		cseRequired: false,
 		hasJointEvaluationFile: false,
 		hasPrefillData: false,
+		notSubject: false,
 		...overrides,
 	};
 }
@@ -99,6 +100,14 @@ function makeRepresentation(
 	});
 }
 
+// The funnel resets a not-subject row to step 0 while the router still maps it
+// to "done": the discriminant, not the progression, settles the démarche.
+const NOT_SUBJECT = {
+	status: "done" as const,
+	currentStep: 0,
+	notSubject: true,
+};
+
 describe("computeRepresentationPanelVariant", () => {
 	it('returns "start" when no démarche exists yet', () => {
 		expect(computeRepresentationPanelVariant(undefined, CAMPAIGN_OPEN)).toBe(
@@ -128,6 +137,24 @@ describe("computeRepresentationPanelVariant", () => {
 				CAMPAIGN_OPEN,
 			),
 		).toBe("submitted");
+	});
+
+	it('returns "not_subject" — not "submitted" — for a settled non-subject démarche', () => {
+		expect(
+			computeRepresentationPanelVariant(
+				makeRepresentation(NOT_SUBJECT),
+				CAMPAIGN_OPEN,
+			),
+		).toBe("not_subject");
+	});
+
+	it('returns "closed" for a non-subject démarche once the campaign is closed', () => {
+		expect(
+			computeRepresentationPanelVariant(
+				makeRepresentation(NOT_SUBJECT),
+				CAMPAIGN_CLOSED,
+			),
+		).toBe("closed");
 	});
 
 	it('returns "closed" for every démarche state once the campaign is closed', () => {
@@ -181,6 +208,24 @@ describe("computeRepresentationCtaHref", () => {
 			computeRepresentationCtaHref(
 				makeRepresentation({ status: "done", currentStep: 5 }),
 				CAMPAIGN_OPEN,
+			),
+		).toBe(RECAP_HREF);
+	});
+
+	it("sends a non-subject démarche back to the funnel entry point, so it stays reversible", () => {
+		expect(
+			computeRepresentationCtaHref(
+				makeRepresentation(NOT_SUBJECT),
+				CAMPAIGN_OPEN,
+			),
+		).toBe(REPRESENTATION_FUNNEL_ROOT);
+	});
+
+	it("sends a non-subject démarche to the recap once the campaign is closed", () => {
+		expect(
+			computeRepresentationCtaHref(
+				makeRepresentation(NOT_SUBJECT),
+				CAMPAIGN_CLOSED,
 			),
 		).toBe(RECAP_HREF);
 	});

--- a/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
@@ -100,8 +100,7 @@ function makeRepresentation(
 	});
 }
 
-// The funnel resets a not-subject row to step 0 while the router still maps it
-// to "done": the discriminant, not the progression, settles the démarche.
+// A not-subject row is reset to step 0 yet mapped "done": the flag settles it.
 const NOT_SUBJECT = {
 	status: "done" as const,
 	currentStep: 0,

--- a/packages/app/src/modules/my-space/buildDeclarationList.ts
+++ b/packages/app/src/modules/my-space/buildDeclarationList.ts
@@ -23,6 +23,7 @@ export type DbDeclaration = {
 	cseRequired: boolean;
 	hasJointEvaluationFile: boolean;
 	hasPrefillData: boolean;
+	notSubject: boolean;
 };
 
 export function buildDeclarationList(
@@ -54,6 +55,7 @@ export function buildDeclarationList(
 				cseRequired: existing.cseRequired,
 				hasJointEvaluationFile: existing.hasJointEvaluationFile,
 				hasPrefillData: existing.hasPrefillData,
+				notSubject: existing.notSubject,
 			});
 		} else if (type !== "representation" || representationVisible) {
 			rows.push({
@@ -72,6 +74,7 @@ export function buildDeclarationList(
 				hasJointEvaluationFile: false,
 				hasPrefillData:
 					type === "remuneration" && yearsWithPrefill.has(currentYear),
+				notSubject: false,
 			});
 		}
 	}
@@ -96,6 +99,7 @@ export function buildDeclarationList(
 			cseRequired: d.cseRequired,
 			hasJointEvaluationFile: d.hasJointEvaluationFile,
 			hasPrefillData: d.hasPrefillData,
+			notSubject: d.notSubject,
 		});
 	}
 

--- a/packages/app/src/modules/my-space/declarationProcessState.ts
+++ b/packages/app/src/modules/my-space/declarationProcessState.ts
@@ -77,6 +77,7 @@ export type RepresentationPanelVariant =
 	| "start"
 	| "draft"
 	| "submitted"
+	| "not_subject"
 	| "closed";
 
 // Representation has no FSM yet — progression is this 3-bucket DeclarationItem.status.
@@ -95,6 +96,7 @@ export function computeRepresentationPanelVariant(
 	campaignOpen: boolean,
 ): RepresentationPanelVariant {
 	if (!campaignOpen) return "closed";
+	if (declaration?.notSubject) return "not_subject";
 	const progress = getRepresentationProgress(declaration);
 	return progress === "not_started" ? "start" : progress;
 }
@@ -104,6 +106,7 @@ export function computeRepresentationCtaHref(
 	campaignOpen: boolean,
 ): string {
 	if (!campaignOpen) return stepHref(TOTAL_REPRESENTATION_STEPS);
+	if (declaration?.notSubject) return REPRESENTATION_FUNNEL_ROOT;
 	const progress = getRepresentationProgress(declaration);
 	if (progress === "submitted") return stepHref(TOTAL_REPRESENTATION_STEPS);
 	if (progress === "draft") {

--- a/packages/app/src/modules/my-space/types.ts
+++ b/packages/app/src/modules/my-space/types.ts
@@ -52,4 +52,5 @@ export type DeclarationItem = {
 	cseRequired: boolean;
 	hasJointEvaluationFile: boolean;
 	hasPrefillData: boolean;
+	notSubject: boolean;
 };

--- a/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
@@ -457,7 +457,36 @@ describe("companyRouter.getWithDeclarations", () => {
 			status: "done",
 			fsmStatus: null,
 			currentStep: 0,
+			notSubject: true,
 		});
+	});
+
+	// "done" alone cannot tell a submitted démarche from a not-subject one, so
+	// the dashboard reads this discriminant rather than the status.
+	it("flags only the not-subject row, never a submitted one nor the rémunération lines", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceBelowThreshold,
+		);
+		const { caller } = await makeCaller({
+			declRows: [makeDeclRow(getCurrentYear())],
+			representationDeclarationRows: [
+				makeRepresentationDeclarationRow({
+					status: "submitted",
+					currentStep: 5,
+				}),
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find((d) => d.type === "representation"),
+		).toMatchObject({ status: "done", notSubject: false });
+		expect(
+			result.declarations
+				.filter((d) => d.type === "remuneration")
+				.map((d) => d.notSubject),
+		).toEqual([false]);
 	});
 
 	it("keeps the démarche listed under the campaign year, not the stored reference year", async () => {

--- a/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
@@ -461,8 +461,7 @@ describe("companyRouter.getWithDeclarations", () => {
 		});
 	});
 
-	// "done" alone cannot tell a submitted démarche from a not-subject one, so
-	// the dashboard reads this discriminant rather than the status.
+	// "done" alone cannot tell a submitted démarche from a not-subject one.
 	it("flags only the not-subject row, never a submitted one nor the rémunération lines", async () => {
 		getRepresentationWorkforceHistoryMock.mockResolvedValue(
 			workforceBelowThreshold,

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -9,6 +9,7 @@ import {
 	getReferenceYearFor,
 	isCseRequired,
 	isPresumedSubjectToRepresentation,
+	isRepresentationNotSubject,
 	parseGipWorkforce,
 } from "~/modules/domain";
 import {
@@ -308,6 +309,7 @@ export const companyRouter = createTRPCRouter({
 				cseRequired: d.cseRequired,
 				hasJointEvaluationFile: yearsWithJointEval.has(d.year),
 				hasPrefillData: yearsWithPrefill.has(d.year),
+				notSubject: false,
 			}));
 
 			if (representationRow) {
@@ -329,6 +331,7 @@ export const companyRouter = createTRPCRouter({
 					cseRequired: false,
 					hasJointEvaluationFile: false,
 					hasPrefillData: false,
+					notSubject: isRepresentationNotSubject(representationRow.status),
 				});
 			}
 

--- a/packages/app/src/server/rules/__tests__/fsmMirrors.conformance.test.ts
+++ b/packages/app/src/server/rules/__tests__/fsmMirrors.conformance.test.ts
@@ -57,6 +57,7 @@ function makeDeclaration(
 		cseRequired: false,
 		hasJointEvaluationFile: false,
 		hasPrefillData: false,
+		notSubject: false,
 		...overrides,
 	};
 }


### PR DESCRIPTION
Closes #4351

## Résumé

Une fois le statut `not_subject` enregistrable côté serveur (#4350), Mon espace reflète maintenant le résultat : ligne du tableau « Non-assujetti » / badge « Effectué », et variante dédiée du panneau latéral Représentation, conformes au Figma.

- Propagation du discriminant `notSubject: boolean` de `company.getWithDeclarations` jusqu'à `DeclarationItem` (`false` pour les lignes rémunération, `isRepresentationNotSubject(representationRow.status)` pour la ligne représentation).
- Ligne du tableau (node Figma `11820-169852`) : Étape « Non-assujetti », Échéance « - », badge « Effectué » (automatique via `status: "done"`), Ressources « Aucune » (aucun lien récépissé PDF).
- Panneau latéral (node Figma `11824-169912`), nouvelle variante `not_subject` : étape 1 seule validée (pas d'étape 2, pas d'échéance), message dédié sur fond bleu, sans alerte Rixain, CTA « Commencer » → `/declaration-representation` (réversibilité).
- Variantes existantes du panneau inchangées ; campagne close prime toujours sur non-assujetti.

## Captures d'écran

Ligne du tableau :

![Ligne du tableau — Représentation Non-assujetti](https://raw.githubusercontent.com/SocialGouv/egapro/071f17284d1b7a22c841f0fe6a55f64309fcdce7/ticket-4351/table-row.png)

Panneau latéral :

![Panneau latéral — variante not_subject](https://raw.githubusercontent.com/SocialGouv/egapro/071f17284d1b7a22c841f0fe6a55f64309fcdce7/ticket-4351/panel.png)

Données de test : « Société Démo » (SIREN fictif `123456789`), déclaration représentation `not_subject` pour l'année de référence 2025, sur environnement local (worktree dev server).

## Test plan

- [x] `pnpm typecheck` / `pnpm test` / `pnpm lint:check` / `pnpm format:check` verts
- [x] Scénarios T2-S1 (ligne du tableau) et T2-S2 (panneau latéral) vérifiés manuellement sur dev server + couverts par tests vitest
- [x] T2-S3 (réversibilité `draft`) et T2-S4 (campagne close prime) couverts par tests vitest (non-régression)
- [x] Fidélité Figma vérifiée par lecture structurelle des deux nodes (`11820-169852`, `11824-169912`) — vérification indépendante par `design-validator` à suivre
