### PR TITLE
ci: utiliser Opus 5 avec effort high pour les questions

### DIFF
--- a/.github/workflows/claude-question.yml
+++ b/.github/workflows/claude-question.yml
@@ -29,6 +29,8 @@ jobs:
           label_trigger: question
           show_full_output: true
           claude_args: >-
+            --model claude-opus-5
+            --effort high
             --max-turns 50
             --mcp-config '{"mcpServers":{"dsfr":{"command":"npx","args":["-y","dsfr-mcp"]}}}'
             --allowedTools "mcp__dsfr__list_components,mcp__dsfr__get_component_doc,mcp__dsfr__search_components,mcp__dsfr__search_icons,mcp__dsfr__get_color_tokens"


### PR DESCRIPTION
## Résumé

- épingle le workflow des issues `question` sur `claude-opus-5`
- configure explicitement l’effort `high`
- conserve les permissions, outils autorisés et limites existantes

## Vérifications

- parsing YAML
- actionlint
- revue indépendante du diff et des permissions