### PR TITLE
chore(deps): bump pnpm/action-setup from 4 to 6 (#4265)

### DIFF
--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -288,7 +288,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -72,7 +72,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -92,7 +92,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -110,7 +110,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -128,7 +128,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -146,7 +146,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -168,7 +168,7 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for better SonarCloud analysis
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -190,7 +190,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/db-schema.yaml
+++ b/.github/workflows/db-schema.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/e2e-grille.yaml
+++ b/.github/workflows/e2e-grille.yaml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lighthouse.yaml
+++ b/.github/workflows/lighthouse.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.deployment.ref }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/preproduction.yaml
+++ b/.github/workflows/preproduction.yaml
@@ -73,7 +73,7 @@ jobs:
     needs: [kontinuous]
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/release-alpha.yaml
+++ b/.github/workflows/release-alpha.yaml
@@ -55,7 +55,7 @@ jobs:
           audience: socialgouv
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           audience: socialgouv
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Related to #4265

Reprend la PR Dependabot #4080.

Branche rebasée sur `alpha` pour relancer la CI (review apps auto, ticket #4264).