### PR TITLE
fix(ci): courses Kubernetes sur le déploiement des review apps (#4265)

### DIFF
--- a/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
+++ b/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
@@ -18,10 +18,12 @@ metadata:
 ---
 # Bind the built-in namespaced `view` ClusterRole instead of a Role created in
 # the same apply: SSA of RoleBinding otherwise 404s on the Role (API cache).
+# New name: roleRef is immutable, leftover RoleBindings from failed review
+# deploys cannot be patched from Role/gip-mds-import to ClusterRole/view.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: gip-mds-import
+  name: gip-mds-import-view
   namespace: {{ .Values.global.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
+++ b/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
@@ -8,32 +8,16 @@
 # check is not enough — the old pods answer it too. The init container below
 # gates the import on `kubectl rollout status`, which only returns once the
 # new ReplicaSet is fully ready and the old one is scaled down. The
-# ServiceAccount/Role/RoleBinding grant the read-only access this watch
-# requires, scoped to the single `app` Deployment.
+# ServiceAccount + RoleBinding (`view` ClusterRole, namespace-scoped) grant
+# the read-only access this watch requires.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gip-mds-import
   namespace: {{ .Values.global.namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: gip-mds-import
-  namespace: {{ .Values.global.namespace }}
-rules:
-  # `get` can be scoped to the deployment name, but `list`/`watch` cannot:
-  # RBAC resourceNames never match collection requests, and `kubectl rollout
-  # status` sets up its watch through list+watch on the deployments
-  # collection (with a fieldSelector). The rule stays namespace-scoped.
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    resourceNames: ["app"]
-    verbs: ["get"]
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    verbs: ["list", "watch"]
----
+# Bind the built-in namespaced `view` ClusterRole instead of a Role created in
+# the same apply: SSA of RoleBinding otherwise 404s on the Role (API cache).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -41,8 +25,8 @@ metadata:
   namespace: {{ .Values.global.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: gip-mds-import
+  kind: ClusterRole
+  name: view
 subjects:
   - kind: ServiceAccount
     name: gip-mds-import

--- a/.kontinuous/templates/apisix-suit.yaml
+++ b/.kontinuous/templates/apisix-suit.yaml
@@ -59,6 +59,36 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
       initContainers:
+        # Sealed-secret `suit` is applied in the same wave as this Deployment;
+        # kubelet then races the controller (rollout watcher gives up in ~7s).
+        # An optional volume lets this init start, then we block until the key
+        # is projected so the main container's required envFrom does not 404.
+        - name: wait-suit-secret
+          image: apache/apisix:3.11.0-debian
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              echo "waiting for secret/suit to be projected..."
+              for i in $(seq 1 90); do
+                if [ -s /var/run/suit/EGAPRO_SUIT_API_KEY ]; then
+                  echo "secret/suit is available"
+                  exit 0
+                fi
+                sleep 2
+              done
+              echo "timeout waiting for secret/suit" >&2
+              exit 1
+          volumeMounts:
+            - name: suit-secret
+              mountPath: /var/run/suit
+              readOnly: true
         - name: seed-conf
           image: apache/apisix:3.11.0-debian
           imagePullPolicy: IfNotPresent
@@ -173,6 +203,10 @@ spec:
         - name: config
           configMap:
             name: apisix-suit-config
+        - name: suit-secret
+          secret:
+            secretName: suit
+            optional: true
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Related to #4265

## Contexte

Ce n’est **pas** un bump Dependabot et ça ne change rien au bot ni aux lockfiles.

Pendant le traitement des PRs Dependabot du ticket #4265, chaque branche a déclenché une **review app**. En en déployant plusieurs en parallèle, deux courses Kubernetes déjà présentes dans les manifests review (`dev`) sont devenues visibles. Les bumps eux-mêmes n’étaient pas en cause : la CI applicative (typecheck, tests, build, e2e) passait, seul le job **Deploy Review** tombait.

Les mêmes pannes peuvent arriver sur n’importe quelle PR qui déploie une review app.

Symptômes constatés :

- `CreateContainerConfigError: secret "suit" not found` sur le Deployment APISIX (`apisix-suit`)
- `Role "gip-mds-import" not found` puis, sur un namespace déjà déployé, `cannot change roleRef` (immuable)

## Changements

- **APISIX** (`apisix-suit.yaml`) : init `wait-suit-secret`. Le sealed-secret `suit` est appliqué dans la même vague que le Deployment ; le watcher de rollout abandonne en ~7 s si le Secret n’est pas encore projeté. Un volume optionnel permet à l’init de démarrer, puis on attend la clé avant le conteneur principal (envFrom toujours obligatoire).
- **Job gip-mds-import (env `dev`)** : le RoleBinding cible le ClusterRole `view` (déjà présent sur le cluster) au lieu d’un Role créé dans le même apply. Le binding est **renommé** `gip-mds-import-view` parce que `roleRef` est immuable : on ne peut pas retargeter un RoleBinding existant.

## Déjà sur `alpha`

Le correctif a été cherry-pické dans #4371 (mergée). Cette PR est donc **redondante** avec `alpha` actuel. Elle documente le fix ; la fermer sans merger est le geste attendu si on ne veut pas rejouer le diff.

## Critères

- [x] Review apps #4369 / #4371 / #4383 vertes après cherry-pick
- [x] Les review apps déjà vertes restent déployables