### PR TITLE
fix(company): #4277 — remonte les entreprises cessées du registre

### DIFF
--- a/packages/app/src/server/services/__tests__/weez.test.ts
+++ b/packages/app/src/server/services/__tests__/weez.test.ts
@@ -72,6 +72,7 @@ describe("fetchCompanyBySiren", () => {
 		expect(calledUrl.href).toContain("/public/v3/unitelegale/findbysiren");
 		expect(calledUrl.searchParams.get("siren")).toBe("532847196");
 		expect(calledUrl.searchParams.get("inclure_non_diffusibles")).toBe("true");
+		expect(calledUrl.searchParams.get("inclure_cesse")).toBe("true");
 	});
 
 	it("returns limited info for non-diffusible company", async () => {

--- a/packages/app/src/server/services/weez.ts
+++ b/packages/app/src/server/services/weez.ts
@@ -97,6 +97,7 @@ export async function fetchCompanyBySiren(
 	url.searchParams.set("siren", siren);
 	url.searchParams.set("page", "0");
 	url.searchParams.set("inclure_non_diffusibles", "true");
+	url.searchParams.set("inclure_cesse", "true");
 
 	const TWENTY_FOUR_HOURS = 86_400;
 


### PR DESCRIPTION
Closes #4277

## Résumé

`fetchCompanyBySiren` n'envoyait pas `inclure_cesse=true` à l'endpoint `/public/v3/unitelegale/findbysiren`, donc l'API excluait par défaut les unités légales cessées : pour une entreprise fermée, `content` revenait vide et la fonction retournait `null`. Au login ProConnect, le fallback `{ siren, name: "Entreprise <siren>" }` était alors utilisé, faisant disparaître raison sociale, adresse et code NAF du bandeau « Mon espace ».

**Fix** : ajout de `url.searchParams.set("inclure_cesse", "true")` dans `fetchCompanyBySiren` (`packages/app/src/server/services/weez.ts`). Correctif en un seul point : les trois appelants (login ProConnect, `admin.searchCompany`, enrichissement GIP-MDS) en héritent.

Aucun changement UI (le bandeau affiche déjà les champs dès qu'ils sont renseignés), aucune migration, aucun changement de domaine.

## Effet de bord connu (attendu)

`admin.searchCompany` répondait `NOT_FOUND` sur une entreprise cessée ; après ce fix elle est trouvée, donc impersonable par un admin. Cohérent avec la demande du ticket. Vérifié que `admin.searchCompany` reste gated par `adminProcedure`, indépendamment de ce que retourne Weez.

## Vérification

**Verrou de non-régression (TU)** — `packages/app/src/server/services/__tests__/weez.test.ts` asserte maintenant que la requête sortante porte `inclure_cesse=true`.

**Revert-verify** (preuve que le test reproduit bien le défaut) :
- `git apply -R` sur le diff source seul (fichier de test conservé) → test **RED** (`expected null to be 'true'` sur l'assertion `inclure_cesse`)
- ré-application du fix → test **GREEN**

**Vérification one-shot (dégradée)** — la procédure décrite dans l'analyse (sonde live avant/après contre l'API réelle Weez) n'a pas pu être rejouée depuis cet environnement : pas de stack Docker disponible (disque hôte plein), et `EGAPRO_WEEZ_API_URL` réelle est un secret scellé non accessible depuis ce worktree. La vérification live avant/après a déjà été faite par l'analyse du bug (`totalElements` passe de `0` à `1` avec le paramètre, fiche complète retournée). Le revert-verify TU ci-dessus est la preuve de substitution disponible dans cet environnement.

## Test plan

- [x] `pnpm typecheck` — 0 erreur
- [x] `pnpm test` — 457 fichiers / 5859 tests, tous verts
- [x] `pnpm check:write` — lint + format propres
- [x] Revert-verify du TU de non-régression (RED sans le fix, GREEN avec)
- [ ] CI (typecheck/test/lint/format + a11y-gate)
- [ ] SonarCloud Quality Gate
