### PR TITLE
chore(deps): bump actions/checkout from 4 to 7 (#4265)

### DIFF
--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: ultra11y — audit RGAA statique
@@ -287,7 +287,7 @@ jobs:
       MAILDEV_URL: http://localhost:1080
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
       - name: Set up Node
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
       - name: Set up Node
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
       - name: Set up Node
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
       - name: Set up Node
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
       - name: Set up Node
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
       - name: Set up Node
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
       - name: Set up Node
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
       - name: Set up Node
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Shallow clones should be disabled for better SonarCloud analysis
       - name: Set up pnpm
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
       - name: Set up Node
@@ -208,6 +208,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Run release scripts tests
         run: bash scripts/release/release-scripts.test.sh

--- a/.github/workflows/claude-question.yml
+++ b/.github/workflows/claude-question.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/db-schema.yaml
+++ b/.github/workflows/db-schema.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6
 

--- a/.github/workflows/e2e-grille.yaml
+++ b/.github/workflows/e2e-grille.yaml
@@ -76,7 +76,7 @@ jobs:
       MAILDEV_URL: http://localhost:1080
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,7 +49,7 @@ jobs:
       MAILDEV_URL: http://localhost:1080
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/lighthouse.yaml
+++ b/.github/workflows/lighthouse.yaml
@@ -15,7 +15,7 @@ jobs:
       !startsWith(github.event.deployment.environment, 'build-')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.deployment.ref }}
       - uses: pnpm/action-setup@v6

--- a/.github/workflows/preproduction.yaml
+++ b/.github/workflows/preproduction.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⏬ Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 📌 Extract metadata (tags, labels) for Docker
         id: meta
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [kontinuous]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⏬ Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 📌 Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/promote-test-env.yaml
+++ b/.github/workflows/promote-test-env.yaml
@@ -39,7 +39,7 @@ jobs:
       contents: read
     steps:
       - name: ⏬ Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -81,7 +81,7 @@ jobs:
       id-token: write # OIDC identity for buildkit-operator /route auth
     steps:
       - name: ⏬ Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ inputs.release }}
 
@@ -142,7 +142,7 @@ jobs:
       # The manifests deployed must be the ones of the promoted version, so
       # the checkout is done on the release tag, not on the workflow ref.
       - name: ⏬ Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ inputs.release }}
           fetch-depth: 0

--- a/.github/workflows/release-alpha.yaml
+++ b/.github/workflows/release-alpha.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/review-auto.yaml
+++ b/.github/workflows/review-auto.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⏬ Checkout code repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # The footer exposes a direct link to the PR on review apps. Review builds
       # trigger on `push` (not `pull_request`), so the PR number is not in the

--- a/.github/workflows/sync-docs-to-wiki.yaml
+++ b/.github/workflows/sync-docs-to-wiki.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Clone wiki
         env:

--- a/.github/workflows/ticket-end-date.yaml
+++ b/.github/workflows/ticket-end-date.yaml
@@ -80,7 +80,7 @@ jobs:
           permissions: '{"issues":"read","organization_projects":"write"}'
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Stamp End date
         env:


### PR DESCRIPTION
Related to #4265

Reprend la PR Dependabot #4078.

Branche rebasée sur `alpha` pour relancer la CI (review apps auto, ticket #4264).