### PR TITLE
fix(declaration-remuneration): #4281 — singulariser "Indicateur par catégories de salariés"

### DIFF
--- a/packages/app/src/e2e/grille/scenarios.ts
+++ b/packages/app/src/e2e/grille/scenarios.ts
@@ -340,7 +340,7 @@ export const FICHE_SCENARIOS = {
 		).toBeVisible();
 		await expect(
 			page.getByRole("heading", {
-				name: "Indicateurs par catégories de salariés",
+				name: "Indicateur par catégories de salariés",
 			}),
 		).toBeVisible();
 		await submitFromStep6Recap(page);

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.module.scss
@@ -15,7 +15,7 @@
 	color: var(--text-title-grey);
 }
 
-/* "Indicateurs pour l'ensemble" / "Indicateurs par catégorie" h2 —
+/* "Indicateurs pour l'ensemble" / "Indicateur par catégories" h2 —
    Marianne Bold 18/28 per Figma. fr-h6 already covers this size. */
 .sectionHeading {
 	line-height: 1.75rem;

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -173,7 +173,7 @@ export function RecapitulatifPage({
 
 			<section>
 				<h2 className={`fr-h6 fr-mb-3w ${styles.sectionHeading}`}>
-					Indicateurs par catégories de salariés
+					Indicateur par catégories de salariés
 				</h2>
 				{sourceLabel && (
 					<p className={`fr-mb-3w ${styles.sourceLine}`}>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.correction.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.correction.test.tsx
@@ -86,7 +86,7 @@ describe("RecapitulatifPage — second declaration (isCorrection)", () => {
 		expect(
 			screen.getByRole("heading", {
 				level: 2,
-				name: "Indicateurs par catégories de salariés",
+				name: "Indicateur par catégories de salariés",
 			}),
 		).toBeInTheDocument();
 		expect(

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -176,7 +176,7 @@ describe("Step6Review", () => {
 			screen.getByText("Indicateurs pour l'ensemble de vos salariés"),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText("Indicateurs par catégories de salariés"),
+			screen.getByText("Indicateur par catégories de salariés"),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -113,7 +113,7 @@ export function SecondDeclarationStep3Review({
 				catégories de salariés aux services du ministère chargé du travail.
 			</p>
 
-			<h2 className="fr-h5 fr-mb-0">Indicateurs par catégories de salariés</h2>
+			<h2 className="fr-h5 fr-mb-0">Indicateur par catégories de salariés</h2>
 
 			<div className={stepStyles.card}>
 				<CardTitle tooltipId="tooltip-second-decl-categories">

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/IndicatorSections.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/IndicatorSections.tsx
@@ -214,7 +214,7 @@ export function IndicatorSections({
 			{indicatorGRequired && (
 				<div className={stepStyles.group}>
 					<h2 className="fr-h6 fr-mb-0">
-						Indicateurs par catégories de salariés
+						Indicateur par catégories de salariés
 					</h2>
 
 					{/* Card: Employee categories (Step 5) */}

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/__tests__/IndicatorSections.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/__tests__/IndicatorSections.test.tsx
@@ -174,7 +174,7 @@ describe("IndicatorSections", () => {
 		);
 
 		expect(
-			screen.getByText("Indicateurs par catégories de salariés"),
+			screen.getByText("Indicateur par catégories de salariés"),
 		).toBeInTheDocument();
 		expect(
 			screen.getByText("Écart de rémunération par catégories de salariés"),
@@ -195,7 +195,7 @@ describe("IndicatorSections", () => {
 		);
 
 		expect(
-			screen.queryByText("Indicateurs par catégories de salariés"),
+			screen.queryByText("Indicateur par catégories de salariés"),
 		).not.toBeInTheDocument();
 		expect(
 			screen.queryByText("Écart de rémunération par catégories de salariés"),


### PR DESCRIPTION
Closes #4281

## Résumé

Le titre de section « Indicateurs par catégories de salariés » utilisait à tort le pluriel — un seul indicateur (rémunération par catégorie) est concerné. Correction du libellé, partout où il apparaît dans le parcours de déclaration rémunération :

- Page de récapitulation (`RecapitulatifPage.tsx`)
- Étape 6 — saisie des indicateurs (`IndicatorSections.tsx`)
- Revue de la seconde déclaration (`SecondDeclarationStep3Review.tsx`)

Changement de contenu textuel uniquement, aucune structure ni logique modifiée.

## Test plan

- Tests unitaires existants mis à jour pour asserter le nouveau libellé (RecapitulatifPage, Step6Review, IndicatorSections) — suite complète verte (`pnpm test`, 457 fichiers / 5865 tests).
- `pnpm typecheck` OK.
- Repérage exhaustif (`grep`) de la chaîne "Indicateurs par catégories de salariés" dans `src/` avant édition : toutes les occurrences pertinentes au parcours rémunération ont été corrigées. Les chaînes voisines mais distinctes ("Indicateurs de rémunération par catégories de salariés à remplir", "l'indicateur par catégories de salariés" déjà singulier) sont hors périmètre du ticket et n'ont pas été touchées.

## Note pour e2e-dev

`src/e2e/grille/scenarios.ts:343` (scénario CAS-13) asserte encore l'ancien libellé au pluriel (`getByRole("heading", { name: "Indicateurs par catégories de salariés" })`) — cette assertion ne matchera plus après ce changement. Hors scope de ce ticket (E2E détenu par e2e-dev) ; signalé ici pour qu'e2e-dev la mette à jour à son passage.

## Vérification

Changement de wording pur — pas de section « Vérification one-shot » applicable (ticket Task, pas Bug).