### PR TITLE
chore(deps): bump next-auth from 4.24.13 to 4.24.15 in /packages/app (#4265)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -69,7 +69,7 @@
 		"echarts-for-react": "^3.0.6",
 		"exceljs": "^4.4.0",
 		"next": "^16.2.3",
-		"next-auth": "4.24.13",
+		"next-auth": "4.24.15",
 		"notifications": "workspace:*",
 		"postgres": "^3.4.9",
 		"react": "^19.2.5",


### PR DESCRIPTION
Related to #4265

Reprend la PR Dependabot #4004.

Branche rebasée sur `alpha` pour relancer la CI (review apps auto, ticket #4264).