### PR TITLE
chore(deps): bump SonarSource/sonarqube-scan-action from 4 to 8 (#4265)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,7 +179,7 @@ jobs:
       - name: Test app with coverage
         run: pnpm test:app:coverage
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
+++ b/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
@@ -18,10 +18,12 @@ metadata:
 ---
 # Bind the built-in namespaced `view` ClusterRole instead of a Role created in
 # the same apply: SSA of RoleBinding otherwise 404s on the Role (API cache).
+# New name: roleRef is immutable, leftover RoleBindings from failed review
+# deploys cannot be patched from Role/gip-mds-import to ClusterRole/view.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: gip-mds-import
+  name: gip-mds-import-view
   namespace: {{ .Values.global.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
+++ b/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
@@ -8,32 +8,16 @@
 # check is not enough — the old pods answer it too. The init container below
 # gates the import on `kubectl rollout status`, which only returns once the
 # new ReplicaSet is fully ready and the old one is scaled down. The
-# ServiceAccount/Role/RoleBinding grant the read-only access this watch
-# requires, scoped to the single `app` Deployment.
+# ServiceAccount + RoleBinding (`view` ClusterRole, namespace-scoped) grant
+# the read-only access this watch requires.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gip-mds-import
   namespace: {{ .Values.global.namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gip-mds-import
-  namespace: {{ .Values.global.namespace }}
-rules:
-  # `get` can be scoped to the deployment name, but `list`/`watch` cannot:
-  # RBAC resourceNames never match collection requests, and `kubectl rollout
-  # status` sets up its watch through list+watch on the deployments
-  # collection (with a fieldSelector). The rule stays namespace-scoped.
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    resourceNames: ["app"]
-    verbs: ["get"]
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    verbs: ["list", "watch"]
----
+# Bind the built-in namespaced `view` ClusterRole instead of a Role created in
+# the same apply: SSA of RoleBinding otherwise 404s on the Role (API cache).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -41,8 +25,8 @@ metadata:
   namespace: {{ .Values.global.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: gip-mds-import
+  kind: ClusterRole
+  name: view
 subjects:
   - kind: ServiceAccount
     name: gip-mds-import

--- a/.kontinuous/templates/apisix-suit.yaml
+++ b/.kontinuous/templates/apisix-suit.yaml
@@ -59,6 +59,36 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
       initContainers:
+        # Sealed-secret `suit` is applied in the same wave as this Deployment;
+        # kubelet then races the controller (rollout watcher gives up in ~7s).
+        # An optional volume lets this init start, then we block until the key
+        # is projected so the main container's required envFrom does not 404.
+        - name: wait-suit-secret
+          image: apache/apisix:3.11.0-debian
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "waiting for secret/suit to be projected..."
+              for i in $(seq 1 90); do
+                if [ -s /var/run/suit/EGAPRO_SUIT_API_KEY ]; then
+                  echo "secret/suit is available"
+                  exit 0
+                fi
+                sleep 2
+              done
+              echo "timeout waiting for secret/suit" >&2
+              exit 1
+          volumeMounts:
+            - name: suit-secret
+              mountPath: /var/run/suit
+              readOnly: true
         - name: seed-conf
           image: apache/apisix:3.11.0-debian
           imagePullPolicy: IfNotPresent
@@ -173,6 +203,10 @@ spec:
         - name: config
           configMap:
             name: apisix-suit-config
+        - name: suit-secret
+          secret:
+            secretName: suit
+            optional: true
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Related to #4265

Reprend la PR Dependabot #4081.

Branche rebasée sur `alpha` pour relancer la CI (review apps auto, ticket #4264).