### PR TITLE
fix(my-space): #4275 — adapte le panneau aux entreprises de moins de 50 salariés

### DIFF
--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -16,7 +16,6 @@ import {
 	setUserPhone,
 } from "./helpers/db";
 import { clickAndExpectDialogOpen, waitForDsfrModal } from "./helpers/dsfr";
-import { indicatorGRequiredForGip } from "./helpers/indicator-g";
 import { loginWithProConnect } from "./helpers/login";
 
 // Per-variant panel rendering is covered by my-space/__tests__/DeclarationProcessPanel.test.tsx.
@@ -120,16 +119,15 @@ test.describe("Declaration process panel", () => {
 		});
 	});
 
-	// Regression #3939: a GIP-derived < 100 company without CSE must never see the
+	// Regressions #3939 and #4275: a voluntary company without CSE must never see the
 	// "déposer l'avis CSE" step — neither during the démarche nor after completion (where
-	// the panel used to stay stuck on "avis CSE en cours" with a /avis-cse CTA). The
-	// indicator-G path step follows the same GIP workforce (79 here), not the WEEZ headcount
-	// or the has_cse flag, so it is hidden except on the tier's own indicator G years.
-	test.describe("GIP < 100 without CSE: the CSE step is hidden, the indicator-G step follows the obligation", () => {
+	// the panel used to stay stuck on "avis CSE en cours" with a /avis-cse CTA). Although
+	// voluntary declarations carry indicator G, their workforce keeps the compliance path
+	// inapplicable. Absence from the GIP file also means the indicators are not prefilled.
+	test.describe("voluntary company without CSE: compliance and CSE steps are hidden", () => {
 		const STEP2_TITLE =
 			"Parcours de mise en conformité pour l'indicateur par catégories de salariés";
 		const STEP3_TITLE = "Déposer le ou les avis du CSE";
-		const indicatorGRequired = indicatorGRequiredForGip(79);
 
 		test.afterAll(async () => {
 			await resetDeclarationToDraft();
@@ -149,13 +147,13 @@ test.describe("Declaration process panel", () => {
 		test.describe("during the démarche (draft)", () => {
 			test.beforeAll(async () => {
 				await ensureCurrentYearDeclaration();
-				await setGipWorkforce(79);
+				await setGipWorkforce(null);
 				await setCompanyHasCse(false);
 				await setUserPhone(TEST_USER_PHONE);
 				await resetDeclarationToDraft();
 			});
 
-			test("announces the declaration step, and the indicator-G step only when owed", async ({
+			test("announces manual indicators without compliance or CSE steps", async ({
 				page,
 			}) => {
 				await openPanel(page);
@@ -164,11 +162,10 @@ test.describe("Declaration process panel", () => {
 				await expect(
 					panel.getByText("Déclaration des indicateurs de rémunération"),
 				).toBeVisible();
-				if (indicatorGRequired) {
-					await expect(panel.getByText(STEP2_TITLE)).toBeVisible();
-				} else {
-					await expect(panel.getByText(STEP2_TITLE)).toHaveCount(0);
-				}
+				await expect(
+					panel.getByText("Indicateurs pour l'ensemble des salariés à remplir"),
+				).toBeVisible();
+				await expect(panel.getByText(STEP2_TITLE)).toHaveCount(0);
 				await expect(panel.getByText(STEP3_TITLE)).toHaveCount(0);
 			});
 		});
@@ -176,7 +173,7 @@ test.describe("Declaration process panel", () => {
 		test.describe("after completion (démarche_completed, not subject)", () => {
 			test.beforeAll(async () => {
 				await ensureCurrentYearDeclaration();
-				await setGipWorkforce(79);
+				await setGipWorkforce(null);
 				await setCompanyHasCse(false);
 				await setUserPhone(TEST_USER_PHONE);
 				await setDeclarationComplianceState({
@@ -202,6 +199,13 @@ test.describe("Declaration process panel", () => {
 					),
 				).toHaveCount(0);
 				await expect(panel.getByText(STEP3_TITLE)).toHaveCount(0);
+				await expect(panel.getByText(STEP2_TITLE)).toHaveCount(0);
+				await expect(
+					panel.getByText("Votre déclaration a été transmise"),
+				).toBeVisible();
+				await expect(
+					panel.getByTitle("Voir le récapitulatif de la déclaration"),
+				).toBeVisible();
 
 				const cta = panel.getByRole("link", { name: "Voir la déclaration" });
 				await expect(cta).toBeVisible();

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -72,6 +72,7 @@ export function CompanyDeclarationsPage({
 		obligationWorkforce,
 		currentYear,
 	);
+	const compliancePathApplicable = cseApplicable && indicatorGRequired;
 	const lastActionDate = getLastActionDate(declarations, currentYear);
 	const currentDeclaration = declarations.find(
 		(d) => d.type === "remuneration" && d.year === currentYear,
@@ -108,14 +109,15 @@ export function CompanyDeclarationsPage({
 			/>
 			<DeclarationProcessPanel
 				campaignDeadlines={campaignDeadlines}
+				compliancePathApplicable={compliancePathApplicable}
 				cseOpinionRequired={cseOpinionRequired}
 				ctaHref={ctaHref}
 				declarationFsmStatus={currentDeclaration?.fsmStatus ?? null}
 				displayContext={displayContext}
+				hasPrefillData={currentDeclaration?.hasPrefillData ?? false}
 				hasSubmittedSecondDeclaration={
 					currentDeclaration?.hasSubmittedSecondDeclaration ?? false
 				}
-				indicatorGRequired={indicatorGRequired}
 				lastActionDate={lastActionDate}
 				lockedByOther={lockedByOther}
 				lockHolder={lockHolder}

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -25,10 +25,11 @@ export type PanelVariant =
 
 type Props = {
 	campaignDeadlines: CampaignDeadlines;
+	compliancePathApplicable: boolean;
 	cseOpinionRequired: boolean;
 	declarationFsmStatus: DeclarationFsmStatus | null;
 	year: number;
-	indicatorGRequired: boolean;
+	hasPrefillData: boolean;
 	lastActionDate: string | null;
 	variant: PanelVariant;
 	displayContext: DeclarationDisplayContext;
@@ -41,10 +42,11 @@ type Props = {
 
 export function DeclarationProcessPanel({
 	campaignDeadlines,
+	compliancePathApplicable,
 	cseOpinionRequired,
 	declarationFsmStatus,
 	year,
-	indicatorGRequired,
+	hasPrefillData,
 	lastActionDate,
 	variant,
 	displayContext,
@@ -92,10 +94,11 @@ export function DeclarationProcessPanel({
 						)}
 						<VerticalStepper
 							campaignDeadlines={campaignDeadlines}
+							compliancePathApplicable={compliancePathApplicable}
 							cseOpinionRequired={cseOpinionRequired}
 							declarationFsmStatus={declarationFsmStatus}
 							displayContext={displayContext}
-							indicatorGRequired={indicatorGRequired}
+							hasPrefillData={hasPrefillData}
 							secondDeclarationSubmitted={hasSubmittedSecondDeclaration}
 							siren={siren}
 							step1={step1}

--- a/packages/app/src/modules/my-space/PanelPlayground.tsx
+++ b/packages/app/src/modules/my-space/PanelPlayground.tsx
@@ -67,7 +67,9 @@ export function PanelPlayground() {
 	const [secondDeclarationSubmitted, setSecondDeclarationSubmitted] =
 		useState(true);
 	const [cseOpinionRequired, setCseOpinionRequired] = useState(true);
-	const [indicatorGRequired, setIndicatorGRequired] = useState(true);
+	const [compliancePathApplicable, setCompliancePathApplicable] =
+		useState(true);
+	const [hasPrefillData, setHasPrefillData] = useState(true);
 	const [preset, setPreset] = useState<DatePreset>("future");
 	const [deadlines, setDeadlines] = useState<CampaignDeadlines>(
 		buildPresetDeadlines("future"),
@@ -163,13 +165,27 @@ export function PanelPlayground() {
 
 					<div className="fr-checkbox-group">
 						<input
-							checked={indicatorGRequired}
-							id="indicator-g-required"
-							onChange={(e) => setIndicatorGRequired(e.currentTarget.checked)}
+							checked={compliancePathApplicable}
+							id="compliance-path-applicable"
+							onChange={(e) =>
+								setCompliancePathApplicable(e.currentTarget.checked)
+							}
 							type="checkbox"
 						/>
-						<label className="fr-label" htmlFor="indicator-g-required">
-							Indicateur G requis (étape 2 visible)
+						<label className="fr-label" htmlFor="compliance-path-applicable">
+							Parcours de conformité applicable (étape 2 visible)
+						</label>
+					</div>
+
+					<div className="fr-checkbox-group">
+						<input
+							checked={hasPrefillData}
+							id="has-prefill-data"
+							onChange={(e) => setHasPrefillData(e.currentTarget.checked)}
+							type="checkbox"
+						/>
+						<label className="fr-label" htmlFor="has-prefill-data">
+							Données préremplies disponibles
 						</label>
 					</div>
 
@@ -263,6 +279,7 @@ export function PanelPlayground() {
 
 			<DeclarationProcessPanel
 				campaignDeadlines={deadlines}
+				compliancePathApplicable={compliancePathApplicable}
 				cseOpinionRequired={cseOpinionRequired}
 				ctaHref="/declaration-remuneration?siren=000000000"
 				declarationFsmStatus={VARIANT_FSM_STATUS[variant]}
@@ -271,8 +288,8 @@ export function PanelPlayground() {
 					secondDeclarationPathChoice: null,
 					cseRequired: cseOpinionRequired,
 				})}
+				hasPrefillData={hasPrefillData}
 				hasSubmittedSecondDeclaration={secondDeclarationSubmitted}
-				indicatorGRequired={indicatorGRequired}
 				lastActionDate="12 mars 2026"
 				lockedByOther={false}
 				lockHolder={null}

--- a/packages/app/src/modules/my-space/StepContent.tsx
+++ b/packages/app/src/modules/my-space/StepContent.tsx
@@ -56,12 +56,14 @@ function BulletRow({ children }: { children: ReactNode }) {
 
 export function Step1Content({
 	campaignDeadlines,
+	hasPrefillData,
 	siren,
 	status,
 	variant,
 	year,
 }: {
 	campaignDeadlines: CampaignDeadlines;
+	hasPrefillData: boolean;
 	siren: string;
 	status: StepStatus;
 	variant: PanelVariant;
@@ -84,8 +86,9 @@ export function Step1Content({
 					</p>
 				</div>
 				<BulletRow>
-					Indicateurs pré-remplis à vérifier et à modifier si nécessaire (issus
-					des données DSN)
+					{hasPrefillData
+						? "Indicateurs pré-remplis à vérifier et à modifier si nécessaire (issus des données DSN)"
+						: "Indicateurs pour l'ensemble des salariés à remplir"}
 				</BulletRow>
 				<BulletRow>
 					Indicateurs de rémunération par catégories de salariés à remplir

--- a/packages/app/src/modules/my-space/VerticalStepper.tsx
+++ b/packages/app/src/modules/my-space/VerticalStepper.tsx
@@ -27,10 +27,11 @@ export function getStepStatuses(
 
 export function VerticalStepper({
 	campaignDeadlines,
+	compliancePathApplicable,
 	cseOpinionRequired,
 	declarationFsmStatus,
 	displayContext,
-	indicatorGRequired,
+	hasPrefillData,
 	secondDeclarationSubmitted,
 	siren,
 	step1,
@@ -40,10 +41,11 @@ export function VerticalStepper({
 	year,
 }: {
 	campaignDeadlines: CampaignDeadlines;
+	compliancePathApplicable: boolean;
 	cseOpinionRequired: boolean;
 	declarationFsmStatus: DeclarationFsmStatus | null;
 	displayContext: DeclarationDisplayContext;
-	indicatorGRequired: boolean;
+	hasPrefillData: boolean;
 	secondDeclarationSubmitted: boolean;
 	siren: string;
 	step1: StepStatus;
@@ -52,7 +54,7 @@ export function VerticalStepper({
 	variant: PanelVariant;
 	year: number;
 }) {
-	const step3Number = indicatorGRequired ? 3 : 2;
+	const step3Number = compliancePathApplicable ? 3 : 2;
 
 	return (
 		<div className={`${styles.stepper} fr-mb-4w`}>
@@ -60,13 +62,14 @@ export function VerticalStepper({
 				<StepCircle number={1} status={step1} />
 				<Step1Content
 					campaignDeadlines={campaignDeadlines}
+					hasPrefillData={hasPrefillData}
 					siren={siren}
 					status={step1}
 					variant={variant}
 					year={year}
 				/>
 			</div>
-			{indicatorGRequired && (
+			{compliancePathApplicable && (
 				<div className={`${styles.stepRow} ${stepRowClass(step2)}`}>
 					<StepCircle number={2} status={step2} />
 					<Step2Content

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -115,6 +115,41 @@ describe("CompanyDeclarationsPage", () => {
 		).toBeInTheDocument();
 	});
 
+	it("shows manual indicators and hides compliance for a voluntary company", () => {
+		renderPage();
+		expect(
+			screen.getByText("Indicateurs pour l'ensemble des salariés à remplir"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/Parcours de mise en conformité/),
+		).not.toBeInTheDocument();
+	});
+
+	it("keeps the transmitted recap visible without compliance after voluntary completion", () => {
+		renderPage({
+			declarations: [
+				makeDeclaration("remuneration", {
+					status: "done",
+					fsmStatus: "demarche_completed",
+				}),
+				makeDeclaration("representation"),
+			],
+		});
+
+		expect(
+			screen.getByText("Votre déclaration a été transmise"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByTitle("Voir le récapitulatif de la déclaration"),
+		).toHaveAttribute(
+			"href",
+			"/declaration-remuneration/recapitulatif?siren=532847196",
+		);
+		expect(
+			screen.queryByText(/Parcours de mise en conformité/),
+		).not.toBeInTheDocument();
+	});
+
 	it("hides the 'Archives' section while archives are unavailable", () => {
 		renderPage();
 		expect(

--- a/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
@@ -47,9 +47,10 @@ type LockHolder = {
 
 const BASE_PROPS = {
 	campaignDeadlines: getDefaultCampaignDeadlines(FUTURE_YEAR),
+	compliancePathApplicable: true,
 	cseOpinionRequired: true,
 	year: FUTURE_YEAR,
-	indicatorGRequired: true,
+	hasPrefillData: true,
 	lastActionDate: "12 mars 2026" as string | null,
 	declarationFsmStatus: null,
 	displayContext: makeDisplayContext(),
@@ -120,6 +121,16 @@ describe("DeclarationProcessPanel", () => {
 					/Indicateurs de rémunération par catégories de salariés à remplir/,
 				),
 			).toBeInTheDocument();
+		});
+
+		it("describes indicators as manual when no prefill data is available", () => {
+			const { panel } = renderPanel("start", { hasPrefillData: false });
+			expect(
+				panel.getByText("Indicateurs pour l'ensemble des salariés à remplir"),
+			).toBeInTheDocument();
+			expect(
+				panel.queryByText(/Indicateurs pré-remplis à vérifier/),
+			).not.toBeInTheDocument();
 		});
 
 		it("renders the CTA link with correct href", () => {

--- a/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
@@ -58,9 +58,10 @@ const RECAP_VIEW = 'a[title="Voir le récapitulatif de la déclaration"]';
 
 const BASE_PROPS = {
 	campaignDeadlines: getDefaultCampaignDeadlines(FUTURE_YEAR),
+	compliancePathApplicable: true,
 	cseOpinionRequired: true,
 	year: FUTURE_YEAR,
-	indicatorGRequired: true,
+	hasPrefillData: true,
 	lastActionDate: null as string | null,
 	displayContext: makeDisplayContext(),
 	hasSubmittedSecondDeclaration: false,
@@ -384,15 +385,17 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 		const STEP3_TITLE = "Déposer le ou les avis du CSE";
 		const STEP1_TITLE = "Déclaration des indicateurs de rémunération";
 
-		it("renders steps 2 and 3 when both indicatorGRequired and cseOpinionRequired are true", () => {
+		it("renders steps 2 and 3 when both compliancePathApplicable and cseOpinionRequired are true", () => {
 			const { panel } = renderPanel("start");
 			expect(panel.getByText(STEP1_TITLE)).toBeInTheDocument();
 			expect(panel.getByText(STEP2_TITLE)).toBeInTheDocument();
 			expect(panel.getByText(STEP3_TITLE)).toBeInTheDocument();
 		});
 
-		it("hides step 2 when indicatorGRequired is false", () => {
-			const { panel } = renderPanel("start", { indicatorGRequired: false });
+		it("hides step 2 when compliancePathApplicable is false", () => {
+			const { panel } = renderPanel("start", {
+				compliancePathApplicable: false,
+			});
 			expect(panel.getByText(STEP1_TITLE)).toBeInTheDocument();
 			expect(panel.queryByText(STEP2_TITLE)).not.toBeInTheDocument();
 			expect(panel.getByText(STEP3_TITLE)).toBeInTheDocument();
@@ -405,10 +408,10 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 			expect(panel.queryByText(STEP3_TITLE)).not.toBeInTheDocument();
 		});
 
-		it("hides both steps 2 and 3 for a company without CSE and without indicator G", () => {
+		it("hides both steps 2 and 3 when neither compliance nor a CSE opinion applies", () => {
 			const { panel } = renderPanel("start", {
 				cseOpinionRequired: false,
-				indicatorGRequired: false,
+				compliancePathApplicable: false,
 			});
 			expect(panel.getByText(STEP1_TITLE)).toBeInTheDocument();
 			expect(panel.queryByText(STEP2_TITLE)).not.toBeInTheDocument();
@@ -430,8 +433,10 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 			expect(stepNumbers(dialog)).toEqual(["1", "2", "3"]);
 		});
 
-		it("renumbers the CSE step to 2 when step 2 (indicator G) is hidden", () => {
-			const { dialog } = renderPanel("start", { indicatorGRequired: false });
+		it("renumbers the CSE step to 2 when the compliance step is hidden", () => {
+			const { dialog } = renderPanel("start", {
+				compliancePathApplicable: false,
+			});
 			expect(stepNumbers(dialog)).toEqual(["1", "2"]);
 		});
 
@@ -443,7 +448,7 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 		it("only shows step 1 when both steps 2 and 3 are hidden", () => {
 			const { dialog } = renderPanel("start", {
 				cseOpinionRequired: false,
-				indicatorGRequired: false,
+				compliancePathApplicable: false,
 			});
 			expect(stepNumbers(dialog)).toEqual(["1"]);
 		});


### PR DESCRIPTION
## Résumé

- distingue l'applicabilité du parcours de conformité de l'obligation de renseigner l'indicateur G
- masque le parcours de conformité pour les entreprises de moins de 100 salariés, notamment les déclarations volontaires de moins de 50 salariés
- adapte le texte du panneau selon la présence effective de données préremplies
- conserve le message de transmission et l'accès au récapitulatif après finalisation
- complète les couvertures Vitest et Playwright du panneau

## Vérifications

- `pnpm --filter app test` — 451 fichiers, 5 586 tests
- `pnpm --filter app run typecheck`
- `pnpm --filter app run lint:check`
- `pnpm --filter app run format:check`

Closes #4275
