### PR TITLE
chore: mettre Ultra11y à jour vers 5.40.1

### DIFF
--- a/.claude/rules/rgaa.md
+++ b/.claude/rules/rgaa.md
@@ -11,7 +11,7 @@ Deux surfaces, et deux seulement.
 **La revue** — l'agent `rgaa-auditor` lance le skill **`review-a11y`** sur le code sous changement et rend son verdict. C'est tout ce qu'il fait : le skill cadre l'audit sur le diff, lance le moteur, réfute les faux positifs, tranche les critères de jugement depuis la source et nomme les critères de rendu comme risques résiduels. Le skill vient du plugin déclaré dans `.claude/settings.json` ; il s'installe une fois avec `claude plugin install ultra11y@ultra11y`. Le plugin apporte aussi un hook `PreToolUse` qui arrête un `git commit` / `git push` / `gh pr create` porteur de non-conformités — coupe-circuits `SKIP_A11Y=1` (une commande), `ULTRA11Y_HOOK=off` (une session), `"hook": { "failOn": "off" }` dans `.ultra11yrc.json` (le dépôt).
 
 **L'analyse** — `.github/workflows/a11y.yaml`, trois jobs portés par la même Action Ultra11y,
-épinglée à un commit immuable :
+épinglée à un tag de version explicite :
 
 | Job | Quand | Ce qu'il fait |
 |---|---|---|

--- a/.claude/rules/rgaa.md
+++ b/.claude/rules/rgaa.md
@@ -10,17 +10,18 @@ Deux surfaces, et deux seulement.
 
 **La revue** — l'agent `rgaa-auditor` lance le skill **`review-a11y`** sur le code sous changement et rend son verdict. C'est tout ce qu'il fait : le skill cadre l'audit sur le diff, lance le moteur, réfute les faux positifs, tranche les critères de jugement depuis la source et nomme les critères de rendu comme risques résiduels. Le skill vient du plugin déclaré dans `.claude/settings.json` ; il s'installe une fois avec `claude plugin install ultra11y@ultra11y`. Le plugin apporte aussi un hook `PreToolUse` qui arrête un `git commit` / `git push` / `gh pr create` porteur de non-conformités — coupe-circuits `SKIP_A11Y=1` (une commande), `ULTRA11Y_HOOK=off` (une session), `"hook": { "failOn": "off" }` dans `.ultra11yrc.json` (le dépôt).
 
-**L'analyse** — `.github/workflows/a11y.yaml`, trois jobs portés par `maxgfr/ultra11y@v5.x` :
+**L'analyse** — `.github/workflows/a11y.yaml`, trois jobs portés par la même Action Ultra11y,
+épinglée à un commit immuable :
 
 | Job | Quand | Ce qu'il fait |
 |---|---|---|
-| `a11y-gate` | **chaque PR** (bloquant) + cron/manuel (muet) | audit statique JSX/TSX de tout `src` — gratuit, quelques secondes, aucun modèle. **La seule gate du dispositif qui arrête un merge** (`fail-on: blocking`) : SARIF, annotations, commentaire sticky |
-| `a11y-pages` | cron hebdo (lundi 04:00 UTC) + manuel | balayage Playwright, critères décidés **au rendu**, rejeu du registre de verdicts, adjudication IA du reliquat. Non bloquant sur les constats ; bloquant sur une panne ou une grille incomplète |
+| `a11y-gate` | **chaque PR** (bloquant) | audit statique JSX/TSX de tout `src` — gratuit, quelques secondes, aucun navigateur et aucun modèle. **La seule gate du dispositif qui arrête un merge sur un constat** (`fail-on: blocking`) : SARIF, annotations, commentaire sticky |
+| `a11y-pages` | cron hebdo (lundi 04:00 UTC) + manuel | balayage Playwright, critères décidés **au rendu**, rejeu du registre, puis adjudication Opus high du reliquat par Claude CLI en lots. Non bloquant sur les constats ; bloquant sur une panne, un rendu absent ou une grille incomplète |
 | `a11y-bundle` | cron + manuel | fusionne le tout dans l'artefact `ultra11y-rgaa` |
 
 Ce que ça ne donne pas, et il faut le savoir : **une régression RGAA de rendu peut vivre jusqu'au prochain tick hebdo.** Ce qui la rattrape sur une PR est l'audit statique, qui ne voit pas la page rendue. C'est l'arbitrage, et c'est celui du coût.
 
-> Câblage complet, coûts mesurés, registre de verdicts, `undecidable.json`, décisions déjà tranchées (le runner CLI écarté, le cron plutôt que `push: alpha`), commandes locales et procédure de bump → **[`docs/accessibilite-ultra11y.md`](../../docs/accessibilite-ultra11y.md)**. À lire avant de toucher à `a11y.yaml` ou à la version d'ultra11y — plusieurs de ces choix ont déjà été faits, défaits, puis refaits.
+> Câblage complet, coûts mesurés, registre de verdicts, `undecidable.json`, runner CLI par lots, choix du cron plutôt que `push: alpha`, commandes locales et procédure de bump → **[`docs/accessibilite-ultra11y.md`](../../docs/accessibilite-ultra11y.md)**. À lire avant de toucher à `a11y.yaml` ou à la version d'ultra11y — plusieurs de ces choix ont déjà été faits, défaits, puis refaits.
 
 ## Ce qui n'est PAS le dispositif
 

--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -174,9 +174,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: ultra11y — audit RGAA statique
-        # v5.40.0 + correctifs de complétude/performance, épinglés au commit immuable en
-        # attendant la prochaine release Ultra11y.
-        uses: maxgfr/ultra11y@76a48723330461b2ee358858d759ae182f0a1381
+        # Tag de release explicite : garder les deux usages de l'Action sur la même version.
+        uses: maxgfr/ultra11y@v5.40.1
         with:
           working-directory: packages/app
           # `src` et NON `src/**/*.tsx` : l'Action interpole `paths` sans quotes dans bash,
@@ -434,8 +433,8 @@ jobs:
       # du code, ré-audit hors navigateur des instantanés, adjudication IA, rapport page par
       # page, crops de preuve, HTML.
       - name: ultra11y — audit, rapport page par page et adjudication
-        # Même commit immuable que la gate PR ; ne jamais laisser les deux tiers diverger.
-        uses: maxgfr/ultra11y@76a48723330461b2ee358858d759ae182f0a1381
+        # Même tag de release que la gate PR ; ne jamais laisser les deux tiers diverger.
+        uses: maxgfr/ultra11y@v5.40.1
         env:
           # Lu depuis l'ENV DU JOB, jamais depuis un input : c'est ce qui rend le tier
           # inoffensif sur une PR de fork, où les secrets ne sont pas exposés — il se

--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -16,11 +16,10 @@ name: "♿ Accessibilité (ultra11y RGAA)"
 #                           depuis `require-decided: pages`, une grille incomplète aussi.
 #   a11y-bundle  LIVRABLE — fusionne les parties en un seul artefact `ultra11y-rgaa`.
 #
-# Il n'y a plus de `a11y-report` hebdomadaire séparé, et plus de `schedule` du tout :
-# `a11y-pages` produit le même livrable AVEC le navigateur, sur le seul déclenchement manuel.
-# Ce qu'on perd en le supprimant, dit franchement : le plancher « sans docker, sans base, sans
-# navigateur » qui sortait un rapport daté même quand la stack tombait. C'est le prix du
-# livrable unique, et `require-sample` fait déjà rougir un balayage amputé.
+# Il n'y a plus de `a11y-report` hebdomadaire séparé : le `schedule` et le déclenchement manuel
+# lancent tous deux `a11y-pages`, qui produit le même livrable AVEC le navigateur. Le job statique
+# ne tourne plus une seconde fois sur ces événements : l'Action du tier rendu réaudite déjà tout
+# `src`, et le doublon ne renforçait aucune porte.
 #
 # Le tier LIGHTHOUSE (score a11y 100 %) reste dans lighthouse.yaml.
 #
@@ -165,6 +164,9 @@ permissions:
 jobs:
   a11y-gate:
     name: "RGAA · audit statique du code"
+    # Le run complet réaudite déjà tout `src` dans `a11y-pages`. Garder cette gate sur les PR
+    # seulement évite deux invocations identiques sur le cron et le dispatch.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -172,7 +174,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: ultra11y — audit RGAA statique
-        uses: maxgfr/ultra11y@v5.34.2
+        # v5.40.0 + correctifs de complétude/performance, épinglés au commit immuable en
+        # attendant la prochaine release Ultra11y.
+        uses: maxgfr/ultra11y@76a48723330461b2ee358858d759ae182f0a1381
         with:
           working-directory: packages/app
           # `src` et NON `src/**/*.tsx` : l'Action interpole `paths` sans quotes dans bash,
@@ -190,7 +194,14 @@ jobs:
           standard: rgaa
           lang: fr
           fail-on: blocking
-          # CETTE GATE PARLE SUR UNE PR, ET SE TAIT SUR LE RUN COMPLET.
+          # Une PR reste strictement statique : aucun navigateur, aucun modèle et aucune
+          # prétention de complétude sur les critères qui exigent le rendu ou le jugement.
+          adjudicate: none
+          ledger: "false"
+          pages-report: "false"
+          require-decided: "false"
+          require-rendered: "false"
+          # CETTE GATE N'EXISTE QUE SUR UNE PR.
           #
           # Elle avait été rendue muette parce qu'elle commentait et uploadait EN MÊME TEMPS que
           # `a11y-pages` : deux commentaires sticky sur la même PR, deux arborescences de rapport
@@ -199,22 +210,21 @@ jobs:
           # instantané de page il annonçait 92 % (15/106) avec 91 critères « à évaluer » là où le
           # tier page en décidait 104 sur 106 — le même dépôt, le même commit, deux chiffres.
           #
-          # Le grief tombe exactement là où les deux jobs ne coexistent plus. Sur une PR
-          # `a11y-pages` ne tourne pas : un seul producteur, un seul commentaire, un seul rapport,
-          # et le taux annoncé est le seul du run. Sur le cron et le dispatch, le livrable reste
-          # celui d'`a11y-pages` et cette gate redevient muette — elle garde les annotations en
-          # ligne et le SARIF, qui ne sont pas des livrables.
+          # Le grief tombe exactement là où les deux jobs ne coexistent plus. Sur une PR,
+          # `a11y-pages` ne tourne pas : un seul producteur, un seul commentaire et un seul
+          # rapport. Sur cron/dispatch, ce job est sauté et le livrable appartient exclusivement
+          # à `a11y-pages`.
           #
           # `digest` et non `pages` : sans instantané, cette gate n'a pas de grille par page à
           # poster. Elle nomme les défauts distincts de l'audit du code, avec leurs emplacements.
           # Le marqueur sticky de `digest` lui est propre : rien ici ne peut écraser le
           # commentaire d'un autre tier.
-          comment: ${{ github.event_name == 'pull_request' }}
+          comment: "true"
           comment-kind: digest
-          report: ${{ github.event_name == 'pull_request' }}
-          html: ${{ github.event_name == 'pull_request' }}
+          report: "true"
+          html: "true"
           # Hors du motif `ultra11y-part-*`, donc jamais happé par la fusion d'`a11y-bundle`.
-          artifact-name: ${{ github.event_name == 'pull_request' && 'ultra11y-pr-static' || '' }}
+          artifact-name: ultra11y-pr-static
 
   a11y-pages:
     name: "RGAA · rapport page par page"
@@ -424,7 +434,8 @@ jobs:
       # du code, ré-audit hors navigateur des instantanés, adjudication IA, rapport page par
       # page, crops de preuve, HTML.
       - name: ultra11y — audit, rapport page par page et adjudication
-        uses: maxgfr/ultra11y@v5.34.2
+        # Même commit immuable que la gate PR ; ne jamais laisser les deux tiers diverger.
+        uses: maxgfr/ultra11y@76a48723330461b2ee358858d759ae182f0a1381
         env:
           # Lu depuis l'ENV DU JOB, jamais depuis un input : c'est ce qui rend le tier
           # inoffensif sur une PR de fork, où les secrets ne sont pas exposés — il se
@@ -438,78 +449,32 @@ jobs:
           graph: "true"
           standard: rgaa
           lang: fr
+          report: "true"
+          html: "true"
+          pages-report: "true"
+          evidence: "true"
           # TOUTE la grille de jugement passe par le modèle — moins ce que le registre rejoue.
           # Chaque entrée du registre repasse par la même porte, sur l'évidence re-dérivée de
           # l'audit du moment ; ce qui n'est pas rejoué est ce qui est payé. Ce que personne ne
           # tranche reste « à évaluer », et `require-decided: pages` plus bas fait rougir le job
           # en le nommant.
           adjudicate: agent
-          # ON RESTE SUR LE RUNNER `action`, ET C'EST UN CHOIX, PAS UN OUBLI.
-          #
-          # 5.30.0 a ouvert un second chemin pour ce tier : `adjudicate-runner: cli` fait
-          # spawner au moteur un `claude -p` lui-même, et `adjudicate-grain: criterion` lui fait
-          # juger un critère par appel. Évalué ici, écarté — trois raisons.
-          #
-          #   1. CE QU'IL VEND, ON L'A DÉJÀ. Son argument est de lever la liste d'événements
-          #      autorisés de `claude-code-action`, donc de rendre le tier disponible sur
-          #      `push`. Ce dépôt a contourné cette restriction par le cron sur `alpha` (voir
-          #      l'en-tête). Il n'y a rien à acheter.
-          #   2. LE DÉFAUT DE L'ACTION EST CASSÉ. `adjudicate-grain` vaut `worklist` par défaut
-          #      et l'Action le passe tel quel à `judge --grain`, qui n'accepte que `batch` ou
-          #      `criterion` (`src/cli.ts:3560`). `runner: cli` au grain par défaut sort en 2
-          #      sans appeler un modèle : 40 min de CI, 0 $, et un rouge sur `require-decided`
-          #      avec toute la grille « à évaluer ». Seul le couple `cli` + `criterion` marche.
-          #   3. IL ÉCHANGE UN PLAFOND QUI MARCHE CONTRE AUCUN. `adjudicate-max-turns` ci-dessous
-          #      est VIVANT sur ce runner-ci. Sous `cli` il est muet — `--max-turns` n'est pas un
-          #      flag du CLI, qui avale un flag inconnu sans un mot. Et `adjudicate-budget-usd`
-          #      ne le remplace pas : il est poussé sur l'argv de CHAQUE `claude -p`
-          #      (`src/agent-cli.ts:170`) avec jusqu'à 4 tentatives, donc le pire cas est
-          #      `critères × passes × tentatives × plafond`. Le seul plafond de run qui
-          #      resterait serait `timeout-minutes`, soit cinq heures de modèle.
-          #
-          # S'ajoute le coût en temps : un appel par critère sur 37 pages allonge le job sans
-          # borne connue, là où les trois étapes dépliées ont une durée mesurée (39 min 25 s).
-          #
-          # TROIS PASSES, et un budget de tours large. Mesuré : l'adjudicateur s'est arrêté à
-          # 22 tours sur 228, sans erreur, en laissant 42 critères `verdict: null` — une passe
-          # unique n'a aucun moyen d'y revenir, et le job finit vert sur une grille que
-          # personne n'a remplie. Chaque passe supplémentaire ne reprend que ce qui est ENCORE
-          # indécis (jamais atteint, ou jugé puis refusé par la porte en portant son motif),
-          # donc elle coûte le reliquat et rien d'autre — et un run qui a tout décidé saute les
-          # suivantes avant d'invoquer le moindre modèle.
+          # LE RUNNER OPTIMISÉ, EXPLICITEMENT. Le moteur lance Claude en lecture seule, groupe
+          # huit critères par appel et checkpoint chaque lot. Une passe suivante ne reçoit que
+          # le reliquat refusé ou resté sans réponse ; le registre rejoué avant cela évite de
+          # repayer les verdicts dont l'évidence est encore valide.
+          adjudicate-runner: cli
+          adjudicate-grain: worklist
           adjudicate-passes: "3"
-          adjudicate-max-turns: "600"
-          # LE MODÈLE, EXPLICITEMENT. Sans cet input l'adjudication prend le défaut de
-          # `claude-code-action`, qui n'est pas une constante de ce dépôt : le tier est facturé
-          # AU CRITÈRE, une worklist RGAA en compte plusieurs dizaines, et un défaut qui bouge
-          # fait bouger la facture sans que rien ici ne change. On le nomme donc.
-          #
-          # Sonnet 5, et pas plus gros. L'amont a mesuré que ce qu'un adjudicateur bon marché
-          # ratait n'était jamais un manque de modèle : sept critères perdus sur un run vert,
-          # sept défauts d'outil — une fiche par critère rendue sans son contrat de verdict, un
-          # contrat de dispatch écrit pour un autre harnais, deux critères sans instrument et
-          # deux sans sujet moissonné. Tous corrigés en amont. Ce qui reste tient à Sonnet.
-          adjudicate-model: claude-sonnet-5
-          # L'EFFORT, ET C'EST LE LEVIER QUI N'EST PAS LE MODÈLE (5.34.0).
-          #
-          # Ce qui arrive à ce tier est, par construction, ce qu'aucun moteur n'a pu décider :
-          # pertinence d'une alternative, intitulé de lien en contexte, ordre de lecture. La
-          # difficulté n'est donc pas de choisir entre deux réponses, c'est de LIRE l'évidence
-          # sans se tromper — et c'est exactement là qu'un run mesuré ici a échoué.
-          #
-          # Mesuré sur le run 32782282651 (5.33.1, effort par défaut) : la porte a refusé 13
-          # verdicts à la première passe, 12 à la deuxième, 2 à la troisième. Aucun refus n'était
-          # un désaccord sur le fond — c'étaient des citations fabriquées, des snippets retapés
-          # au lieu d'être copiés, et des chemins préfixés `packages/app/` alors que le
-          # `working-directory` EST `packages/app`. Trois critères en sont morts, le job est
-          # sorti rouge à 103/106.
-          #
-          # `high` et pas plus : le tier est facturé au critère, et l'amont a montré que monter
-          # le MODÈLE ne rattrapait pas ces défauts-là. C'est du soin de lecture qu'il faut, pas
-          # de la puissance. Les niveaux sont low, medium, high, xhigh, max — et une valeur hors
-          # liste est refusée par l'Action plutôt que transmise (le CLI avalerait un niveau
-          # inconnu en silence, exactement comme il avale un flag inconnu).
+          # Opus high est réservé au cron/dispatch, jamais aux PR. Le CLI applique le budget à
+          # CHAQUE lot de huit, pas à la passe entière : 106 critères font au plus 14 lots, donc
+          # 0,70 $ borne une passe complète à 9,80 $ hors rares retries de transport. Les passes
+          # suivantes ne reçoivent que le reliquat et s'arrêtent dès que la grille est complète.
+          # `opus` est volontairement l'alias Claude CLI : le tier reste Opus, sa version peut
+          # évoluer avec le CLI.
+          adjudicate-model: opus
           adjudicate-effort: high
+          adjudicate-budget-usd: "0.70"
           # Le registre : écrit à chaque run avec les verdicts que la porte a acceptés, rejoué au
           # run suivant. Il EST versionné (`packages/app/.ultra11y/verdicts/rgaa.json`) — rien
           # ici ne le commite pour autant, c'est un geste humain. Voir l'en-tête.
@@ -548,6 +513,10 @@ jobs:
           # Ce qui reste ouvert est NOMMÉ dans le log et dans la fiche par page ; jamais un
           # seuil, jamais un pourcentage.
           require-decided: "pages"
+          # Si un critère de rendu reste ouvert, cette porte refuse un run sans aucune capture
+          # navigateur. `require-sample` ci-dessous impose indépendamment la présence des 24
+          # pages attendues par la configuration du dépôt.
+          require-rendered: "true"
           # LA COUVERTURE, elle, bloque — et c'est la seule chose qui bloque ici.
           #
           # `require-decided` porte sur les CRITÈRES ; celle-ci porte sur les PAGES, et c'est
@@ -624,8 +593,8 @@ jobs:
   #
   # `if: always()` : un tier qui échoue ne doit pas emporter le livrable de l'autre.
   # `actions/upload-artifact/merge` ne trouvant AUCUNE partie échoue par défaut — d'où
-  # `continue-on-error`, parce qu'un run sans artefact est un fait, pas une panne : c'est le
-  # cas d'un `push` sur alpha, où seule la gate tourne, et où elle ne produit plus rien.
+  # `continue-on-error`, parce qu'un run sans artefact est un fait à rendre visible dans les
+  # logs de fusion, pas une raison de masquer les statuts des producteurs.
   a11y-bundle:
     name: "RGAA · livrable unique"
     needs: [a11y-gate, a11y-pages]

--- a/docs/accessibilite-ultra11y.md
+++ b/docs/accessibilite-ultra11y.md
@@ -10,7 +10,7 @@
 ### 2. L'analyse, par la GitHub Action
 
 `.github/workflows/a11y.yaml`, trois jobs portés par la même Action Ultra11y, épinglée à un
-commit immuable :
+tag de version explicite :
 
 | Job | Quand | Ce qu'il fait |
 |---|---|---|
@@ -253,16 +253,15 @@ Trois surfaces à bouger ensemble — deux dans le dépôt, une hors dépôt :
 
 ```bash
 pnpm --filter app add -D ultra11y@<version>   # version EXACTE, pas de ^
-# puis aligner les DEUX `maxgfr/ultra11y@<tag-ou-sha>` de .github/workflows/a11y.yaml
+# puis aligner les DEUX `maxgfr/ultra11y@v<version>` de .github/workflows/a11y.yaml
 claude plugin update ultra11y@ultra11y        # hors dépôt, à lancer à la main
 ```
 
-La devDependency est sur **5.40.0**. L'Action est temporairement épinglée au commit
-`76a48723330461b2ee358858d759ae182f0a1381`, qui ajoute les correctifs de complétude des worklists
-et de performance trouvés pendant la validation réelle ; remplacer ce SHA par le prochain tag de
-release avant merge. Le **plugin Claude Code** est une troisième surface, hors dépôt : il se met à
-jour à la main et peut donc rester très en retard sans que rien ne le signale — vérifier son cache
-si le skill `review-a11y` se comporte autrement que la CI.
+La devDependency et les deux usages de l'Action sont alignés sur **5.40.1**. Cette release contient
+les correctifs de complétude des worklists et de performance validés sur le dépôt réel. Le
+**plugin Claude Code** est une troisième surface, hors dépôt : il se met à jour à la main et peut
+donc rester très en retard sans que rien ne le signale — vérifier son cache si le skill
+`review-a11y` se comporte autrement que la CI.
 
 À noter si un bump échoue : la publication npm de la 5.3.0 est
 tombée sur la signature de provenance (`CA_CREATE_SIGNING_CERTIFICATE_ERROR`, 403 du CA) alors

--- a/docs/accessibilite-ultra11y.md
+++ b/docs/accessibilite-ultra11y.md
@@ -9,12 +9,13 @@
 
 ### 2. L'analyse, par la GitHub Action
 
-`.github/workflows/a11y.yaml`, trois jobs, tous portés par `maxgfr/ultra11y@v5.x` :
+`.github/workflows/a11y.yaml`, trois jobs portés par la même Action Ultra11y, épinglée à un
+commit immuable :
 
 | Job | Quand | Ce qu'il fait |
 |---|---|---|
-| `a11y-gate` | **chaque PR** (bloquant), + cron/manuel (muet) | Audit statique JSX/TSX de tout `src`. Gratuit, quelques secondes, aucun modèle. **C'est la seule gate de tout le dispositif qui arrête un merge** (`fail-on: blocking`). Sur une PR il parle : SARIF, annotations en ligne, commentaire sticky `digest` nommant les défauts distincts, et son propre rapport (`ultra11y-pr-static`). Sur le run complet il se tait — le livrable est celui d'`a11y-pages`. |
-| `a11y-pages` | **cron hebdo (lundi 04:00 UTC) + manuel** | La suite Playwright `src/e2e/a11y/` enregistre **39 pages** en épinglant l'état applicatif que chaque écran de tunnel exige — dont **37 sont effectivement capturées**, les 2 restantes étant gardées par un `test.skip` faute de données ; **24** seulement sont déclarées dans `.ultra11yrc.json`, et c'est ce sous-ensemble que `require-sample` tient ; l'Action réingère les instantanés et décide les critères **au rendu** depuis eux (contraste calculé, information par la couleur, contraste des composants, visibilité du focus, verrou d'orientation), **rejoue le registre de verdicts** puis fait adjuger le reliquat par une passe Claude Code (`adjudicate-model: claude-sonnet-5`, secret `CLAUDE_CODE_OAUTH_TOKEN`). Produit LE rapport page par page du livrable. Les constats ne bloquent pas — on mesure. Une panne, si ; une grille incomplète (`require-decided: pages`) ou un balayage amputé (`require-sample`) aussi. |
+| `a11y-gate` | **chaque PR** (bloquant) | Audit statique JSX/TSX de tout `src`. Gratuit, quelques secondes, aucun navigateur et aucun modèle. **C'est la seule gate du dispositif qui arrête un merge sur un constat** (`fail-on: blocking`) : SARIF, annotations, commentaire sticky `digest` et rapport `ultra11y-pr-static`. |
+| `a11y-pages` | **cron hebdo (lundi 04:00 UTC) + manuel** | La suite Playwright `src/e2e/a11y/` enregistre **39 pages** en épinglant l'état applicatif que chaque écran de tunnel exige — dont **37 sont effectivement capturées**, les 2 restantes étant gardées par un `test.skip` faute de données ; **24** seulement sont déclarées dans `.ultra11yrc.json`, et c'est ce sous-ensemble que `require-sample` tient. L'Action réaudite tout `src`, réingère les instantanés, rejoue le registre puis soumet seulement le reliquat à Claude CLI par lots de huit (`opus`, effort `high`). Produit LE rapport page par page. Les constats ne bloquent pas — on mesure. Une panne, une grille incomplète (`require-decided: pages`), un rendu requis mais absent (`require-rendered`) ou un balayage amputé (`require-sample`) bloquent. |
 | `a11y-bundle` | cron + manuel | Fusionne les parties en un seul artefact `ultra11y-rgaa`. |
 
 **Deux déclenchements, et ils ne paient pas la même chose.** `pull_request` ne lance que la gate
@@ -22,13 +23,11 @@ statique — gratuite, sans modèle, bloquante. `schedule` (hebdo) et `workflow_
 chaîne complète : balayage navigateur, critères de rendu, rejeu du registre puis adjudication IA
 du reliquat, livrable.
 
-**Pourquoi un cron et non `push: alpha`**, alors que c'est bien sur alpha qu'on veut le run
-complet. `adjudicate: agent` passe par `claude-code-action`, **qui refuse l'événement `push`** —
-l'Action y dégrade en avertissement et la grille repart « à évaluer » sans que rien ne rougisse.
-Les événements qu'il accepte sont `pull_request`, `workflow_dispatch`, `schedule`, `workflow_run`
-et `repository_dispatch`. Or **la branche par défaut de ce dépôt est `alpha`** : un `schedule` lit
-le fichier depuis alpha et s'exécute sur alpha. Le cron donne donc ce qu'un `push: alpha` aurait
-donné, avec le modèle en plus, et une facture bornée à un run par semaine au lieu d'un par merge.
+**Pourquoi un cron et non `push: alpha`**, alors que le runner CLI sait désormais traiter un
+`push`. Le run complet construit la stack, parcourt les pages et paie le reliquat au modèle ; le
+lancer à chaque merge multiplierait le coût sans améliorer le feedback immédiat, déjà fourni par
+la gate statique. La branche par défaut étant `alpha`, le `schedule` lit et exécute son workflow :
+le même périmètre exhaustif, une fois par semaine, plus le `workflow_dispatch` à la demande.
 
 Ce que ça ne donne pas, et il faut le savoir : **une régression RGAA de rendu peut vivre jusqu'au
 prochain tick.** Ce qui la rattrape sur une PR est l'audit statique, qui ne voit pas la page
@@ -178,9 +177,15 @@ jq '.standard' audits/audit-latest.json    # doit dire "rgaa", jamais "wcag"
 
 ### Ce que coûte l'adjudication
 
-Sans registre à rejouer : **9,59 $**, mesuré sur le run du 24/08/2026 (3 passes — 5,91 + 2,43 +
-1,25). Le registre **est** commité depuis (`packages/app/.ultra11y/verdicts/rgaa.json`, 47
-verdicts) : les runs suivants rejouent ce qui tient et ne paient que le reliquat.
+Sans registre à rejouer, l'ancien runner Sonnet a coûté **9,59 $**, mesuré sur le run du
+24/08/2026 (3 passes — 5,91 + 2,43 + 1,25). Le registre **est** commité depuis
+(`packages/app/.ultra11y/verdicts/rgaa.json`, 47 verdicts) : les runs suivants rejouent ce qui
+tient et ne paient que le reliquat. Le runner actuel utilise Opus high.
+`adjudicate-budget-usd` borne **chaque lot CLI**, et non une passe entière : avec des lots de
+huit, les 106 critères RGAA représentent au plus 14 appels. La valeur `0.70` borne donc une passe
+complète à **9,80 $** hors rares retries de transport, et trois passes à **29,40 $** dans le pire
+cas nominal. Chaque passe suivante ne reçoit que le reliquat ; une grille complète arrête les
+passes restantes.
 
 **L'effort est le second levier, et il n'est pas le modèle.** `adjudicate-effort: high` (5.34.0).
 Ce qui arrive à ce tier est ce qu'aucun moteur n'a pu décider, donc la difficulté n'est pas de
@@ -192,27 +197,18 @@ citations fabriquées, des snippets retapés au lieu d'être copiés, et des che
 morts et le job est sorti rouge à 103/106. Monter le modèle ne répare pas ça ; monter le soin de
 lecture, si.
 
-### Le runner CLI, évalué et écarté
+### Le runner CLI, retenu depuis 5.40.0
 
-5.30.0 a ouvert un second chemin pour le tier agent : `adjudicate-runner: cli` fait spawner au
-moteur un `claude -p` lui-même, et `adjudicate-grain: criterion` lui fait juger un critère par
-appel. Ce dépôt **reste sur le runner `action`**, et c'est un choix documenté plutôt qu'un oubli.
+Le runner `cli` est désormais le chemin de production. L'Action traduit son grain public
+`worklist` en lots moteur de huit critères, lance Claude en lecture seule, checkpoint chaque lot
+et reprend seulement le reliquat aux passes suivantes. Les problèmes qui avaient motivé son rejet
+dans ce dépôt sont corrigés : le grain par défaut est valide, l'indisponibilité fournisseur coupe
+les retries extérieurs et une passe entièrement inopérante fait échouer la porte finale au lieu de
+laisser une grille vide paraître exploitable.
 
-- **Ce qu'il vend, on l'a déjà.** Son argument est de lever la liste d'événements autorisés de
-  `claude-code-action`, donc de rendre le tier disponible sur `push`. Le cron sur `alpha` a déjà
-  contourné cette restriction — voir plus haut.
-- **Le défaut de l'Action est cassé.** `adjudicate-grain` vaut `worklist` par défaut, l'Action le
-  passe tel quel à `judge --grain`, et le moteur n'accepte que `batch` ou `criterion`
-  (`src/cli.ts:3560`). Le couple `cli` + défaut sort en 2 **sans appeler un modèle** : 40 min de
-  CI, 0 $, et un rouge sur `require-decided` avec toute la grille « à évaluer ».
-- **Il échange un plafond qui marche contre aucun.** `adjudicate-max-turns: "600"` est vivant sur
-  le runner `action`. Sous `cli` il est muet : `--max-turns` n'est pas un flag du CLI, qui avale un
-  flag inconnu sans un mot. Et `adjudicate-budget-usd` ne le remplace pas — il est poussé sur
-  l'argv de **chaque** `claude -p` (`src/agent-cli.ts:170`), avec jusqu'à `MAX_ATTEMPTS = 4`
-  tentatives : le pire cas est `critères × passes × tentatives × plafond`, et le seul plafond de
-  run restant serait `timeout-minutes`.
-- **Et le temps.** Un appel par critère sur 37 pages allonge le job sans borne connue, là où les
-  trois étapes dépliées ont une durée mesurée : 39 min 25 s.
+Le coût de chaque lot est borné par `adjudicate-budget-usd: "0.70"`, avec au plus 14 lots par
+passe et trois passes. Le tier et l'effort sont configurés sur `opus` et `high` ; `opus` est
+l'alias du Claude CLI, donc le tier reste Opus mais sa version précise peut évoluer avec le CLI.
 
 ### En local, la même chose sans CI
 
@@ -257,13 +253,16 @@ Trois surfaces à bouger ensemble — deux dans le dépôt, une hors dépôt :
 
 ```bash
 pnpm --filter app add -D ultra11y@<version>   # version EXACTE, pas de ^
-# puis aligner les DEUX `maxgfr/ultra11y@v<version>` de .github/workflows/a11y.yaml
+# puis aligner les DEUX `maxgfr/ultra11y@<tag-ou-sha>` de .github/workflows/a11y.yaml
 claude plugin update ultra11y@ultra11y        # hors dépôt, à lancer à la main
 ```
 
-Les deux sont sur **5.34.2**. Le **plugin Claude Code** est une troisième surface, hors dépôt : il
-se met à jour à la main et peut donc rester très en retard sans que rien ne le signale — vérifier
-son cache si le skill `review-a11y` se comporte autrement que la CI.
+La devDependency est sur **5.40.0**. L'Action est temporairement épinglée au commit
+`76a48723330461b2ee358858d759ae182f0a1381`, qui ajoute les correctifs de complétude des worklists
+et de performance trouvés pendant la validation réelle ; remplacer ce SHA par le prochain tag de
+release avant merge. Le **plugin Claude Code** est une troisième surface, hors dépôt : il se met à
+jour à la main et peut donc rester très en retard sans que rien ne le signale — vérifier son cache
+si le skill `review-a11y` se comporte autrement que la CI.
 
 À noter si un bump échoue : la publication npm de la 5.3.0 est
 tombée sur la signature de provenance (`CA_CREATE_SIGNING_CERTIFICATE_ERROR`, 403 du CA) alors
@@ -271,4 +270,3 @@ que l'échange OIDC avait réussi, et semantic-release ne republie pas un tag ex
 `v5.3.0` existe donc sans version npm correspondante. C'était transitoire : le commit suivant
 a publié normalement. Si ça se reproduit, le contournement est un nouveau commit releasable,
 pas une republication.
-

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -102,7 +102,7 @@
 		"swagger-ui-dist": "^5.32.2",
 		"tsx": "^4.21.0",
 		"typescript": "^6.0.2",
-		"ultra11y": "5.34.2",
+		"ultra11y": "5.40.0",
 		"vite-tsconfig-paths": "^6.1.1",
 		"vitest": "^4.1.4"
 	},

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -102,7 +102,7 @@
 		"swagger-ui-dist": "^5.32.2",
 		"tsx": "^4.21.0",
 		"typescript": "^6.0.2",
-		"ultra11y": "5.40.0",
+		"ultra11y": "5.40.1",
 		"vite-tsconfig-paths": "^6.1.1",
 		"vitest": "^4.1.4"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       ultra11y:
-        specifier: 5.34.2
-        version: 5.34.2(playwright-core@1.62.1)
+        specifier: 5.40.0
+        version: 5.40.0(playwright-core@1.62.1)
       vite-tsconfig-paths:
         specifier: ^6.1.1
         version: 6.1.1(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -6345,8 +6345,8 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  ultra11y@5.34.2:
-    resolution: {integrity: sha512-ZAeprPe4y3biOdbtyFY6vbZXeaMAODemVXlSx4HatqO8hHWEF1lKHrJ0LjltOxolYRkdbaXbaWapPtJZtv1CVg==}
+  ultra11y@5.40.0:
+    resolution: {integrity: sha512-D8yiqGuDQ1Im2iA1s6eTL1GOrJIQgWyFHT6OHlHxpUeatBujhr+/y03uNCc1AlQTUUJRon4Qwdp1TIcP/+8rhg==}
     engines: {node: '>=22.18.0'}
     hasBin: true
 
@@ -13284,7 +13284,7 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
-  ultra11y@5.34.2(playwright-core@1.62.1):
+  ultra11y@5.40.0(playwright-core@1.62.1):
     dependencies:
       '@axe-core/playwright': 4.13.0(playwright-core@1.62.1)
       '@babel/parser': 8.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       ultra11y:
-        specifier: 5.40.0
-        version: 5.40.0(playwright-core@1.62.1)
+        specifier: 5.40.1
+        version: 5.40.1(playwright-core@1.62.1)
       vite-tsconfig-paths:
         specifier: ^6.1.1
         version: 6.1.1(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -6345,8 +6345,8 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  ultra11y@5.40.0:
-    resolution: {integrity: sha512-D8yiqGuDQ1Im2iA1s6eTL1GOrJIQgWyFHT6OHlHxpUeatBujhr+/y03uNCc1AlQTUUJRon4Qwdp1TIcP/+8rhg==}
+  ultra11y@5.40.1:
+    resolution: {integrity: sha512-v9z7qMyl86DlZ6ESlzkUrZ/YaliZ9qE0NJzYcKyWIBFpmMRbqbyQx7sq7DPLeCoDh+w/ZD4MT+6Caob394GMWg==}
     engines: {node: '>=22.18.0'}
     hasBin: true
 
@@ -13284,7 +13284,7 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
-  ultra11y@5.40.0(playwright-core@1.62.1):
+  ultra11y@5.40.1(playwright-core@1.62.1):
     dependencies:
       '@axe-core/playwright': 4.13.0(playwright-core@1.62.1)
       '@babel/parser': 8.0.4


### PR DESCRIPTION
## Résumé

- met la devDependency Ultra11y à jour de 5.34.2 vers 5.40.1 ;
- aligne les deux usages de la GitHub Action sur le tag de release v5.40.1 ;
- limite les pull requests à la gate statique sur tout src, sans navigateur ni modèle ;
- réserve le parcours Playwright, les 106 critères RGAA et l’adjudication CLI Opus high au cron et au déclenchement manuel ;
- impose require-decided=pages, require-rendered et require-sample ;
- borne chaque lot CLI à 0,70 USD, soit 9,80 USD par passe nominale au maximum et trois passes au plus.

## Validation

- Ultra11y v5.40.1 publiée sur GitHub et npm après une CI main entièrement verte ;
- run keyed réel sur Ultra11y : 9 pages × 106 critères, grille complète en deux passes, coût total 3,14 USD ;
- audit statique Egapro : 331 fichiers, aucune non-conformité ;
- installation figée et version résolue 5.40.1 ;
- format, lint et typecheck : OK ;
- suite complète Egapro : 6 029 tests OK ;
- build Next.js : OK ;
- workflow YAML valide et tous les inputs existent dans action.yml ;
- correctif amont : 4 026 tests, 3 ignorés, perf, bundles reproductibles, smoke test et Chromium réel OK.

La PR reste en brouillon pour relecture humaine ; le SHA temporaire a été remplacé par la release publiée.
