### PR TITLE
chore(agents): #4318 — architect sur opus, code-dev et e2e-dev en effort high

### DIFF
--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Architecte technique : lit le codebase et produit des specs exécutables (modes epic-create / epic-enrich / task).
-model: fable
+model: opus
 effort: xhigh
 ---
 
@@ -11,7 +11,7 @@ You are the technical architect for the egapro project. You read the codebase an
 
 ## Model & Tools
 
-- **Model:** fable (architectural decisions)
+- **Model:** opus (architectural decisions)
 - **Effort:** `xhigh` (frontmatter) — le spec qu'il produit est exécuté par un tiers : un même ticket analysé deux fois doit recevoir le même niveau de raisonnement.
 - **Tools:** Bash (gh CLI), Read, Grep, Glob, figma MCP (read-only — never modify code)
 

--- a/.claude/agents/code-dev/AGENT.md
+++ b/.claude/agents/code-dev/AGENT.md
@@ -10,14 +10,14 @@ You execute one pre-specified ticket end-to-end : edit code, write its vitest te
 > **L'absence de `model:` ET de `effort:` dans le frontmatter est délibérée — ne pas la « réparer ».** `code-dev` est le seul agent dont ces deux valeurs ne sont pas une propriété de l'agent mais un réglage du run.
 >
 > - **`model:`** — il varie par ticket : l'orchestrateur le passe toujours par `--model` (sonnet par défaut, opus si le ticket porte le label `complexe`, cf. `dispatch_plan.sh`). Le poser ici figerait ce choix.
-> - **`effort:`** — `code-dev` est **le poste de dépense de toute la pipeline** : seul agent invoqué une fois par ticket (donc N fois par epic), sur la session la plus longue (timeout 90 min, budget $10–20 chacune). Les treize autres tournent une fois par epic ou par bug sur des sessions courtes : y pinner un effort ne coûte rien, et le rend lisible. Ici, ça déciderait de la facture depuis un fichier que personne n'ouvre en lançant un epic. L'effort reste donc **hérité**, comme il l'a toujours été — c'est un réglage de run, à faire à l'invocation le jour où on veut le fixer.
+> - **`effort:`** — `code-dev` est **le poste de dépense de toute la pipeline** : seul agent invoqué une fois par ticket (donc N fois par epic), sur la session la plus longue (timeout 90 min, budget $10–20 chacune). Les treize autres tournent une fois par epic ou par bug sur des sessions courtes : y pinner un effort ne coûte rien, et le rend lisible. Ici, ça déciderait de la facture depuis un fichier que personne n'ouvre en lançant un epic. L'effort est donc **passé à l'invocation** — `--effort high` par défaut, dans `epic_loop.sh` (surchargeable par `EPIC_LOOP_EFFORT_CODE_DEV`) comme dans le CLI foreground de `/implement`, là où on voit ce qu'on dépense.
 >
-> Corollaire : **ne jamais invoquer `code-dev` via l'outil Agent** — sans `--model`, il hériterait silencieusement du modèle de la session appelante. Il se lance en process CLI (`claude --agent code-dev --model <x> [--effort <e>]`), ce qui est de toute façon obligatoire puisqu'il spawne lui-même des sous-agents.
+> Corollaire : **ne jamais invoquer `code-dev` via l'outil Agent** — sans `--model`, il hériterait silencieusement du modèle de la session appelante. Il se lance en process CLI (`claude --agent code-dev --model <x> --effort <e>`), ce qui est de toute façon obligatoire puisqu'il spawne lui-même des sous-agents.
 
 ## Model & Tools
 
 - **Model:** sonnet par défaut, **opus si le ticket a le label `complexe`** — passé par `--model` à l'invocation, jamais par le frontmatter (voir l'encadré ci-dessus).
-- **Effort:** **hérité** — jamais posé en frontmatter, jamais passé en `--effort` par l'orchestrateur (voir l'encadré ci-dessus). C'est le seul agent dans ce cas.
+- **Effort:** `high` — passé par `--effort` à l'invocation, jamais posé en frontmatter (voir l'encadré ci-dessus). C'est le seul agent dans ce cas.
 - **Tools:** all (Bash, Read, Write, Edit, Grep, Glob, Playwright, next-devtools, dsfr)
 
 ## Inputs

--- a/.claude/agents/e2e-dev/AGENT.md
+++ b/.claude/agents/e2e-dev/AGENT.md
@@ -2,7 +2,7 @@
 name: e2e-dev
 description: Écrit/maintient tous les tests E2E Playwright (src/e2e/) en fin de pipeline — après dev terminé et sous-tickets mergés (Feature) ou après code-dev (Task/Bug). Lance la suite E2E actuelle, trie les échecs (régression vs évolution légitime), puis crée ou imbrique un scénario E2E pour la nouvelle fonctionnalité.
 model: opus
-effort: xhigh
+effort: high
 ---
 
 # E2E-dev Agent
@@ -17,7 +17,7 @@ Tu es invoqué à deux moments selon le type de ticket :
 ## Model & Tools
 
 - **Model:** opus (toujours — fixé en frontmatter). Le triage régression vs évolution légitime et le jugement « ce comportement mérite-t-il un E2E ? » sont des décisions à fort enjeu.
-- **Effort:** `xhigh` (fixé en frontmatter).
+- **Effort:** `high` (fixé en frontmatter).
 - **Tools:** Bash (gh CLI, runners `pnpm`, lifecycle du dev server), Read, Write, Edit, Grep, Glob, Playwright, next-devtools — tes seuls writes portent sur des fichiers `src/e2e/**`.
 
 ## Inputs

--- a/.claude/skills/analyse/SKILL.md
+++ b/.claude/skills/analyse/SKILL.md
@@ -9,8 +9,8 @@ description: "Conception pipeline. Détecte le mode (epic/task/bug) selon le typ
 
 | Mode | Trigger | Agents invoqués | Sortie |
 |---|---|---|---|
-| **epic** | Issue type `Feature`, ou prompt « nouvelle feature », « parcours », « ajouter une page X » | `product-owner` (Opus) → `architect` (Fable) | Epic GitHub avec N sous-issues |
-| **task** | Issue type `Task`, ou prompt « refactor », « migrer », « ajouter un champ X » sans contexte feature | `architect` mode task (Fable) | Commentaire `## Analyse architecte` posté sur la task |
+| **epic** | Issue type `Feature`, ou prompt « nouvelle feature », « parcours », « ajouter une page X » | `product-owner` (Opus) → `architect` (Opus) | Epic GitHub avec N sous-issues |
+| **task** | Issue type `Task`, ou prompt « refactor », « migrer », « ajouter un champ X » sans contexte feature | `architect` mode task (Opus) | Commentaire `## Analyse architecte` posté sur la task |
 | **bug** | Issue type `Bug`, ou prompt « bug », « cassé », « ne marche pas », « écart figma », « régression » | `bug-analyst` (Opus) | Commentaire `## Analyse du bug` posté sur le bug |
 
 Chaque agent gère lui-même un gate de validation utilisateur explicite avant de poster sur GitHub. L'orchestrateur (toi qui exécutes ce skill) chaîne et ne ré-interroge pas l'utilisateur entre étapes.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -171,7 +171,7 @@ Pour un single ticket (Task, Bug, ou sub-issue d'epic dispatchée manuellement),
    MODEL=$(gh issue view "$ISSUE_N" --json labels --jq '.labels[].name' | grep -qx complexe && echo opus || echo sonnet)
    BUDGET=$([ "$MODEL" = opus ] && echo 20 || echo 10)
    env -u CLAUDECODE timeout 5400 claude \
-     --agent code-dev --model "$MODEL" \
+     --agent code-dev --model "$MODEL" --effort high \
      --print --output-format stream-json --verbose \
      --dangerously-skip-permissions --max-budget-usd "$BUDGET" \
      "$PROMPT" 2>&1 | tee "/tmp/code-dev-${ISSUE_N}.jsonl"
@@ -186,7 +186,7 @@ Pour un single ticket (Task, Bug, ou sub-issue d'epic dispatchée manuellement),
    | `.status` | Action skill | Markdown affiché |
    |---|---|---|
    | `validated` | enchaîner sur **e2e-dev** (étape 5bis) ; le ticket reste In progress, l'utilisateur le bouge à In review à son rythme | `## Code: PASS` + ticket/branche/PR, puis le verdict E2E |
-   | `needs_opus_escalation` | relancer immédiatement le **CLI `code-dev`** avec `--model opus` et le même `$PROMPT` ; si le retour Opus est `validated`, enchaîner sur e2e-dev (étape 5bis) | `## Code: PASS` ou `## Code: REFACTO` selon le retour Opus |
+   | `needs_opus_escalation` | relancer immédiatement le **CLI `code-dev`** avec `--model opus --effort high` et le même `$PROMPT` ; si le retour Opus est `validated`, enchaîner sur e2e-dev (étape 5bis) | `## Code: PASS` ou `## Code: REFACTO` selon le retour Opus |
    | `refacto` | aucune (le ticket est en To Do) ; pas d'e2e-dev | `## Code: REFACTO` + diagnostic + next-step `/analyse <N>` (re-spec) |
    | `rate_limited` | proposer de retenter dans `retry_in` secondes ou abandonner | `## Code: RATE_LIMITED` + délai suggéré |
    | `failed` | propager l'erreur sans modifier le ticket ; pas d'e2e-dev | `## Code: FAILED` + raison technique |
@@ -195,7 +195,7 @@ Pour un single ticket (Task, Bug, ou sub-issue d'epic dispatchée manuellement),
 
    ```bash
    env -u CLAUDECODE timeout 3600 claude \
-     --agent e2e-dev --model opus --effort xhigh \
+     --agent e2e-dev --model opus --effort high \
      --print --output-format json \
      --dangerously-skip-permissions --max-budget-usd 15 \
      "$E2E_PROMPT" 2>&1 | tee "/tmp/e2e-dev-${ISSUE_N}.json"
@@ -211,7 +211,7 @@ Pour un single ticket (Task, Bug, ou sub-issue d'epic dispatchée manuellement),
      | `rate_limited` | proposer de retenter ou de lancer `e2e-dev` plus tard | `## E2E: RATE_LIMITED` + délai |
      | `failed` | noter l'échec technique (dev server / infra), proposer de relancer | `## E2E: FAILED` + raison |
 
-   - **Sur `regression`** : lancer `architect-rework` exactement comme `e2e-dev` (CLI foreground, `claude --agent architect-rework --model opus --effort xhigh`), en lui passant le ticket et la base de comparaison. Il lit le commentaire `e2e-dev:`, crée des tickets Task de fix (To Do) ou pose une question à l'utilisateur (`needs_user`). Comme on est en foreground (utilisateur présent), afficher le verdict et la **next-step** (`/implement <ticket-de-fix>`), plutôt que de relancer l'orchestrateur automatiquement.
+   - **Sur `regression`** : lancer `architect-rework` de la même façon que `e2e-dev` (CLI foreground, `claude --agent architect-rework --model opus --effort xhigh`), en lui passant le ticket et la base de comparaison. Il lit le commentaire `e2e-dev:`, crée des tickets Task de fix (To Do) ou pose une question à l'utilisateur (`needs_user`). Comme on est en foreground (utilisateur présent), afficher le verdict et la **next-step** (`/implement <ticket-de-fix>`), plutôt que de relancer l'orchestrateur automatiquement.
    - **e2e-dev ne bouge pas le board** : le ticket reste en `In progress` ; une régression est traitée par les tickets de fix d'`architect-rework` (l'utilisateur les implémente, puis `e2e-dev` re-valide).
 
 6. **Pour les sub-issues d'epic validées en mode synchrone** : `process_tick_result.sh` n'est pas appelé (c'est un mécanisme du loop driver). Le squash-merge de la PR validée dans `epic/<N>` peut être déclenché manuellement (de préférence **après** que `e2e-dev` a poussé sa couverture, pour que les E2E partent avec) :

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Executes **automatiquement**, sans intervention.
 
 ### Agents (`.claude/agents/`)
 
-Chaque agent porte son couple `model:` / `effort:` en frontmatter, et les invocations CLI headless repassent les memes valeurs en `--model` / `--effort` : la redondance est volontaire, aucune precedence ne peut produire de divergence. **Seule exception : `code-dev`**, dont ni le modele ni l'effort ne sont pinnes — le modele varie par ticket (passe en `--model`), et l'effort reste herite : c'est le poste de depense de la pipeline (1 run par ticket, session la plus longue), donc un reglage de run et non une propriete de l'agent.
+Chaque agent porte son couple `model:` / `effort:` en frontmatter, et les invocations CLI headless repassent les memes valeurs en `--model` / `--effort` : la redondance est volontaire, aucune precedence ne peut produire de divergence. **Seule exception : `code-dev`**, dont ni le modele ni l'effort ne sont pinnes en frontmatter — les deux sont passes a l'invocation : le modele varie par ticket (`--model`), et l'effort est fixe pour le run (`--effort high`, surchargeable par `EPIC_LOOP_EFFORT_CODE_DEV`). C'est le poste de depense de la pipeline (1 run par ticket, session la plus longue), donc un reglage de run et non une propriete de l'agent.
 
 | Agent | Role | Modele | Effort |
 |---|---|---|---|
@@ -273,12 +273,12 @@ Chaque agent porte son couple `model:` / `effort:` en frontmatter, et les invoca
 | `structural-auditor` | greps mecaniques, fuites du domaine, affaiblissement de test | sonnet | high |
 | `rgaa-auditor` | lance le skill ultra11y `review-a11y` sur le code modifie | sonnet | high |
 | `security-auditor` | OWASP Top 10 + RGS, cible sur les mecanismes du projet | sonnet | high |
-| `code-dev` | implemente un ticket end-to-end **et ecrit ses tests vitest** | passe en `--model` : sonnet, opus si `complexe` | herite (non pinne) |
-| `e2e-dev` | ecrit tous les tests Playwright, en fin de pipeline | opus | xhigh |
+| `code-dev` | implemente un ticket end-to-end **et ecrit ses tests vitest** | passe en `--model` : sonnet, opus si `complexe` | passe en `--effort` : high |
+| `e2e-dev` | ecrit tous les tests Playwright, en fin de pipeline | opus | high |
 | `functional-validator` | rejoue les scenarios PO sur le dev server | sonnet | medium |
 | `design-validator` | mesure la fidelite visuelle contre le Figma | sonnet | xhigh |
 | `product-owner`, `bug-analyst`, `architect-rework` | conception : besoin, diagnostic, rework | opus | xhigh |
-| `architect` | decoupage et redaction des specs | fable | xhigh |
+| `architect` | decoupage et redaction des specs | opus | xhigh |
 | `review-fixer` | adresse les commentaires de revue | sonnet | high |
 | `doc-writer` | regenere `docs/` depuis le code | sonnet | medium |
 

--- a/scripts/orchestration/epic_loop.sh
+++ b/scripts/orchestration/epic_loop.sh
@@ -35,6 +35,7 @@ fi
 #   EPIC_LOOP_BUDGET_SONNET   10     USD max per Sonnet sub-agent
 #   EPIC_LOOP_BUDGET_OPUS     20     USD max per Opus sub-agent (Opus 5 pricing)
 #   EPIC_LOOP_AGENT_TIMEOUT   5400   seconds max per agent (90 min)
+#   EPIC_LOOP_EFFORT_CODE_DEV high   reasoning effort passed to each code-dev
 #   EPIC_MAX_PARALLEL         5      max concurrent worktrees
 #
 # Usage:
@@ -79,6 +80,10 @@ SLEEP_WAIT="${EPIC_LOOP_SLEEP_WAIT:-30}"
 BUDGET_SONNET="${EPIC_LOOP_BUDGET_SONNET:-10}"
 BUDGET_OPUS="${EPIC_LOOP_BUDGET_OPUS:-20}"
 AGENT_TIMEOUT="${EPIC_LOOP_AGENT_TIMEOUT:-5400}"
+# code-dev carries neither model: nor effort: in its frontmatter (cf. its
+# AGENT.md): both are run settings, passed here. The model varies per ticket
+# (dispatch_plan.sh), the effort is fixed for the whole run.
+AGENT_EFFORT="${EPIC_LOOP_EFFORT_CODE_DEV:-high}"
 # Max consecutive e2e-dev regression rounds before escalating to the user.
 # Each round = e2e-dev finds a regression → architect-rework creates fix
 # ticket(s) → the loop reprocesses them → e2e-dev re-runs. Beyond this cap the
@@ -266,6 +271,7 @@ Ton dernier message DOIT être uniquement ce JSON (rien d'autre, pas de prose)."
     $TIMEOUT_PREFIX env -u CLAUDECODE claude \
         --agent "$AGENT" \
         --model "$MODEL" \
+        --effort "$AGENT_EFFORT" \
         --print \
         --output-format stream-json \
         --verbose \

--- a/scripts/orchestration/run_e2e_dev.sh
+++ b/scripts/orchestration/run_e2e_dev.sh
@@ -198,7 +198,7 @@ set +e
 $TIMEOUT_PREFIX env -u CLAUDECODE claude \
     --agent e2e-dev \
     --model opus \
-    --effort xhigh \
+    --effort high \
     --print \
     --output-format json \
     --dangerously-skip-permissions \


### PR DESCRIPTION
## Ce que ça change

Trois réglages de la pipeline d'agents, rien d'autre — aucun code applicatif touché.

| Agent | Avant | Après |
|---|---|---|
| `architect` | model `fable` | model **`opus`** |
| `code-dev` | effort hérité de la session appelante | effort **`high`**, passé à l'invocation |
| `e2e-dev` | effort `xhigh` | effort **`high`** |

## Détail

**`architect` → opus** — frontmatter + sa section « Model & Tools ». Il est invoqué par l'outil Agent (pas de `--model` en ligne de commande), donc le frontmatter suffit. La doc `/analyse` disait déjà « Architect (Opus) » à l'étape 2 tout en annonçant « Fable » dans sa table de modes : la divergence est levée.

**`code-dev` → effort `high`** — son AGENT.md pose que ni `model:` ni `effort:` ne vont en frontmatter, parce que c'est le poste de dépense de la pipeline et que le réglage doit être visible là où on lance le run. Le choix est donc fixé **aux sites d'invocation**, pas dans le frontmatter :
- `epic_loop.sh` : nouvel env `EPIC_LOOP_EFFORT_CODE_DEV` (défaut `high`), passé en `--effort` dans `spawn_agent` — surchargeable sans éditer le script, comme les budgets ;
- `/implement` (mode task/bug) : `--effort high` dans l'invocation CLI foreground, y compris sur la relance `needs_opus_escalation`.

L'encadré « ne pas réparer l'absence de frontmatter » et la ligne « Effort: hérité » sont mis à jour en conséquence.

**`e2e-dev` → effort `high`** — frontmatter, `run_e2e_dev.sh` et le snippet CLI de `/implement`, les trois portant la même valeur (la redondance frontmatter ↔ flag est volontaire dans ce repo). `architect-rework` reste en `xhigh` : la phrase qui le lançait « exactement comme e2e-dev » est reformulée pour ne plus impliquer des flags identiques.

Le tableau des agents du README est aligné sur les trois.
