### PR TITLE
feat(company): #4194 — colonne pays de l'entreprise et mapping WEEZ

### DIFF
--- a/packages/app/drizzle/0050_shiny_the_hood.sql
+++ b/packages/app/drizzle/0050_shiny_the_hood.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "app_company" ADD COLUMN "country_code" varchar(5);--> statement-breakpoint
+ALTER TABLE "app_company" ADD COLUMN "country_label" varchar(255);--> statement-breakpoint
+--- Targeted backfill: only rows already proven French by their department get
+--- the FRANCE label. Blanket-labelling the table would stamp FRANCE onto the
+--- foreign companies already in base — precisely the population this column
+--- exists to identify — and the error would survive until the referent's next
+--- login. Rows without a department stay unknown and are repaired at the next
+--- Weez lookup.
+UPDATE "app_company" SET "country_label" = 'FRANCE' WHERE "department_code" IS NOT NULL AND "country_label" IS NULL;

--- a/packages/app/drizzle/meta/0050_snapshot.json
+++ b/packages/app/drizzle/meta/0050_snapshot.json
@@ -1,0 +1,3043 @@
+{
+	"id": "1aa318fe-3aa1-49b0-bf71-cb5a5be768c3",
+	"prevId": "9c689794-f88e-45e4-bdd3-b4edfd6085ce",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_admin_impersonation_event": {
+			"name": "app_admin_impersonation_event",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"admin_user_id": {
+					"name": "admin_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stopped_at": {
+					"name": "stopped_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"admin_impersonation_event_admin_started_idx": {
+					"name": "admin_impersonation_event_admin_started_idx",
+					"columns": [
+						{
+							"expression": "admin_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+					"name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_user",
+					"columnsFrom": ["admin_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_admin_impersonation_event_siren_app_company_siren_fk": {
+					"name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_campaign_deadline": {
+			"name": "app_campaign_deadline",
+			"schema": "",
+			"columns": {
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"gip_publication_date": {
+					"name": "gip_publication_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"campaign_start_date": {
+					"name": "campaign_start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public_data_release_date": {
+					"name": "public_data_release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"decl1_modification_deadline": {
+					"name": "decl1_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_justification_deadline": {
+					"name": "decl1_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_joint_evaluation_deadline": {
+					"name": "decl1_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_modification_deadline": {
+					"name": "decl2_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_justification_deadline": {
+					"name": "decl2_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_joint_evaluation_deadline": {
+					"name": "decl2_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_label": {
+					"name": "naf_label",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"department_code": {
+					"name": "department_code",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"department_label": {
+					"name": "department_label",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"country_code": {
+					"name": "country_code",
+					"type": "varchar(5)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"country_label": {
+					"name": "country_label",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"statut_diffusion": {
+					"name": "statut_diffusion",
+					"type": "varchar(1)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file": {
+			"name": "app_cse_opinion_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_id": {
+					"name": "file_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_file_declaration_idx": {
+					"name": "cse_opinion_file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_file_id_app_file_id_fk": {
+					"name": "app_cse_opinion_file_file_id_app_file_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_file",
+					"columnsFrom": ["file_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_file_decl_number_type_idx": {
+					"name": "cse_opinion_file_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_declaration_idx": {
+					"name": "cse_opinion_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_decl_number_type_idx": {
+					"name": "cse_opinion_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_lock": {
+			"name": "app_declaration_lock",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locked_by_user_id": {
+					"name": "locked_by_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locked_at": {
+					"name": "locked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_heartbeat_at": {
+					"name": "last_heartbeat_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"declaration_lock_declaration_id_unique": {
+					"name": "declaration_lock_declaration_id_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_lock_expires_at_idx": {
+					"name": "declaration_lock_expires_at_idx",
+					"columns": [
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_lock_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_lock_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_lock",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_lock_locked_by_user_id_app_user_id_fk": {
+					"name": "app_declaration_lock_locked_by_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_lock",
+					"tableTo": "app_user",
+					"columnsFrom": ["locked_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_status_history": {
+			"name": "app_declaration_status_history",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "declaration_event_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"round": {
+					"name": "round",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"decl_status_history_declaration_idx": {
+					"name": "decl_status_history_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_status_history_actor_user_id_app_user_id_fk": {
+					"name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_user",
+					"columnsFrom": ["actor_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_women": {
+					"name": "hourly_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_men": {
+					"name": "hourly_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_declaration_path_choice": {
+					"name": "first_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_path_choice": {
+					"name": "second_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_women": {
+					"name": "indicator_a_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_men": {
+					"name": "indicator_a_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_women": {
+					"name": "indicator_a_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_men": {
+					"name": "indicator_a_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_women": {
+					"name": "indicator_b_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_men": {
+					"name": "indicator_b_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_women": {
+					"name": "indicator_b_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_men": {
+					"name": "indicator_b_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_women": {
+					"name": "indicator_c_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_men": {
+					"name": "indicator_c_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_women": {
+					"name": "indicator_c_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_men": {
+					"name": "indicator_c_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_women": {
+					"name": "indicator_d_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_men": {
+					"name": "indicator_d_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_women": {
+					"name": "indicator_d_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_men": {
+					"name": "indicator_d_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_women": {
+					"name": "indicator_e_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_men": {
+					"name": "indicator_e_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold1": {
+					"name": "indicator_f_annual_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold2": {
+					"name": "indicator_f_annual_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold3": {
+					"name": "indicator_f_annual_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women1": {
+					"name": "indicator_f_annual_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women2": {
+					"name": "indicator_f_annual_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women3": {
+					"name": "indicator_f_annual_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women4": {
+					"name": "indicator_f_annual_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men1": {
+					"name": "indicator_f_annual_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men2": {
+					"name": "indicator_f_annual_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men3": {
+					"name": "indicator_f_annual_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men4": {
+					"name": "indicator_f_annual_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold1": {
+					"name": "indicator_f_hourly_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold2": {
+					"name": "indicator_f_hourly_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold3": {
+					"name": "indicator_f_hourly_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women1": {
+					"name": "indicator_f_hourly_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women2": {
+					"name": "indicator_f_hourly_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women3": {
+					"name": "indicator_f_hourly_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women4": {
+					"name": "indicator_f_hourly_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men1": {
+					"name": "indicator_f_hourly_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men2": {
+					"name": "indicator_f_hourly_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men3": {
+					"name": "indicator_f_hourly_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men4": {
+					"name": "indicator_f_hourly_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "declaration_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cse_required": {
+					"name": "cse_required",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"rules_version": {
+					"name": "rules_version",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'2027.1'"
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft": {
+					"name": "draft",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft_updated_at": {
+					"name": "draft_updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declarations_siren_year_active_unique": {
+					"name": "declarations_siren_year_active_unique",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "cancelled_at IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_siren_app_company_siren_fk": {
+					"name": "app_declaration_siren_app_company_siren_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_women_count": {
+					"name": "hourly_women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_men_count": {
+					"name": "hourly_men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_export": {
+			"name": "app_export",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'v1'"
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"s3_key": {
+					"name": "s3_key",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"row_count": {
+					"name": "row_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"export_year_version_idx": {
+					"name": "export_year_version_idx",
+					"nullsNotDistinct": false,
+					"columns": ["year", "version"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_file": {
+			"name": "app_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "file_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"file_declaration_idx": {
+					"name": "file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"file_joint_eval_unique": {
+					"name": "file_joint_eval_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"type\" = 'joint_evaluation'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_gip_mds_data": {
+			"name": "app_gip_mds_data",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"imported_at": {
+					"name": "imported_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_start": {
+					"name": "period_start",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_end": {
+					"name": "period_end",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_ema": {
+					"name": "workforce_ema",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_global": {
+					"name": "men_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_global": {
+					"name": "women_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_hourly_global": {
+					"name": "men_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_hourly_global": {
+					"name": "women_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_variable": {
+					"name": "men_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_variable": {
+					"name": "women_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_women": {
+					"name": "global_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_men": {
+					"name": "global_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_women": {
+					"name": "global_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_men": {
+					"name": "global_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_women": {
+					"name": "variable_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_men": {
+					"name": "variable_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_women": {
+					"name": "variable_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_men": {
+					"name": "variable_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_women": {
+					"name": "global_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_men": {
+					"name": "global_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_women": {
+					"name": "global_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_men": {
+					"name": "global_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_women": {
+					"name": "variable_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_men": {
+					"name": "variable_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_women": {
+					"name": "variable_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_men": {
+					"name": "variable_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold1": {
+					"name": "annual_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold2": {
+					"name": "annual_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold3": {
+					"name": "annual_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_women_count": {
+					"name": "annual_quartile1_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_women_count": {
+					"name": "annual_quartile2_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_women_count": {
+					"name": "annual_quartile3_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_women_count": {
+					"name": "annual_quartile4_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_men_count": {
+					"name": "annual_quartile1_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_men_count": {
+					"name": "annual_quartile2_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_men_count": {
+					"name": "annual_quartile3_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_men_count": {
+					"name": "annual_quartile4_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold1": {
+					"name": "hourly_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold2": {
+					"name": "hourly_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold3": {
+					"name": "hourly_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_women_count": {
+					"name": "hourly_quartile1_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_women_count": {
+					"name": "hourly_quartile2_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_women_count": {
+					"name": "hourly_quartile3_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_women_count": {
+					"name": "hourly_quartile4_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_men_count": {
+					"name": "hourly_quartile1_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_men_count": {
+					"name": "hourly_quartile2_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_men_count": {
+					"name": "hourly_quartile3_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_men_count": {
+					"name": "hourly_quartile4_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_index": {
+					"name": "confidence_index",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_exotic_contracts": {
+					"name": "confidence_exotic_contracts",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_unit_measure": {
+					"name": "confidence_unit_measure",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_suspension_ratio": {
+					"name": "confidence_suspension_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_suspensions": {
+					"name": "confidence_long_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_end_suspensions": {
+					"name": "confidence_no_end_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_sick_leave_ratio": {
+					"name": "confidence_sick_leave_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_sick_leave": {
+					"name": "confidence_long_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_sick_leave": {
+					"name": "confidence_no_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota250": {
+					"name": "confidence_quota250",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota0": {
+					"name": "confidence_quota0",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_multi_year": {
+					"name": "confidence_multi_year",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_fp_ratio": {
+					"name": "confidence_fp_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_remuneration": {
+					"name": "confidence_extreme_remuneration",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_rate": {
+					"name": "confidence_extreme_rate",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gip_mds_data_siren_idx": {
+					"name": "gip_mds_data_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_gip_mds_data_siren_app_company_siren_fk": {
+					"name": "app_gip_mds_data_siren_app_company_siren_fk",
+					"tableFrom": "app_gip_mds_data",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_gip_mds_data_siren_year_pk": {
+					"name": "app_gip_mds_data_siren_year_pk",
+					"columns": ["siren", "year"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_global_setting": {
+			"name": "app_global_setting",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"default": 1
+				},
+				"active_campaign_year": {
+					"name": "active_campaign_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"declaration_lock_timeout_minutes": {
+					"name": "declaration_lock_timeout_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 30
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_global_setting_updated_by_app_user_id_fk": {
+					"name": "app_global_setting_updated_by_app_user_id_fk",
+					"tableFrom": "app_global_setting",
+					"tableTo": "app_user",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_referent": {
+			"name": "app_referent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"county": {
+					"name": "county",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "referent_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"principal": {
+					"name": "principal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"substitute_name": {
+					"name": "substitute_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"substitute_email": {
+					"name": "substitute_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"referent_region_idx": {
+					"name": "referent_region_idx",
+					"columns": [
+						{
+							"expression": "region",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_representation_campaign": {
+			"name": "app_representation_campaign",
+			"schema": "",
+			"columns": {
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"campaign_start_date": {
+					"name": "campaign_start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"campaign_end_date": {
+					"name": "campaign_end_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_deadline": {
+					"name": "declaration_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_representation_declaration": {
+			"name": "app_representation_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"legacy_declarant": {
+					"name": "legacy_declarant",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"imported_from_v1_at": {
+					"name": "imported_from_v1_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_period_start": {
+					"name": "reference_period_start",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_period_end": {
+					"name": "reference_period_end",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"executive_women_percent": {
+					"name": "executive_women_percent",
+					"type": "numeric(5, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"executive_men_percent": {
+					"name": "executive_men_percent",
+					"type": "numeric(5, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"not_computable_reason_executives": {
+					"name": "not_computable_reason_executives",
+					"type": "representation_not_computable_executives",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"member_women_percent": {
+					"name": "member_women_percent",
+					"type": "numeric(5, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"member_men_percent": {
+					"name": "member_men_percent",
+					"type": "numeric(5, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"not_computable_reason_members": {
+					"name": "not_computable_reason_members",
+					"type": "representation_not_computable_members",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"publish_date": {
+					"name": "publish_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"publish_url": {
+					"name": "publish_url",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"publish_modalities": {
+					"name": "publish_modalities",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "representation_declaration_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"submitted_at": {
+					"name": "submitted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft": {
+					"name": "draft",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft_updated_at": {
+					"name": "draft_updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"representation_declaration_siren_year_unique": {
+					"name": "representation_declaration_siren_year_unique",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"representation_declaration_declarant_idx": {
+					"name": "representation_declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_representation_declaration_siren_app_company_siren_fk": {
+					"name": "app_representation_declaration_siren_app_company_siren_fk",
+					"tableFrom": "app_representation_declaration",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_representation_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_representation_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_representation_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_admin": {
+					"name": "is_admin",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"audit.action_log": {
+			"name": "action_log",
+			"schema": "audit",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_email": {
+					"name": "user_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action": {
+					"name": "action",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_type": {
+					"name": "resource_type",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "varchar(45)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"action_log_created_at_idx": {
+					"name": "action_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_user_idx": {
+					"name": "action_log_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_siren_idx": {
+					"name": "action_log_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_action_idx": {
+					"name": "action_log_action_idx",
+					"columns": [
+						{
+							"expression": "action",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_category_created_at_idx": {
+					"name": "action_log_category_created_at_idx",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.compliance_path": {
+			"name": "compliance_path",
+			"schema": "public",
+			"values": ["justify", "corrective_action", "joint_evaluation"]
+		},
+		"public.declaration_event_type": {
+			"name": "declaration_event_type",
+			"schema": "public",
+			"values": [
+				"submit",
+				"path_choice",
+				"second_declaration_submit",
+				"joint_evaluation_submit",
+				"cse_opinion_submit",
+				"cancel",
+				"demarche_complete",
+				"step_change"
+			]
+		},
+		"public.declaration_status": {
+			"name": "declaration_status",
+			"schema": "public",
+			"values": [
+				"draft",
+				"awaiting_compliance_path_choice",
+				"corrective_actions_chosen",
+				"joint_evaluation_chosen",
+				"awaiting_revision_choice",
+				"revised_joint_evaluation_chosen",
+				"awaiting_cse_opinion",
+				"demarche_completed"
+			]
+		},
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		},
+		"public.file_type": {
+			"name": "file_type",
+			"schema": "public",
+			"values": ["cse_opinion", "joint_evaluation"]
+		},
+		"public.referent_type": {
+			"name": "referent_type",
+			"schema": "public",
+			"values": ["email", "url"]
+		},
+		"public.representation_declaration_status": {
+			"name": "representation_declaration_status",
+			"schema": "public",
+			"values": ["draft", "submitted", "not_subject"]
+		},
+		"public.representation_not_computable_executives": {
+			"name": "representation_not_computable_executives",
+			"schema": "public",
+			"values": ["aucun_cadre_dirigeant", "un_seul_cadre_dirigeant"]
+		},
+		"public.representation_not_computable_members": {
+			"name": "representation_not_computable_members",
+			"schema": "public",
+			"values": ["aucune_instance_dirigeante"]
+		}
+	},
+	"schemas": {
+		"audit": "audit"
+	},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
 			"when": 1787833039307,
 			"tag": "0049_fluffy_hercules",
 			"breakpoints": true
+		},
+		{
+			"idx": 50,
+			"version": "7",
+			"when": 1787918177718,
+			"tag": "0050_shiny_the_hood",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/app/src/server/api/routers/__tests__/admin.searchCompany.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/admin.searchCompany.test.ts
@@ -15,6 +15,8 @@ const WEEZ_COMPANY = {
 	region: null,
 	departmentCode: null,
 	departmentLabel: null,
+	countryCode: null,
+	countryLabel: "FRANCE",
 	// Weez/INSEE headcount, deliberately far from the GIP one.
 	workforce: 500,
 	statutDiffusion: null,

--- a/packages/app/src/server/api/routers/__tests__/company.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.test.ts
@@ -351,6 +351,8 @@ describe("findUserCompany NAF label enrichment", () => {
 			region: null,
 			departmentCode: null,
 			departmentLabel: null,
+			countryCode: null,
+			countryLabel: "FRANCE",
 			workforce: 100,
 			statutDiffusion: null,
 		});

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -11,6 +11,7 @@ import { devLoginSchema } from "~/modules/login/schemas";
 import { logAction } from "~/server/audit/log";
 import { buildRequestContext, toHeaders } from "~/server/audit/requestContext";
 import { db } from "~/server/db";
+import { toCompanyInsertValues } from "~/server/db/companyInsert";
 import {
 	adminImpersonationEvents,
 	companies,
@@ -420,36 +421,14 @@ export const authConfig = {
 				if (profileData.siret) {
 					const siren = extractSiren(profileData.siret);
 
-					let companyValues: {
-						siren: string;
-						name: string;
-						address?: string | null;
-						nafCode?: string | null;
-						nafLabel?: string | null;
-						region?: string | null;
-						departmentCode?: string | null;
-						departmentLabel?: string | null;
-						workforce?: number | null;
-						statutDiffusion?: string | null;
-					};
+					let companyValues: ReturnType<typeof toCompanyInsertValues>;
 					try {
-						const companyInfo = await fetchCompanyBySiren(siren);
-						companyValues = companyInfo
-							? {
-									siren,
-									name: companyInfo.name,
-									address: companyInfo.address,
-									nafCode: companyInfo.nafCode,
-									nafLabel: companyInfo.nafLabel,
-									region: companyInfo.region,
-									departmentCode: companyInfo.departmentCode,
-									departmentLabel: companyInfo.departmentLabel,
-									workforce: companyInfo.workforce,
-									statutDiffusion: companyInfo.statutDiffusion,
-								}
-							: { siren, name: `Entreprise ${siren}` };
+						companyValues = toCompanyInsertValues(
+							siren,
+							await fetchCompanyBySiren(siren),
+						);
 					} catch {
-						companyValues = { siren, name: `Entreprise ${siren}` };
+						companyValues = toCompanyInsertValues(siren, null);
 					}
 
 					await db.transaction(async (tx) => {

--- a/packages/app/src/server/db/__tests__/companyInsert.test.ts
+++ b/packages/app/src/server/db/__tests__/companyInsert.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { toCompanyInsertValues } from "../companyInsert";
+
+describe("toCompanyInsertValues", () => {
+	const COMPANY_INFO = {
+		name: "Alpha Solutions",
+		address: "12 RUE DES INNOVATEURS, 75011 PARIS",
+		nafCode: "6202A",
+		nafLabel: "Conseil en systèmes et logiciels informatiques",
+		region: "Île-de-France",
+		departmentCode: "75",
+		departmentLabel: "Paris",
+		countryCode: null,
+		countryLabel: "FRANCE",
+		workforce: 256,
+		statutDiffusion: "O",
+	};
+
+	it("carries every lookup field onto the insert shape, country included", () => {
+		expect(toCompanyInsertValues("532847196", COMPANY_INFO)).toEqual({
+			siren: "532847196",
+			...COMPANY_INFO,
+		});
+	});
+
+	it("carries a foreign country onto the insert shape", () => {
+		expect(
+			toCompanyInsertValues("987654321", {
+				...COMPANY_INFO,
+				countryCode: "99248",
+				countryLabel: "QATAR",
+			}),
+		).toMatchObject({ countryCode: "99248", countryLabel: "QATAR" });
+	});
+
+	it("falls back to a bare placeholder row when the lookup found nothing", () => {
+		expect(toCompanyInsertValues("532847196", null)).toEqual({
+			siren: "532847196",
+			name: "Entreprise 532847196",
+		});
+	});
+});

--- a/packages/app/src/server/db/__tests__/companyLocation.integration.test.ts
+++ b/packages/app/src/server/db/__tests__/companyLocation.integration.test.ts
@@ -1,16 +1,17 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { env } from "~/env.js";
 import { db } from "~/server/db";
 import { companies } from "~/server/db/schema";
 
-describe("app_company region/department persistence (real Postgres)", () => {
+describe("app_company region/department/country persistence (real Postgres)", () => {
 	let sql!: ReturnType<typeof postgres>;
 
 	const SIREN_DIFFUSIBLE = "700000001";
 	const SIREN_NON_DIFFUSIBLE = "700000002";
-	const SIRENS = [SIREN_DIFFUSIBLE, SIREN_NON_DIFFUSIBLE];
+	const SIREN_ETRANGER = "700000003";
+	const SIRENS = [SIREN_DIFFUSIBLE, SIREN_NON_DIFFUSIBLE, SIREN_ETRANGER];
 
 	async function cleanup() {
 		await sql`DELETE FROM app_company WHERE siren IN ${sql(SIRENS)}`;
@@ -57,10 +58,12 @@ describe("app_company region/department persistence (real Postgres)", () => {
 			region: "Nouvelle-Aquitaine",
 			departmentCode: "33",
 			departmentLabel: "Gironde",
+			countryCode: null,
+			countryLabel: "FRANCE",
 		});
 
 		const [raw] = await sql`
-			SELECT region, department_code, department_label
+			SELECT region, department_code, department_label, country_code, country_label
 			FROM app_company
 			WHERE siren = ${SIREN_DIFFUSIBLE}
 		`;
@@ -69,6 +72,115 @@ describe("app_company region/department persistence (real Postgres)", () => {
 			region: "Nouvelle-Aquitaine",
 			department_code: "33",
 			department_label: "Gironde",
+			country_code: null,
+			country_label: "FRANCE",
+		});
+	});
+
+	it("round-trips a foreign country on its own columns (S5)", async () => {
+		await db.insert(companies).values({
+			siren: SIREN_ETRANGER,
+			name: "Gamma Holding",
+			countryCode: "99248",
+			countryLabel: "QATAR",
+		});
+
+		const [row] = await db
+			.select()
+			.from(companies)
+			.where(eq(companies.siren, SIREN_ETRANGER));
+
+		expect(row).toMatchObject({
+			region: null,
+			departmentCode: null,
+			countryCode: "99248",
+			countryLabel: "QATAR",
+		});
+	});
+
+	it("upserts the country on conflict, replacing an unknown by a resolved one (S5)", async () => {
+		await db.insert(companies).values({
+			siren: SIREN_ETRANGER,
+			name: "Gamma Holding",
+		});
+
+		const enriched = {
+			siren: SIREN_ETRANGER,
+			name: "Gamma Holding",
+			countryCode: "99248",
+			countryLabel: "QATAR",
+		};
+		await db
+			.insert(companies)
+			.values(enriched)
+			.onConflictDoUpdate({
+				target: companies.siren,
+				set: { ...enriched, updatedAt: new Date() },
+			});
+
+		const [row] = await db
+			.select()
+			.from(companies)
+			.where(eq(companies.siren, SIREN_ETRANGER));
+
+		expect(row).toMatchObject({
+			countryCode: "99248",
+			countryLabel: "QATAR",
+		});
+	});
+
+	it("keeps the country filled while address is null (non-diffusible, S4)", async () => {
+		await db.insert(companies).values({
+			siren: SIREN_NON_DIFFUSIBLE,
+			name: "Entreprise non diffusible",
+			address: null,
+			departmentCode: "33",
+			countryLabel: "FRANCE",
+		});
+
+		const [row] = await db
+			.select()
+			.from(companies)
+			.where(eq(companies.siren, SIREN_NON_DIFFUSIBLE));
+
+		expect(row?.address).toBeNull();
+		expect(row).toMatchObject({ countryCode: null, countryLabel: "FRANCE" });
+	});
+
+	it("keeps France and unknown apart on the tri-state columns (S6)", async () => {
+		// The backfill of migration 0050 labels FRANCE only where a department
+		// proves the row French. Replayed here on two fresh rows: a blanket
+		// UPDATE would stamp FRANCE onto the foreign row too.
+		await db.insert(companies).values([
+			{
+				siren: SIREN_DIFFUSIBLE,
+				name: "Alpha Solutions",
+				departmentCode: "75",
+			},
+			{ siren: SIREN_ETRANGER, name: "Gamma Holding", departmentCode: null },
+		]);
+
+		await sql`
+			UPDATE app_company
+			SET country_label = 'FRANCE'
+			WHERE department_code IS NOT NULL
+				AND country_label IS NULL
+				AND siren IN ${sql(SIRENS)}
+		`;
+
+		const rows = await db
+			.select()
+			.from(companies)
+			.where(inArray(companies.siren, [SIREN_DIFFUSIBLE, SIREN_ETRANGER]));
+		const bySiren = new Map(rows.map((r) => [r.siren, r]));
+
+		expect(bySiren.get(SIREN_DIFFUSIBLE)).toMatchObject({
+			countryCode: null,
+			countryLabel: "FRANCE",
+		});
+		expect(bySiren.get(SIREN_ETRANGER)).toMatchObject({
+			countryCode: null,
+			countryLabel: null,
 		});
 	});
 
@@ -143,6 +255,8 @@ describe("app_company region/department persistence (real Postgres)", () => {
 			region: null,
 			departmentCode: null,
 			departmentLabel: null,
+			countryCode: null,
+			countryLabel: null,
 		});
 	});
 });

--- a/packages/app/src/server/db/companyInsert.ts
+++ b/packages/app/src/server/db/companyInsert.ts
@@ -1,0 +1,32 @@
+import type { companies } from "~/server/db/schema";
+import type { CompanyInfo } from "~/server/services/weez";
+
+/**
+ * Maps a Weez lookup onto the `companies` insert shape, for the two paths that
+ * persist it: the ProConnect login and the GIP-MDS import.
+ *
+ * Single point on purpose. Both paths used to copy the fields one by one, so a
+ * new column stayed silently empty in production unless every copy was updated
+ * in the same change.
+ */
+export function toCompanyInsertValues(
+	siren: string,
+	info: CompanyInfo | null,
+): typeof companies.$inferInsert {
+	if (!info) return { siren, name: `Entreprise ${siren}` };
+
+	return {
+		siren,
+		name: info.name,
+		address: info.address,
+		nafCode: info.nafCode,
+		nafLabel: info.nafLabel,
+		region: info.region,
+		departmentCode: info.departmentCode,
+		departmentLabel: info.departmentLabel,
+		countryCode: info.countryCode,
+		countryLabel: info.countryLabel,
+		workforce: info.workforce,
+		statutDiffusion: info.statutDiffusion,
+	};
+}

--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -130,6 +130,10 @@ export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
 		region: "Weez: libellé région (dérivé du code postal établissement)",
 		department_code: "Weez: code département (dérivé du code postal)",
 		department_label: "Weez: libellé département (dérivé du code postal)",
+		country_code:
+			"Weez: code pays COG INSEE du siège (codepaysetrangeretablissement). null pour la France comme pour un pays inconnu — c'est country_label qui distingue les deux",
+		country_label:
+			"Weez: libellé du pays du siège, en capitales (libellepaysetrangeretablissement). 'FRANCE' si l'unité légale porte un code postal, null si le pays n'a pas pu être résolu",
 		has_cse: "SUIT: CSE_existant",
 	},
 	user: {

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -532,6 +532,10 @@ export const companies = createTable("company", (d) => ({
 	region: d.varchar({ length: 255 }),
 	departmentCode: d.varchar({ length: 3 }),
 	departmentLabel: d.varchar({ length: 255 }),
+	// Tri-state country, never collapsed: France = (null, "FRANCE"),
+	// abroad = (COG code, Weez label), unknown = (null, null).
+	countryCode: d.varchar({ length: 5 }),
+	countryLabel: d.varchar({ length: 255 }),
 	workforce: d.integer(),
 	hasCse: d.boolean(),
 	statutDiffusion: d.varchar({ length: 1 }),

--- a/packages/app/src/server/services/__tests__/weez.test.ts
+++ b/packages/app/src/server/services/__tests__/weez.test.ts
@@ -22,12 +22,65 @@ describe("fetchCompanyBySiren", () => {
 	const fetchSpy = vi.fn();
 
 	beforeEach(() => {
+		// The spy is shared across the describe: without a reset it keeps the
+		// previous test's call history and queued responses, and any assertion
+		// on a call index silently reads the wrong request.
+		fetchSpy.mockReset();
 		vi.stubGlobal("fetch", fetchSpy);
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
+
+	/**
+	 * Queues the head-office response of the conditional second call. Only a
+	 * legal unit without a postal code triggers it.
+	 */
+	function mockHeadOffice(establishment: unknown) {
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			json: async () => establishment,
+		});
+	}
+
+	const NO_COUNTRY = {
+		codepaysetrangeretablissement: null,
+		libellepaysetrangeretablissement: null,
+	};
+
+	/** Queues the legal-unit response of the first call. */
+	function mockLegalUnit(entity: {
+		siren: string;
+		codepostal: string | null;
+		name?: string;
+		statutdiffusionunitelegale?: string;
+	}) {
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				content: [
+					{
+						siren: entity.siren,
+						denominationunitelegale: entity.name ?? "Alpha Solutions",
+						raisonsociale: null,
+						activiteprincipalenaf25unitelegale: "6202A",
+						nomenclatureactiviteprincipalelibelleunitelegale:
+							"Conseil en systèmes et logiciels informatiques",
+						effectiftotal: 256,
+						numerovoie: "12",
+						typevoie: "RUE",
+						libellevoie: "DES INNOVATEURS",
+						codepostal: entity.codepostal,
+						libellecommune: entity.codepostal ? "PARIS" : null,
+						statutdiffusionunitelegale:
+							entity.statutdiffusionunitelegale ?? "O",
+					},
+				],
+				totalElements: 1,
+			}),
+		});
+	}
 
 	it("returns company info for a diffusible company", async () => {
 		fetchSpy.mockResolvedValueOnce({
@@ -64,6 +117,8 @@ describe("fetchCompanyBySiren", () => {
 			region: "Île-de-France",
 			departmentCode: "75",
 			departmentLabel: "Paris",
+			countryCode: null,
+			countryLabel: "FRANCE",
 			workforce: 256,
 			statutDiffusion: "O",
 		});
@@ -97,6 +152,7 @@ describe("fetchCompanyBySiren", () => {
 				totalElements: 1,
 			}),
 		});
+		mockHeadOffice(NO_COUNTRY);
 
 		const result = await fetchCompanyBySiren("111222333");
 
@@ -108,6 +164,8 @@ describe("fetchCompanyBySiren", () => {
 			region: null,
 			departmentCode: null,
 			departmentLabel: null,
+			countryCode: null,
+			countryLabel: null,
 			workforce: 50,
 			statutDiffusion: "N",
 		});
@@ -147,6 +205,8 @@ describe("fetchCompanyBySiren", () => {
 			region: "Nouvelle-Aquitaine",
 			departmentCode: "33",
 			departmentLabel: "Gironde",
+			countryCode: null,
+			countryLabel: "FRANCE",
 			workforce: 50,
 			statutDiffusion: "N",
 		});
@@ -176,6 +236,8 @@ describe("fetchCompanyBySiren", () => {
 				totalElements: 1,
 			}),
 		});
+
+		mockHeadOffice(NO_COUNTRY);
 
 		const result = await fetchCompanyBySiren("222333444");
 
@@ -239,6 +301,8 @@ describe("fetchCompanyBySiren", () => {
 				totalElements: 1,
 			}),
 		});
+
+		mockHeadOffice(NO_COUNTRY);
 
 		const result = await fetchCompanyBySiren("451678973");
 
@@ -306,6 +370,8 @@ describe("fetchCompanyBySiren", () => {
 			region: "Auvergne-Rhône-Alpes",
 			departmentCode: "69",
 			departmentLabel: "Rhône",
+			countryCode: null,
+			countryLabel: "FRANCE",
 			workforce: null,
 			statutDiffusion: "O",
 		});
@@ -375,8 +441,137 @@ describe("fetchCompanyBySiren", () => {
 			region: "Nouvelle-Aquitaine",
 			departmentCode: "33",
 			departmentLabel: "Gironde",
+			countryCode: null,
+			countryLabel: "FRANCE",
 			workforce: 12,
 			statutDiffusion: "O",
+		});
+	});
+
+	it("resolves FRANCE without calling the head office when a postal code is present (S1)", async () => {
+		mockLegalUnit({ siren: "532847196", codepostal: "75011" });
+
+		const result = await fetchCompanyBySiren("532847196");
+
+		expect(result).toMatchObject({ countryCode: null, countryLabel: "FRANCE" });
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("reads the country off the head office when the legal unit has no postal code (S2)", async () => {
+		mockLegalUnit({ siren: "987654321", codepostal: null });
+		mockHeadOffice({
+			codepaysetrangeretablissement: "99248",
+			libellepaysetrangeretablissement: "QATAR",
+		});
+
+		const result = await fetchCompanyBySiren("987654321");
+
+		expect(result).toMatchObject({
+			countryCode: "99248",
+			countryLabel: "QATAR",
+		});
+
+		const headOfficeUrl = fetchSpy.mock.calls[1]?.[0] as URL;
+		expect(headOfficeUrl.href).toContain(
+			"/public/v3/unitelegale/etablissementsiege",
+		);
+		expect(headOfficeUrl.searchParams.get("siren")).toBe("987654321");
+	});
+
+	it("reads the country off a paginated head-office envelope (S2)", async () => {
+		mockLegalUnit({ siren: "987654321", codepostal: null });
+		mockHeadOffice({
+			content: [
+				{
+					codepaysetrangeretablissement: "99248",
+					libellepaysetrangeretablissement: "QATAR",
+				},
+			],
+		});
+
+		const result = await fetchCompanyBySiren("987654321");
+
+		expect(result).toMatchObject({
+			countryCode: "99248",
+			countryLabel: "QATAR",
+		});
+	});
+
+	it("leaves the country unknown when the head-office call fails, without breaking the lookup (S3)", async () => {
+		mockLegalUnit({ siren: "987654321", codepostal: null, name: "Gamma SARL" });
+		fetchSpy.mockRejectedValueOnce(new Error("network down"));
+
+		const result = await fetchCompanyBySiren("987654321");
+
+		expect(result).toMatchObject({
+			name: "Gamma SARL",
+			countryCode: null,
+			countryLabel: null,
+		});
+	});
+
+	it("leaves the country unknown when the head office answers with an error status (S3)", async () => {
+		mockLegalUnit({ siren: "987654321", codepostal: null });
+		fetchSpy.mockResolvedValueOnce({
+			ok: false,
+			status: 503,
+			statusText: "Service Unavailable",
+		});
+
+		const result = await fetchCompanyBySiren("987654321");
+
+		expect(result).toMatchObject({ countryCode: null, countryLabel: null });
+	});
+
+	it("leaves the country unknown when the head office carries no country (S3)", async () => {
+		mockLegalUnit({ siren: "987654321", codepostal: null });
+		mockHeadOffice(NO_COUNTRY);
+
+		const result = await fetchCompanyBySiren("987654321");
+
+		expect(result).toMatchObject({ countryCode: null, countryLabel: null });
+	});
+
+	it("leaves the country unknown when the head office answers with no row at all (S3)", async () => {
+		mockLegalUnit({ siren: "987654321", codepostal: null });
+		mockHeadOffice(null);
+
+		const result = await fetchCompanyBySiren("987654321");
+
+		expect(result).toMatchObject({ countryCode: null, countryLabel: null });
+	});
+
+	it.each([
+		["a code without a label", "99248", null],
+		["a label without a code", null, "QATAR"],
+	])("leaves the country unknown rather than half-filled when the head office returns %s (S3)", async (_case, code, label) => {
+		mockLegalUnit({ siren: "987654321", codepostal: null });
+		mockHeadOffice({
+			codepaysetrangeretablissement: code,
+			libellepaysetrangeretablissement: label,
+		});
+
+		const result = await fetchCompanyBySiren("987654321");
+
+		expect(result).toMatchObject({ countryCode: null, countryLabel: null });
+	});
+
+	it("keeps FRANCE on a non-diffusible company while address and NAF stay masked (S4)", async () => {
+		mockLegalUnit({
+			siren: "111222333",
+			codepostal: "33000",
+			statutdiffusionunitelegale: "N",
+		});
+
+		const result = await fetchCompanyBySiren("111222333");
+
+		expect(result).toMatchObject({
+			address: null,
+			nafCode: null,
+			nafLabel: null,
+			departmentCode: "33",
+			countryCode: null,
+			countryLabel: "FRANCE",
 		});
 	});
 });

--- a/packages/app/src/server/services/__tests__/weez.test.ts
+++ b/packages/app/src/server/services/__tests__/weez.test.ts
@@ -556,6 +556,31 @@ describe("fetchCompanyBySiren", () => {
 		expect(result).toMatchObject({ countryCode: null, countryLabel: null });
 	});
 
+	it("drops an over-long country code rather than truncating it into another country", async () => {
+		mockLegalUnit({ siren: "987654321", codepostal: null });
+		mockHeadOffice({
+			codepaysetrangeretablissement: "992480",
+			libellepaysetrangeretablissement: "QATAR",
+		});
+
+		const result = await fetchCompanyBySiren("987654321");
+
+		expect(result).toMatchObject({ countryCode: null, countryLabel: null });
+	});
+
+	it("clamps an over-long country label to the column width", async () => {
+		mockLegalUnit({ siren: "987654321", codepostal: null });
+		mockHeadOffice({
+			codepaysetrangeretablissement: "99248",
+			libellepaysetrangeretablissement: "Q".repeat(300),
+		});
+
+		const result = await fetchCompanyBySiren("987654321");
+
+		expect(result?.countryCode).toBe("99248");
+		expect(result?.countryLabel).toBe("Q".repeat(255));
+	});
+
 	it("keeps FRANCE on a non-diffusible company while address and NAF stay masked (S4)", async () => {
 		mockLegalUnit({
 			siren: "111222333",

--- a/packages/app/src/server/services/gipMds.ts
+++ b/packages/app/src/server/services/gipMds.ts
@@ -4,6 +4,7 @@ import { eq, inArray } from "drizzle-orm";
 import type { GipMdsRow } from "~/modules/declaration-remuneration/shared/gipMdsMapping";
 import { CSV_TO_SCHEMA_MAP } from "~/modules/declaration-remuneration/shared/gipMdsMapping";
 import type { DB } from "~/server/db";
+import { toCompanyInsertValues } from "~/server/db/companyInsert";
 import { campaignDeadlines, companies, gipMdsData } from "~/server/db/schema";
 import { reconcileCseRequirementForYear } from "./cseRequirementSync";
 import { suitAwareFetch } from "./suitClient";
@@ -180,18 +181,7 @@ async function ensureCompaniesExist(db: DB, sirens: string[]): Promise<void> {
 	await db.insert(companies).values(companyValues).onConflictDoNothing();
 }
 
-type CompanyInsert = {
-	siren: string;
-	name: string;
-	address?: string | null;
-	nafCode?: string | null;
-	nafLabel?: string | null;
-	region?: string | null;
-	departmentCode?: string | null;
-	departmentLabel?: string | null;
-	workforce?: number | null;
-	statutDiffusion?: string | null;
-};
+type CompanyInsert = ReturnType<typeof toCompanyInsertValues>;
 
 async function fetchCompanyInfoBatch(
 	sirens: string[],
@@ -203,23 +193,9 @@ async function fetchCompanyInfoBatch(
 		const settled = await Promise.allSettled(
 			batch.map(async (siren) => {
 				try {
-					const info = await fetchCompanyBySiren(siren);
-					return info
-						? {
-								siren,
-								name: info.name,
-								address: info.address,
-								nafCode: info.nafCode,
-								nafLabel: info.nafLabel,
-								region: info.region,
-								departmentCode: info.departmentCode,
-								departmentLabel: info.departmentLabel,
-								workforce: info.workforce,
-								statutDiffusion: info.statutDiffusion,
-							}
-						: { siren, name: `Entreprise ${siren}` };
+					return toCompanyInsertValues(siren, await fetchCompanyBySiren(siren));
 				} catch {
-					return { siren, name: `Entreprise ${siren}` };
+					return toCompanyInsertValues(siren, null);
 				}
 			}),
 		);

--- a/packages/app/src/server/services/weez.ts
+++ b/packages/app/src/server/services/weez.ts
@@ -6,6 +6,9 @@ import { isCompanyDiffusible } from "~/modules/public-api";
 
 const NON_DIFFUSIBLE_NAME = "Entreprise non diffusible";
 
+const WEEZ_TIMEOUT_MS = 10_000;
+const TWENTY_FOUR_HOURS = 86_400;
+
 // INSEE "tranche d'effectif salarié" code → lower bound of the size band, used
 // as a workforce proxy when the registry exposes the band but not an exact
 // `effectiftotal` (the usual case for public administrations and many ETI/GE).
@@ -52,6 +55,15 @@ type WeezLegalEntity = {
 	statutdiffusionunitelegale: string | null;
 };
 
+// Head office of the legal unit, from `/public/v3/unitelegale/etablissementsiege`
+// (schema `EtabDocDtoV3`). INSEE carries the foreign-country fields on the
+// establishment only — `findbysiren` has no country key at all — and fills them
+// solely when the registered address is abroad.
+type WeezEstablishment = {
+	codepaysetrangeretablissement: string | null;
+	libellepaysetrangeretablissement: string | null;
+};
+
 type WeezPaginatedResponse<T> = {
 	content: T[];
 	pageNumber: number;
@@ -68,9 +80,19 @@ export type CompanyInfo = {
 	region: string | null;
 	departmentCode: string | null;
 	departmentLabel: string | null;
+	countryCode: string | null;
+	countryLabel: string | null;
 	workforce: number | null;
 	statutDiffusion: string | null;
 };
+
+/** France carries no COG code: the label alone marks the state. */
+const FRANCE_COUNTRY = { countryCode: null, countryLabel: "FRANCE" } as const;
+
+/** Neither France nor a known foreign country — repaired at the next refresh. */
+const UNKNOWN_COUNTRY = { countryCode: null, countryLabel: null } as const;
+
+type CompanyCountry = Pick<CompanyInfo, "countryCode" | "countryLabel">;
 
 function buildAddress(entity: WeezLegalEntity): string | null {
 	const streetParts = [
@@ -89,20 +111,89 @@ function buildAddress(entity: WeezLegalEntity): string | null {
 	return null;
 }
 
+function weezUrl(path: string, siren: string): URL {
+	const url = new URL(`${env.EGAPRO_WEEZ_API_URL.replace(/\/$/, "")}${path}`);
+	url.searchParams.set("siren", siren);
+	return url;
+}
+
+// The endpoint answers with the single head-office row. Both the bare object and
+// the paginated envelope used by the other v3 routes are accepted: reading only
+// one of the two shapes would leave the country column silently empty rather
+// than fail loudly.
+function readEstablishment(payload: unknown): WeezEstablishment | null {
+	if (!payload || typeof payload !== "object") return null;
+	const content = (payload as WeezPaginatedResponse<WeezEstablishment>).content;
+	if (Array.isArray(content)) return content[0] ?? null;
+	return payload as WeezEstablishment;
+}
+
+async function fetchHeadOffice(
+	siren: string,
+): Promise<WeezEstablishment | null> {
+	const response = await fetch(
+		weezUrl("/public/v3/unitelegale/etablissementsiege", siren),
+		{
+			headers: { Accept: "application/json" },
+			signal: AbortSignal.timeout(WEEZ_TIMEOUT_MS),
+			next: { revalidate: TWENTY_FOUR_HOURS },
+		},
+	);
+
+	if (!response.ok) {
+		throw new Error(
+			`Weez API error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return readEstablishment(await response.json());
+}
+
+/**
+ * Resolves the tri-state country of a legal unit.
+ *
+ * The postal code decides whether the second call is worth making — it never
+ * derives the value. A legal unit registered abroad carries neither postal code
+ * nor commune, and its country lives on the head office. `fetchCompanyBySiren`
+ * runs on every ProConnect login and in a loop over several thousand SIREN on
+ * the GIP-MDS import, so the extra request is spent only on that population.
+ *
+ * A failing or silent head office leaves the country unknown: it is never
+ * guessed as France, and it never breaks the main lookup.
+ */
+async function resolveCountry(
+	siren: string,
+	postalCode: string | null,
+): Promise<CompanyCountry> {
+	if (postalCode) return FRANCE_COUNTRY;
+
+	try {
+		const establishment = await fetchHeadOffice(siren);
+		const countryCode = establishment?.codepaysetrangeretablissement ?? null;
+		const countryLabel =
+			establishment?.libellepaysetrangeretablissement ?? null;
+
+		// Both halves or neither: a code without a label reads as an unnamed
+		// foreign country, and a label without a code is France-shaped. Either
+		// would break the tri-state for every consumer downstream.
+		if (!countryCode || !countryLabel) return UNKNOWN_COUNTRY;
+
+		return { countryCode, countryLabel };
+	} catch {
+		return UNKNOWN_COUNTRY;
+	}
+}
+
 export async function fetchCompanyBySiren(
 	siren: string,
 ): Promise<CompanyInfo | null> {
-	const baseUrl = env.EGAPRO_WEEZ_API_URL.replace(/\/$/, "");
-	const url = new URL(`${baseUrl}/public/v3/unitelegale/findbysiren`);
-	url.searchParams.set("siren", siren);
+	const url = weezUrl("/public/v3/unitelegale/findbysiren", siren);
 	url.searchParams.set("page", "0");
 	url.searchParams.set("inclure_non_diffusibles", "true");
 
-	const TWENTY_FOUR_HOURS = 86_400;
-
 	const response = await fetch(url, {
 		headers: { Accept: "application/json" },
-		signal: AbortSignal.timeout(10_000),
+		signal: AbortSignal.timeout(WEEZ_TIMEOUT_MS),
 		next: { revalidate: TWENTY_FOUR_HOURS },
 	});
 
@@ -124,6 +215,11 @@ export async function fetchCompanyBySiren(
 	// when `address` becomes null.
 	const location = getLocationFromPostalCode(entity.codepostal);
 
+	// Coarse geography, kept on non-diffusible units like region and department
+	// already are — and for a company registered abroad, those two are empty by
+	// construction, so masking the country would leave nothing at all.
+	const country = await resolveCountry(siren, entity.codepostal);
+
 	const statutDiffusion = entity.statutdiffusionunitelegale ?? null;
 
 	if (!isCompanyDiffusible(statutDiffusion)) {
@@ -138,6 +234,8 @@ export async function fetchCompanyBySiren(
 			region: location.region,
 			departmentCode: location.departmentCode,
 			departmentLabel: location.departmentLabel,
+			countryCode: country.countryCode,
+			countryLabel: country.countryLabel,
 			workforce:
 				entity.effectiftotal ??
 				trancheToWorkforce(entity.trancheeffectifsunitelegale),
@@ -159,6 +257,8 @@ export async function fetchCompanyBySiren(
 		region: location.region,
 		departmentCode: location.departmentCode,
 		departmentLabel: location.departmentLabel,
+		countryCode: country.countryCode,
+		countryLabel: country.countryLabel,
 		workforce:
 			entity.effectiftotal ??
 			trancheToWorkforce(entity.trancheeffectifsunitelegale),

--- a/packages/app/src/server/services/weez.ts
+++ b/packages/app/src/server/services/weez.ts
@@ -7,6 +7,12 @@ import { isCompanyDiffusible } from "~/modules/public-api";
 const NON_DIFFUSIBLE_NAME = "Entreprise non diffusible";
 
 const WEEZ_TIMEOUT_MS = 10_000;
+
+// Column widths of `companies.country_code` / `country_label`. The registry is
+// not bound by them, and neither insert path catches a Postgres overflow: one
+// over-long value would break a ProConnect login, or the whole GIP-MDS import.
+const COUNTRY_CODE_MAX_LENGTH = 5;
+const COUNTRY_LABEL_MAX_LENGTH = 255;
 const TWENTY_FOUR_HOURS = 86_400;
 
 // INSEE "tranche d'effectif salarié" code → lower bound of the size band, used
@@ -178,7 +184,16 @@ async function resolveCountry(
 		// would break the tri-state for every consumer downstream.
 		if (!countryCode || !countryLabel) return UNKNOWN_COUNTRY;
 
-		return { countryCode, countryLabel };
+		// An over-long code is dropped rather than truncated: the code is an
+		// identifier, and cutting it would persist a *different* country as
+		// authoritative data. The label is a display string, so it degrades the
+		// way `nafLabel` already does below.
+		if (countryCode.length > COUNTRY_CODE_MAX_LENGTH) return UNKNOWN_COUNTRY;
+
+		return {
+			countryCode,
+			countryLabel: countryLabel.slice(0, COUNTRY_LABEL_MAX_LENGTH),
+		};
 	} catch {
 		return UNKNOWN_COUNTRY;
 	}


### PR DESCRIPTION
Closes #4194

## Ce que fait cette PR

Ajoute le **pays de l'entreprise** — absent de la V2, régression V1 — sous forme de deux colonnes nullables sur `companies`, alimentées depuis le champ d'autorité du registre.

C'est la **donnée socle** attendue par #4279 (surfaces d'identité), #4195 / #4196 (fichiers publics) et #2753 (consultation publique) : une entreprise étrangère n'a ni région ni département, et le registre ne renvoie pour elle que la voie, sans commune ni code postal.

## Le pays vient du siège, pas de l'unité légale

`findbysiren` — l'endpoint déjà utilisé — **ne porte aucune clé pays**. Le pays est exposé par `/public/v3/unitelegale/etablissementsiege` (`libellepaysetrangeretablissement` / `codepaysetrangeretablissement`), renseigné uniquement quand l'adresse est à l'étranger.

**L'appel siège est conditionnel** : il n'a lieu que si l'unité légale ne porte pas de code postal. Le code postal *décide* de l'appel, il ne *dérive* jamais la valeur. `fetchCompanyBySiren` tourne à chaque login ProConnect et en boucle sur plusieurs milliers de SIREN à l'import GIP-MDS — la requête supplémentaire n'est dépensée que sur la population étrangère.

**Un échec du second appel ne casse jamais le lookup** et ne produit jamais un « France » deviné : la valeur reste inconnue et se répare au rafraîchissement suivant.

## Invariant tri-état

| État | `country_code` | `country_label` |
|---|---|---|
| France | `null` | `FRANCE` |
| Étranger | code COG INSEE | libellé WEEZ |
| Inconnu | `null` | `null` |

France et inconnu ne se confondent jamais — c'est ce qui permet à #4279 de masquer la ligne plutôt que d'afficher une adresse tronquée. Un siège qui ne renvoie qu'une moitié de la paire est traité comme inconnu plutôt que persisté à moitié : un code sans libellé serait un pays étranger sans nom, un libellé sans code serait « France » au sens du code.

## Les deux chemins d'écriture, et pourquoi le mapping est factorisé

`auth/config.ts` (login ProConnect) et `services/gipMds.ts` (import GIP-MDS) recopiaient `CompanyInfo` **champ par champ**, à l'identique. Ajouter une colonne sans les toucher aurait livré la colonne vide en production.

Le mapping vit désormais en un seul point, `server/db/companyInsert.ts` — module feuille, imports de type uniquement. La prochaine colonne n'en touchera qu'un.

## Backfill ciblé

Le backfill de la migration `0050` ne pose `FRANCE` que sur les lignes **déjà prouvées françaises par leur département**. Un `UPDATE` global aurait étiqueté « France » les entreprises étrangères déjà en base — précisément la population que cette colonne existe pour identifier — et l'erreur aurait survécu jusqu'au prochain login du référent.

## Non-diffusion

Le pays suit le régime de `region` / `department_code` / `department_label` (**conservé**), pas celui de l'adresse et du NAF (masqués) : c'est de la géographie grossière, pas de l'identité — et pour une entreprise étrangère, région et département étant vides par construction, le masquer ne laisserait rien.

## Vérification

- `pnpm typecheck` — vert
- `pnpm test` — **5871/5871**, 458 fichiers
- `pnpm test:integration` — les 9 cas de `companyLocation.integration.test.ts` verts, migration `0050` appliquée sur le Postgres local
- `pnpm lint:check` / `pnpm format:check` — verts

Scénarios de l'analyse couverts : **S1** (française, aucun appel siège émis — assertion sur le nombre d'appels), **S2** (étrangère, code + libellé), **S3** (siège en erreur / muet / sans ligne / à moitié rempli → inconnu, lookup intact), **S4** (non diffusible française → `FRANCE`, adresse et NAF masqués), **S5** (persistance et upsert sur les colonnes `snake_case`), **S6** (backfill : France et inconnu restent distincts).

`git diff origin/alpha -- drizzle/0050_shiny_the_hood.sql` ne contient que les deux `ADD COLUMN` générés par drizzle-kit et l'`UPDATE` de backfill commenté — aucun drift de schéma embarqué.

## Points pour la revue

- **Forme de la réponse `/etablissementsiege`** — l'URL WEEZ est un secret scellé, je n'ai pas pu rejouer l'appel depuis le worktree. Le contrat vient de l'investigation de l'analyse. `readEstablishment` accepte donc l'objet nu **et** l'enveloppe paginée des autres routes v3, pour qu'une nuance de contrat ne laisse pas la colonne silencieusement vide. Un relecteur ayant accès à l'API peut confirmer laquelle des deux formes est la bonne, et l'autre branche pourra tomber.
- **Conflit attendu avec #4277 (PR #4394)** — touche la même requête dans `fetchCompanyBySiren` et le même fichier de test. Une dizaine de lignes, codé sur `origin/alpha` comme convenu.
- Un échec d'intégration **pré-existant et hors périmètre** subsiste en local sur `declarationDraft.integration.test.ts` : il insère en SQL brut dans `app_declaration_lock` sans `id`, dont la valeur par défaut vit dans Drizzle (`$defaultFn`) et non en base. Fichier absent du diff.
