### PR TITLE
fix(declaration): #4389 — espacement 32px entre accordéons catégories et rangée d'actions

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -629,7 +629,7 @@ export function CategoryForm({
 			</div>
 
 			<fieldset
-				className={readOnly ? common.readOnlyFieldset : undefined}
+				className={`${common.readOnlyFieldset} ${common.flexColumnGap2}`}
 				id={CATEGORY_FORM_FIELD_ID}
 			>
 				<legend className="fr-sr-only">Catégories d&apos;emplois</legend>


### PR DESCRIPTION
Closes #4389

## Contexte

Sur l'étape 5 de la 1re déclaration (et l'étape 2 de la 2e déclaration, écran partagé), la rangée d'actions de bas de formulaire venait au contact de la bordure du dernier accordéon au lieu d'en être séparée de 32 px, comme le prescrit le Figma.

## Cause racine

Le `<fieldset>` de `CategoryForm.tsx` n'appliquait `common.readOnlyFieldset` qu'en mode lecture seule, et jamais `common.flexColumnGap2`. Deux conséquences :

- `.fr-accordions-group` et `.categoryFooter` étant les deux seuls enfants du fieldset, le `gap: 2rem` porté par le `<form>` parent ne descendait pas dedans — le fieldset ne comptait que pour un seul enfant flex du form.
- En mode édition, le fieldset n'avait aucune classe et gardait la boîte par défaut du navigateur (bordure `2px groove`, padding, `min-width: min-content`) : contenu décalé de 16 px à droite et 32 px plus étroit que ses frères.

## Correctif

Application inconditionnelle de `common.readOnlyFieldset` + `common.flexColumnGap2` sur le fieldset — l'idiome déjà en place sur `JointEvaluationForm.tsx:98`, et le même que celui qu'appliquent déjà, sans condition, les fieldsets des étapes 1/2/3/4/6. Une ligne, un fichier, aucune valeur en dur, aucune touche au SCSS.

`CategoryForm` étant le composant partagé monté à la fois par `Step5EmployeeCategories.tsx` (1re déclaration) et `SecondDeclarationStep2Form.tsx` (2e déclaration, sans wrapper ni override de cette className), le correctif s'applique identiquement aux deux écrans.

## Vérification

Mesure DOM sur dev server, viewport 1440, `/declaration-remuneration/etape/5` :

```js
const g = document.querySelector(".fr-accordions-group");
const f = g.nextElementSibling;
f.getBoundingClientRect().top - g.getBoundingClientRect().bottom;
```

| Mesure | Avant | Après | Attendu |
|---|---|---|---|
| Écart accordéons → rangée d'actions | 0 px | **32 px** | 32 px |
| `left` du bloc accordéons (mode édition) | 328.5 | **312.5** | identique aux frères (bloc Définitions, boutons de navigation) |
| `width` du bloc accordéons (mode édition) | 768 | **800** | identique aux frères |
| Cadre gris autour des accordéons | présent (bordure UA `2px groove`) | **absent** | absent |

Avant/après reproduit en local en revenant temporairement sur le commit précédent (fichier seul, sans stash) puis en le restaurant — écarts confirmés dans les deux sens.

Second écran (`SecondDeclarationStep2Form`) non atteint directement en local (le parcours de mise en conformité ne s'est pas déclenché pour la fiche de test utilisée malgré des écarts ≥ 5 %, probablement lié au palier d'effectif) ; couverture assurée par le partage strict du même composant `CategoryForm.tsx`, sans surcouche de style, comme détaillé ci-dessus.

**Couverture permanente** : non ajoutée, conformément à l'analyse du bug — défaut purement cosmétique, non bloquant, et jsdom ne fait pas de layout (une assertion `getBoundingClientRect` y serait vide de sens, ne pouvant jamais échouer).

## Captures d'écran

*(dev server local, données fictives)*

- Avant (mode lecture seule, déclaration finalisée) : rangée d'actions collée à l'accordéon
- Après : écart de 32 px conforme au Figma, alignement horizontal identique aux blocs voisins
