### PR TITLE
feat(declaration-remuneration): #4276 — colonnes du fichier d'import catégories

### DIFF
--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -1,4 +1,5 @@
-import { expect, type Page, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 import { getReferenceYearFor } from "~/modules/domain";
 import { withCampaignYear } from "./helpers/campaign-year";
 import {
@@ -629,6 +630,153 @@ test.describe("Step 5 — one physical headcount per pay basis (#4254)", () => {
 			await expect(count("hourly", "women")).toHaveValue("");
 			await expect(count("hourly", "men")).toHaveValue("");
 			await expect(rowTotal(page, "Rémunération horaire")).toHaveText("-");
+		});
+	});
+
+	test("le modèle d'import porte les treize colonnes et alimente les deux bases (#4276)", async ({
+		page,
+	}) => {
+		test.slow();
+
+		// Keys = the thirteen template columns in their spec order, values = a
+		// distinct number per column, so a mapping shifted by the two headcount
+		// columns inserted mid-list lands a value in the wrong input instead of
+		// staying green.
+		const importedValues = {
+			"Libellé de la catégorie": "Ouvriers",
+			"Annuel effectif femmes": "11",
+			"Annuel effectif hommes": "12",
+			"Horaire effectif femmes": "13",
+			"Horaire effectif hommes": "14",
+			"Annuel base femmes (€)": "101",
+			"Annuel base hommes (€)": "102",
+			"Annuel variable femmes (€)": "103",
+			"Annuel variable hommes (€)": "104",
+			"Horaire base femmes (€)": "105",
+			"Horaire base hommes (€)": "106",
+			"Horaire variable femmes (€)": "107",
+			"Horaire variable hommes (€)": "108",
+		};
+
+		const inputByHeader: Record<
+			Exclude<keyof typeof importedValues, "Libellé de la catégorie">,
+			Locator
+		> = {
+			"Annuel effectif femmes": categoryWorkforceInput(page, {
+				basis: "annual",
+				sex: "women",
+			}),
+			"Annuel effectif hommes": categoryWorkforceInput(page, {
+				basis: "annual",
+				sex: "men",
+			}),
+			"Horaire effectif femmes": categoryWorkforceInput(page, {
+				basis: "hourly",
+				sex: "women",
+			}),
+			"Horaire effectif hommes": categoryWorkforceInput(page, {
+				basis: "hourly",
+				sex: "men",
+			}),
+			"Annuel base femmes (€)": categoryPayInput(page, {
+				measure: "Salaire de base annuel",
+				sex: "femmes",
+			}),
+			"Annuel base hommes (€)": categoryPayInput(page, {
+				measure: "Salaire de base annuel",
+				sex: "hommes",
+			}),
+			"Annuel variable femmes (€)": categoryPayInput(page, {
+				measure: "Composantes variables annuelles",
+				sex: "femmes",
+			}),
+			"Annuel variable hommes (€)": categoryPayInput(page, {
+				measure: "Composantes variables annuelles",
+				sex: "hommes",
+			}),
+			"Horaire base femmes (€)": categoryPayInput(page, {
+				measure: "Salaire de base horaire",
+				sex: "femmes",
+			}),
+			"Horaire base hommes (€)": categoryPayInput(page, {
+				measure: "Salaire de base horaire",
+				sex: "hommes",
+			}),
+			"Horaire variable femmes (€)": categoryPayInput(page, {
+				measure: "Composantes variables horaires",
+				sex: "femmes",
+			}),
+			"Horaire variable hommes (€)": categoryPayInput(page, {
+				measure: "Composantes variables horaires",
+				sex: "hommes",
+			}),
+		};
+
+		await page.goto("/declaration-remuneration/etape/5");
+		await page.getByRole("button", { name: "Importer les données" }).click();
+
+		const panel = page.getByRole("dialog", {
+			name: "Importer vos données depuis un fichier",
+		});
+		await expect(panel).toBeVisible();
+
+		const templateHeaders =
+			await test.step("le modèle téléchargé porte les treize colonnes attendues", async () => {
+				const [download] = await Promise.all([
+					page.waitForEvent("download"),
+					panel
+						.getByRole("button", { name: "Fichier d'import à remplir" })
+						.click(),
+				]);
+
+				expect(download.suggestedFilename()).toBe("modele-indicateur-g.csv");
+
+				const template = readFileSync(await download.path(), "utf8").replace(
+					/^\uFEFF/,
+					"",
+				);
+				expect(template.split(";")).toEqual(Object.keys(importedValues));
+
+				return template;
+			});
+
+		await test.step("un fichier au format du modèle renseigne les treize champs", async () => {
+			// Built on the very header line the app just served, so the template and
+			// the parser are asserted against each other, not against a copy.
+			const csv = `\uFEFF${templateHeaders}\n${Object.values(importedValues).join(";")}`;
+
+			await panel.getByLabel("Sélectionner des fichiers").setInputFiles({
+				buffer: Buffer.from(csv, "utf8"),
+				mimeType: "text/csv",
+				name: "categories.csv",
+			});
+			await panel
+				.getByRole("button", { exact: true, name: "Importer" })
+				.click();
+
+			await expect(panel).toBeHidden();
+
+			const { "Libellé de la catégorie": name, ...amounts } = importedValues;
+
+			const category = page.getByRole("button", {
+				name: `Catégorie d'emplois n°1 : ${name}`,
+			});
+			await expect(category).toBeVisible();
+
+			// An imported category remounts its accordion, which DSFR brings back
+			// folded — its fields reach the DOM only once it is disclosed.
+			if ((await category.getAttribute("aria-expanded")) !== "true") {
+				await category.click();
+			}
+
+			for (const [header, value] of Object.entries(amounts)) {
+				// Pay amounts come back through the form's decimal formatting;
+				// headcounts are plain integers.
+				const shown = header.endsWith("(€)") ? `${value},00` : value;
+				await expect(
+					inputByHeader[header as keyof typeof inputByHeader],
+				).toHaveValue(shown);
+			}
 		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/categoryFileHandler.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/categoryFileHandler.test.ts
@@ -63,7 +63,6 @@ describe("generateTemplate", () => {
 		// Blob.text() UTF-8-decodes the bytes, stripping the leading BOM.
 		const lines = (await blob.text()).split("\n");
 		expect(lines).toHaveLength(1);
-		expect(lines[0]).toBe(HEADER_LINE);
 		expect(lines[0]?.split(";")).toEqual(TEMPLATE_HEADERS);
 	});
 
@@ -229,7 +228,27 @@ describe("parseImportFile — XLSX", () => {
 
 describe("parseImportFile — CSV", () => {
 	it("parses a valid CSV file, restituting annual and hourly headcounts alongside the 8 remuneration columns", async () => {
-		const csv = `${HEADER_LINE}\nOuvriers;50;60;45;55;30000;31000;;;;;;\nCadres;20;25;18;22;;;;;;;;`;
+		const csv = [
+			HEADER_LINE,
+			[
+				"Ouvriers",
+				"50",
+				"60",
+				"45",
+				"55",
+				"30000",
+				"31000",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+			].join(";"),
+			["Cadres", "20", "25", "18", "22", "", "", "", "", "", "", "", ""].join(
+				";",
+			),
+		].join("\n");
 		const result = await parseImportFile(csvFile(csv));
 
 		expect(result.ok).toBe(true);
@@ -287,7 +306,13 @@ describe("parseImportFile — CSV", () => {
 	});
 
 	it("rejects a file built on the old 11-column format, listing the renamed and new headers as missing", async () => {
-		const csv = `${OLD_TEMPLATE_HEADERS.join(";")}\nOuvriers;50;60;30000;31000;;;;;;`;
+		expect(OLD_TEMPLATE_HEADERS).toHaveLength(11);
+		const csv = [
+			OLD_TEMPLATE_HEADERS.join(";"),
+			["Ouvriers", "50", "60", "30000", "31000", "", "", "", "", "", ""].join(
+				";",
+			),
+		].join("\n");
 		const result = await parseImportFile(csvFile(csv));
 
 		expect(result.ok).toBe(false);

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/categoryFileHandler.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/categoryFileHandler.test.ts
@@ -4,6 +4,22 @@ import { describe, expect, it } from "vitest";
 import { generateTemplate, parseImportFile } from "../categoryFileHandler";
 
 const TEMPLATE_HEADERS = [
+	"Libellé de la catégorie",
+	"Annuel effectif femmes",
+	"Annuel effectif hommes",
+	"Horaire effectif femmes",
+	"Horaire effectif hommes",
+	"Annuel base femmes (€)",
+	"Annuel base hommes (€)",
+	"Annuel variable femmes (€)",
+	"Annuel variable hommes (€)",
+	"Horaire base femmes (€)",
+	"Horaire base hommes (€)",
+	"Horaire variable femmes (€)",
+	"Horaire variable hommes (€)",
+];
+const HEADER_LINE = TEMPLATE_HEADERS.join(";");
+const OLD_TEMPLATE_HEADERS = [
 	"Nom de la catégorie",
 	"Effectif femmes",
 	"Effectif hommes",
@@ -16,14 +32,14 @@ const TEMPLATE_HEADERS = [
 	"Horaire variable femmes (€)",
 	"Horaire variable hommes (€)",
 ];
-const HEADER_LINE = TEMPLATE_HEADERS.join(";");
 
 async function xlsxFile(
+	headers: string[],
 	dataRows: Array<Array<string | number>>,
 ): Promise<File> {
 	const workbook = new ExcelJS.Workbook();
 	const sheet = workbook.addWorksheet("Indicateur G");
-	sheet.addRow(TEMPLATE_HEADERS);
+	sheet.addRow(headers);
 	for (const row of dataRows) {
 		sheet.addRow(row);
 	}
@@ -38,7 +54,7 @@ function csvFile(content: string, name = "test.csv"): File {
 }
 
 describe("generateTemplate", () => {
-	it("returns a synchronous CSV blob holding only the 11 header labels and no data row", async () => {
+	it("returns a synchronous CSV blob holding only the 13 header labels, in order, and no data row", async () => {
 		const blob = generateTemplate();
 
 		expect(blob).toBeInstanceOf(Blob);
@@ -48,6 +64,7 @@ describe("generateTemplate", () => {
 		const lines = (await blob.text()).split("\n");
 		expect(lines).toHaveLength(1);
 		expect(lines[0]).toBe(HEADER_LINE);
+		expect(lines[0]?.split(";")).toEqual(TEMPLATE_HEADERS);
 	});
 
 	it("prefixes the raw CSV bytes with a UTF-8 BOM", async () => {
@@ -59,9 +76,23 @@ describe("generateTemplate", () => {
 
 describe("parseImportFile — XLSX", () => {
 	it("parses categories from an XLSX file", async () => {
-		const file = await xlsxFile([
-			["Ouvriers", "50", "60", "30000", "31000", "", "", "", "", "", ""],
-			["Cadres", "20", "25", "", "", "", "", "", "", "", ""],
+		const file = await xlsxFile(TEMPLATE_HEADERS, [
+			[
+				"Ouvriers",
+				"50",
+				"60",
+				"45",
+				"55",
+				"30000",
+				"31000",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+			],
+			["Cadres", "20", "25", "18", "22", "", "", "", "", "", "", "", ""],
 		]);
 		const result = await parseImportFile(file);
 
@@ -71,13 +102,16 @@ describe("parseImportFile — XLSX", () => {
 		expect(result.categories).toHaveLength(2);
 		expect(result.categories[0]?.name).toBe("Ouvriers");
 		expect(result.categories[0]?.womenCount).toBe("50");
+		expect(result.categories[0]?.hourlyWomenCount).toBe("45");
+		expect(result.categories[0]?.hourlyMenCount).toBe("55");
 		expect(result.categories[0]?.annualBaseWomen).toBe("30000");
 		expect(result.categories[1]?.name).toBe("Cadres");
 		expect(result.categories[1]?.womenCount).toBe("20");
+		expect(result.categories[1]?.hourlyWomenCount).toBe("18");
 	});
 
 	it("returns empty-file error for an XLSX with only the header row", async () => {
-		const result = await parseImportFile(await xlsxFile([]));
+		const result = await parseImportFile(await xlsxFile(TEMPLATE_HEADERS, []));
 
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
@@ -87,7 +121,9 @@ describe("parseImportFile — XLSX", () => {
 
 	it("returns empty-file error when every XLSX data row has an empty name", async () => {
 		const result = await parseImportFile(
-			await xlsxFile([["", "5", "8", "", "", "", "", "", "", "", ""]]),
+			await xlsxFile(TEMPLATE_HEADERS, [
+				["", "5", "8", "", "", "", "", "", "", "", "", "", ""],
+			]),
 		);
 
 		expect(result.ok).toBe(false);
@@ -112,6 +148,8 @@ describe("parseImportFile — XLSX", () => {
 			"",
 			"",
 			"",
+			"",
+			"",
 		]);
 		row.getCell(2).value = { formula: "50+5", result: 55 };
 		const buffer = await workbook.xlsx.writeBuffer();
@@ -126,11 +164,72 @@ describe("parseImportFile — XLSX", () => {
 
 		expect(result.categories[0]?.womenCount).toBe("55");
 	});
+
+	it("parses the same content identically whether column order matches the template or not", async () => {
+		const shuffledHeaders = [
+			"Annuel effectif hommes",
+			"Libellé de la catégorie",
+			"Horaire effectif hommes",
+			"Annuel effectif femmes",
+			"Horaire effectif femmes",
+			"Annuel base hommes (€)",
+			"Annuel base femmes (€)",
+			"Annuel variable femmes (€)",
+			"Annuel variable hommes (€)",
+			"Horaire base femmes (€)",
+			"Horaire base hommes (€)",
+			"Horaire variable femmes (€)",
+			"Horaire variable hommes (€)",
+		];
+		const orderedFile = await xlsxFile(TEMPLATE_HEADERS, [
+			[
+				"Ouvriers",
+				"50",
+				"60",
+				"45",
+				"55",
+				"30000",
+				"31000",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+			],
+		]);
+		const shuffledFile = await xlsxFile(shuffledHeaders, [
+			[
+				"60",
+				"Ouvriers",
+				"55",
+				"50",
+				"45",
+				"31000",
+				"30000",
+				"",
+				"",
+				"",
+				"",
+				"",
+				"",
+			],
+		]);
+
+		const orderedResult = await parseImportFile(orderedFile);
+		const shuffledResult = await parseImportFile(shuffledFile);
+
+		expect(orderedResult.ok).toBe(true);
+		expect(shuffledResult.ok).toBe(true);
+		if (!orderedResult.ok || !shuffledResult.ok) return;
+
+		expect(shuffledResult.categories).toEqual(orderedResult.categories);
+	});
 });
 
 describe("parseImportFile — CSV", () => {
-	it("parses a valid CSV file", async () => {
-		const csv = `${HEADER_LINE}\nOuvriers;50;60;30000;31000;;;;;\nCadres;20;25;;;;;;;;;`;
+	it("parses a valid CSV file, restituting annual and hourly headcounts alongside the 8 remuneration columns", async () => {
+		const csv = `${HEADER_LINE}\nOuvriers;50;60;45;55;30000;31000;;;;;;\nCadres;20;25;18;22;;;;;;;;`;
 		const result = await parseImportFile(csvFile(csv));
 
 		expect(result.ok).toBe(true);
@@ -139,11 +238,14 @@ describe("parseImportFile — CSV", () => {
 		expect(result.categories).toHaveLength(2);
 		expect(result.categories[0]?.name).toBe("Ouvriers");
 		expect(result.categories[0]?.womenCount).toBe("50");
+		expect(result.categories[0]?.menCount).toBe("60");
+		expect(result.categories[0]?.hourlyWomenCount).toBe("45");
+		expect(result.categories[0]?.hourlyMenCount).toBe("55");
 		expect(result.categories[0]?.annualBaseWomen).toBe("30000");
 	});
 
 	it("normalizes comma decimals to dots", async () => {
-		const csv = `${HEADER_LINE}\nOuvriers;10;12;30 000,50;31000;;;;;`;
+		const csv = `${HEADER_LINE}\nOuvriers;10;12;8;9;30 000,50;31000;;;;;;`;
 		const result = await parseImportFile(csvFile(csv));
 
 		expect(result.ok).toBe(true);
@@ -153,7 +255,7 @@ describe("parseImportFile — CSV", () => {
 	});
 
 	it("parses a quoted field that contains the separator and escaped quotes", async () => {
-		const csv = `${HEADER_LINE}\n"Cadres ""séniors""; groupe A";10;12;;;;;;;;`;
+		const csv = `${HEADER_LINE}\n"Cadres ""séniors""; groupe A";10;12;;;;;;;;;;`;
 		const result = await parseImportFile(csvFile(csv));
 
 		expect(result.ok).toBe(true);
@@ -164,7 +266,7 @@ describe("parseImportFile — CSV", () => {
 	});
 
 	it("skips rows with empty name", async () => {
-		const csv = `${HEADER_LINE}\nOuvriers;10;12;;;;;;\n;5;8;;;;;;`;
+		const csv = `${HEADER_LINE}\nOuvriers;10;12;;;;;;;;\n;5;8;;;;;;;;`;
 		const result = await parseImportFile(csvFile(csv));
 
 		expect(result.ok).toBe(true);
@@ -184,6 +286,21 @@ describe("parseImportFile — CSV", () => {
 		expect(result.errors[0]?.message).toContain("Colonnes manquantes");
 	});
 
+	it("rejects a file built on the old 11-column format, listing the renamed and new headers as missing", async () => {
+		const csv = `${OLD_TEMPLATE_HEADERS.join(";")}\nOuvriers;50;60;30000;31000;;;;;;`;
+		const result = await parseImportFile(csvFile(csv));
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+
+		expect(result.errors[0]?.type).toBe("missing-columns");
+		expect(result.errors[0]?.message).toContain("Libellé de la catégorie");
+		expect(result.errors[0]?.message).toContain("Annuel effectif femmes");
+		expect(result.errors[0]?.message).toContain("Annuel effectif hommes");
+		expect(result.errors[0]?.message).toContain("Horaire effectif femmes");
+		expect(result.errors[0]?.message).toContain("Horaire effectif hommes");
+	});
+
 	it("returns error on empty file", async () => {
 		const result = await parseImportFile(csvFile(""));
 
@@ -194,7 +311,9 @@ describe("parseImportFile — CSV", () => {
 	});
 
 	it("returns empty-file error when every CSV data row has an empty name", async () => {
-		const result = await parseImportFile(csvFile(`${HEADER_LINE}\n;5;8;;;;;;`));
+		const result = await parseImportFile(
+			csvFile(`${HEADER_LINE}\n;5;8;;;;;;;;;;`),
+		);
 
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
@@ -227,7 +346,7 @@ describe("parseImportFile — CSV", () => {
 
 	it("round-trips: fill the header-only template then parse it", async () => {
 		const template = await generateTemplate().text();
-		const filled = `${template}\nTechniciens;30;40;;;;;18.50;19;;`;
+		const filled = `${template}\nTechniciens;30;40;28;38;;;;;18.50;19;;`;
 		const result = await parseImportFile(csvFile(filled));
 
 		expect(result.ok).toBe(true);
@@ -235,6 +354,37 @@ describe("parseImportFile — CSV", () => {
 
 		expect(result.categories).toHaveLength(1);
 		expect(result.categories[0]?.name).toBe("Techniciens");
+		expect(result.categories[0]?.hourlyWomenCount).toBe("28");
+		expect(result.categories[0]?.hourlyMenCount).toBe("38");
 		expect(result.categories[0]?.hourlyBaseWomen).toBe("18.50");
+	});
+
+	it("produces the same result from an equivalent CSV and XLSX file", async () => {
+		const dataRow = [
+			"Ouvriers",
+			"50",
+			"60",
+			"45",
+			"55",
+			"30000",
+			"31000",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+		];
+		const csv = `${HEADER_LINE}\n${dataRow.join(";")}`;
+		const csvResult = await parseImportFile(csvFile(csv));
+		const xlsxResult = await parseImportFile(
+			await xlsxFile(TEMPLATE_HEADERS, [dataRow]),
+		);
+
+		expect(csvResult.ok).toBe(true);
+		expect(xlsxResult.ok).toBe(true);
+		if (!csvResult.ok || !xlsxResult.ok) return;
+
+		expect(csvResult.categories).toEqual(xlsxResult.categories);
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/categoryFileHandler.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/categoryFileHandler.ts
@@ -4,9 +4,11 @@ import type { EmployeeCategory } from "./categorySerializer";
 
 /** Column definitions for the import/export template. */
 const TEMPLATE_COLUMNS = [
-	{ key: "name", header: "Nom de la catégorie" },
-	{ key: "womenCount", header: "Effectif femmes" },
-	{ key: "menCount", header: "Effectif hommes" },
+	{ key: "name", header: "Libellé de la catégorie" },
+	{ key: "womenCount", header: "Annuel effectif femmes" },
+	{ key: "menCount", header: "Annuel effectif hommes" },
+	{ key: "hourlyWomenCount", header: "Horaire effectif femmes" },
+	{ key: "hourlyMenCount", header: "Horaire effectif hommes" },
 	{ key: "annualBaseWomen", header: "Annuel base femmes (€)" },
 	{ key: "annualBaseMen", header: "Annuel base hommes (€)" },
 	{ key: "annualVariableWomen", header: "Annuel variable femmes (€)" },
@@ -296,10 +298,8 @@ function buildCategoryFromRow(
 		name: get("name").trim(),
 		womenCount: normalizeDecimal(get("womenCount")),
 		menCount: normalizeDecimal(get("menCount")),
-		// Hourly headcounts have no column in the template yet — #4276 owns the
-		// import file, this ticket only owns the model (#4254).
-		hourlyWomenCount: "",
-		hourlyMenCount: "",
+		hourlyWomenCount: normalizeDecimal(get("hourlyWomenCount")),
+		hourlyMenCount: normalizeDecimal(get("hourlyMenCount")),
 		annualBaseWomen: normalizeDecimal(get("annualBaseWomen")),
 		annualBaseMen: normalizeDecimal(get("annualBaseMen")),
 		annualVariableWomen: normalizeDecimal(get("annualVariableWomen")),


### PR DESCRIPTION
Closes #4276

**⚠️ PR empilée sur #4384** (base = branche de #4254, pas `alpha`) : #4254 ajoute les champs d'effectif horaire (`hourlyWomenCount`/`hourlyMenCount`) sur `EmployeeCategory`, ce ticket branche le fichier d'import dessus. Cette PR n'affiche que le diff propre à #4276 ; GitHub la re-ciblera automatiquement sur `alpha` une fois #4384 mergée.

## Résumé

Le modèle téléchargeable `modele-indicateur-g.csv` et le parsing d'import (CSV + XLSX) de `categoryFileHandler.ts` passent de 11 à 13 colonnes :

- 3 libellés renommés : « Nom de la catégorie » → « Libellé de la catégorie », « Effectif femmes » → « Annuel effectif femmes », « Effectif hommes » → « Annuel effectif hommes »
- 2 nouvelles colonnes, placées avant « Annuel base femmes (€) » : « Horaire effectif femmes », « Horaire effectif hommes »

Les deux nouvelles colonnes alimentent les champs `hourlyWomenCount`/`hourlyMenCount` d'`EmployeeCategory` (existants depuis #4254), normalisées via `normalizeDecimal` comme le reste des champs numériques.

Décisions de spec appliquées telles quelles (cf. `## Analyse architecte` sur #4276) :
- mapping par nom d'en-tête, insensible à la casse et à l'ordre (mécanique `mapColumns` inchangée)
- aucun alias de rétro-compatibilité : un fichier à l'ancien format (11 colonnes) est rejeté par le contrôle « Colonnes manquantes » existant, qui liste précisément les en-têtes attendus absents

## Fichiers modifiés

- `packages/app/src/modules/declaration-remuneration/steps/step5/categoryFileHandler.ts`
- `packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/categoryFileHandler.test.ts`

`CategoryImportExport.tsx` (consommateur du handler, utilisé à la fois par l'étape 5 de la 1re déclaration et par `SecondDeclarationStep2Form`) n'a aucune hypothèse en dur sur le nombre de colonnes et n'a pas eu besoin d'être modifié.

## Test plan

- Vitest : 19/19 tests sur `categoryFileHandler.test.ts` (nouveaux cas : ordre de colonnes différent, équivalence CSV/XLSX, rejet de l'ancien format 11-colonnes avec message listant les 5 en-têtes manquants)
- Suite complète : 5809/5809 tests verts
- `pnpm typecheck` : 0 erreur
- Pas de test E2E ajouté (hors périmètre de `code-dev`)
- Pas de changement UI — le panneau d'import (`CategoryImportExport.tsx`) est inchangé, donc pas de vérification Figma nécessaire pour ce ticket (le node Figma cité dans l'issue documente le vocabulaire du formulaire, périmètre de #4254)