### PR TITLE
fix(declaration): #4390 — plusieurs incohérences d'effectif rendues en liste distincte

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -640,9 +640,18 @@ describe("Step5EmployeeCategories", () => {
 		await user.click(screen.getByRole("button", { name: /suivant/i }));
 
 		expect(
-			screen.getByText(/ne correspond pas à l'effectif déclaré/),
-		).toBeInTheDocument();
-		expect(screen.getByRole("alert")).toHaveTextContent("Données incohérentes");
+			screen.getAllByText(/ne correspond pas à l'effectif déclaré/),
+		).not.toHaveLength(0);
+		const alert = screen.getByRole("alert");
+		expect(alert).toHaveTextContent("Données incohérentes");
+		// Two simultaneous mismatches (women + men) render as two list items,
+		// each naming its own sex and totals, rather than one merged paragraph (#4390).
+		const items = within(alert).getAllByRole("listitem");
+		expect(items).toHaveLength(2);
+		expect(items.map((item) => item.textContent)).toEqual([
+			"Le total des effectifs femmes de la ligne « Rémunération annuelle » (5) ne correspond pas à l'effectif déclaré à l'étape 1 (10).",
+			"Le total des effectifs hommes de la ligne « Rémunération annuelle » (15) ne correspond pas à l'effectif déclaré à l'étape 1 (20).",
+		]);
 		expect(mockMutate).not.toHaveBeenCalled();
 	});
 
@@ -1093,6 +1102,9 @@ describe("Step5EmployeeCategories — headcount per pay basis (#4254)", () => {
 			"Le total des effectifs femmes de la ligne « Rémunération horaire » (4) ne correspond pas à l'effectif déclaré à l'étape 1 (5).",
 		);
 		expect(alert).not.toHaveTextContent("« Rémunération annuelle »");
+		// A single inconsistency stays a plain paragraph, not a list (#4390).
+		expect(within(alert).queryAllByRole("listitem")).toHaveLength(0);
+		expect(alert.querySelector("p")).not.toBeNull();
 		expect(mockMutate).not.toHaveBeenCalled();
 	});
 
@@ -1166,5 +1178,145 @@ describe("Step5EmployeeCategories — headcount per pay basis (#4254)", () => {
 
 		await user.click(screen.getByRole("button", { name: /suivant/i }));
 		expect(mockMutate).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders one list item per inconsistency when both bases and both sexes mismatch (#4390)", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+				hourlyMaxMen={9}
+				hourlyMaxWomen={7}
+				indicatorGRequired
+				maxMen={20}
+				maxWomen={10}
+			/>,
+		);
+
+		await fillNameAndSource(user);
+		await user.type(
+			screen.getByLabelText(countLabel("annuelle", "femmes")),
+			"5",
+		);
+		await user.type(
+			screen.getByLabelText(countLabel("annuelle", "hommes")),
+			"15",
+		);
+		await user.type(
+			screen.getByLabelText(countLabel("horaire", "femmes")),
+			"4",
+		);
+		await user.type(
+			screen.getByLabelText(countLabel("horaire", "hommes")),
+			"6",
+		);
+		await fillAllPayCells(user);
+
+		await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+		const alert = screen.getByRole("alert");
+		expect(alert).toHaveTextContent("Données incohérentes");
+		const items = within(alert).getAllByRole("listitem");
+		expect(items).toHaveLength(4);
+
+		const texts = items.map((item) => item.textContent ?? "");
+		expect(
+			texts.some(
+				(text) =>
+					text.includes("Rémunération annuelle") &&
+					text.includes("femmes") &&
+					text.includes("(5)") &&
+					text.includes("(10)"),
+			),
+		).toBe(true);
+		expect(
+			texts.some(
+				(text) =>
+					text.includes("Rémunération annuelle") &&
+					text.includes("hommes") &&
+					text.includes("(15)") &&
+					text.includes("(20)"),
+			),
+		).toBe(true);
+		expect(
+			texts.some(
+				(text) =>
+					text.includes("Rémunération horaire") &&
+					text.includes("femmes") &&
+					text.includes("(4)") &&
+					text.includes("(7)"),
+			),
+		).toBe(true);
+		expect(
+			texts.some(
+				(text) =>
+					text.includes("Rémunération horaire") &&
+					text.includes("hommes") &&
+					text.includes("(6)") &&
+					text.includes("(9)"),
+			),
+		).toBe(true);
+		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it("keeps every hidden message after dismissal of a four-way inconsistency (#4390)", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+				hourlyMaxMen={9}
+				hourlyMaxWomen={7}
+				indicatorGRequired
+				maxMen={20}
+				maxWomen={10}
+			/>,
+		);
+
+		await fillNameAndSource(user);
+		await user.type(
+			screen.getByLabelText(countLabel("annuelle", "femmes")),
+			"5",
+		);
+		await user.type(
+			screen.getByLabelText(countLabel("annuelle", "hommes")),
+			"15",
+		);
+		await user.type(
+			screen.getByLabelText(countLabel("horaire", "femmes")),
+			"4",
+		);
+		await user.type(
+			screen.getByLabelText(countLabel("horaire", "hommes")),
+			"6",
+		);
+		await fillAllPayCells(user);
+
+		await user.click(screen.getByRole("button", { name: /suivant/i }));
+		expect(screen.getByRole("alert")).toHaveTextContent("Données incohérentes");
+
+		await user.click(
+			screen.getByRole("button", { name: "Masquer le message" }),
+		);
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+		const hidden = document.getElementById(
+			"step5-categories-error-inconsistent",
+		);
+		expect(hidden).not.toBeNull();
+		expect(hidden).toHaveTextContent(
+			"Le total des effectifs femmes de la ligne « Rémunération annuelle » (5) ne correspond pas à l'effectif déclaré à l'étape 1 (10).",
+		);
+		expect(hidden).toHaveTextContent(
+			"Le total des effectifs hommes de la ligne « Rémunération annuelle » (15) ne correspond pas à l'effectif déclaré à l'étape 1 (20).",
+		);
+		expect(hidden).toHaveTextContent(
+			"Le total des effectifs femmes de la ligne « Rémunération horaire » (4) ne correspond pas à l'effectif déclaré à l'étape 1 (7).",
+		);
+		expect(hidden).toHaveTextContent(
+			"Le total des effectifs hommes de la ligne « Rémunération horaire » (6) ne correspond pas à l'effectif déclaré à l'étape 1 (9).",
+		);
+		expect(mockMutate).not.toHaveBeenCalled();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -645,7 +645,7 @@ describe("Step5EmployeeCategories", () => {
 		const alert = screen.getByRole("alert");
 		expect(alert).toHaveTextContent("Données incohérentes");
 		// Two simultaneous mismatches (women + men) render as two list items,
-		// each naming its own sex and totals, rather than one merged paragraph (#4390).
+		// each naming its own sex and totals, rather than one merged paragraph.
 		const items = within(alert).getAllByRole("listitem");
 		expect(items).toHaveLength(2);
 		expect(items.map((item) => item.textContent)).toEqual([
@@ -1102,7 +1102,7 @@ describe("Step5EmployeeCategories — headcount per pay basis (#4254)", () => {
 			"Le total des effectifs femmes de la ligne « Rémunération horaire » (4) ne correspond pas à l'effectif déclaré à l'étape 1 (5).",
 		);
 		expect(alert).not.toHaveTextContent("« Rémunération annuelle »");
-		// A single inconsistency stays a plain paragraph, not a list (#4390).
+		// A single inconsistency stays a plain paragraph, not a list.
 		expect(within(alert).queryAllByRole("listitem")).toHaveLength(0);
 		expect(alert.querySelector("p")).not.toBeNull();
 		expect(mockMutate).not.toHaveBeenCalled();

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -432,7 +432,7 @@ export function CategoryForm({
 				hourly: { women: hourlyMaxWomen, men: hourlyMaxMen },
 			} as const;
 			const sums = sumCategoryWorkforce(data.categories);
-			const workforceErrors: string[] = [];
+			const workforceErrors: FieldError[] = [];
 			for (const row of WORKFORCE_ROWS) {
 				for (const [sex, sexLabel] of [
 					["women", "femmes"],
@@ -441,19 +441,15 @@ export function CategoryForm({
 					const max = maxByBasis[row.basis][sex];
 					const total = sums[row.basis][sex];
 					if (max === undefined || total === max) continue;
-					workforceErrors.push(
-						`Le total des effectifs ${sexLabel} de la ligne « ${row.label} » (${total}) ne correspond pas à l'effectif déclaré à l'étape 1 (${max}).`,
-					);
+					workforceErrors.push({
+						fieldId: CATEGORY_FORM_FIELD_ID,
+						category: "inconsistent",
+						message: `Le total des effectifs ${sexLabel} de la ligne « ${row.label} » (${total}) ne correspond pas à l'effectif déclaré à l'étape 1 (${max}).`,
+					});
 				}
 			}
 			if (workforceErrors.length > 0) {
-				setCategoryErrors([
-					{
-						fieldId: CATEGORY_FORM_FIELD_ID,
-						category: "inconsistent",
-						message: workforceErrors.join(" "),
-					},
-				]);
+				setCategoryErrors(workforceErrors);
 				return;
 			}
 


### PR DESCRIPTION
Closes #4390

## Contexte

L'étape 5 contrôle que les sommes des effectifs par catégorie correspondent aux effectifs déclarés à l'étape 1, sur les deux bases « Rémunération annuelle » et « Rémunération horaire » (#4254). Jusqu'à quatre incohérences peuvent être remontées simultanément (femmes/hommes × annuelle/horaire), mais `CategoryForm` les concaténait en une seule chaîne (`join(" ")`) avant de construire un unique `FieldError` — `FieldErrorAlert` rendait donc toujours un seul paragraphe, même avec plusieurs incohérences.

## Correction

`CategoryForm.tsx` construit désormais directement un tableau de `FieldError`, une entrée par incohérence (base + sexe), et passe ce tableau tel quel à `setCategoryErrors`. `FieldErrorAlert` n'est pas modifié : c'est son rendu conditionnel déjà existant (`<p>` pour une erreur, `<ul>/<li>` pour plusieurs) qui prend le relais — le même mécanisme que les autres catégories d'erreurs du formulaire.

## Vérification

**One-shot (avant/après)**, sur le scénario DOM de l'étape 5 avec quatre incohérences simultanées (annuelle/horaire × femmes/hommes) :

| | Avant correctif | Après correctif |
|---|---|---|
| Structure de l'alerte | un paragraphe unique | une liste `<ul>` |
| `querySelectorAll("li").length` | `0` | `4` |
| Contenu | quatre phrases concaténées par un espace dans le `<p>` | une phrase distincte par `<li>` |

Après masquage (« Masquer le message »), le bloc `.fr-sr-only` contient bien les quatre phrases dans les deux cas.

**Revert-verify** : les deux nouveaux tests Vitest échouent (RED) sur le code d'avant correctif (`git apply -R` du diff de `CategoryForm.tsx`), puis passent (GREEN) une fois le correctif réappliqué — preuve que le test reproduit effectivement le défaut.

## Tests

`Step5EmployeeCategories.test.tsx` :
- 2 tests existants renforcés (2 incohérences simultanées → 2 `listitem` avec textes exacts ; incohérence unique → toujours un paragraphe, 0 `listitem`), sans relâchement d'aucune assertion.
- 2 tests ajoutés : 4 incohérences simultanées → 4 `listitem` nommant chacun la base, le sexe, le total saisi et l'effectif attendu ; persistance des 4 messages dans le bloc `fr-sr-only` après dismiss.
- Mutation de sauvegarde non appelée dans tous les cas d'erreur.

Aucune modification de `FieldErrorAlert` ni de la logique de validation de cohérence. Aucun test E2E ajouté (hors périmètre `code-dev`) — le test E2E de #4254 couvre déjà les incohérences isolées ; `e2e-dev` tranchera si un scénario supplémentaire est nécessaire.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (suite complète, 5808/5808)
- [x] `pnpm check:write` (lint + format)
- [ ] CI GitHub Actions
- [ ] SonarCloud Quality Gate
