### PR TITLE
fix(a11y): retirer le plafond par lot, passer en Sonnet 5 et supprimer le cron

### DIFF
--- a/.claude/hooks/check-ultra11y-plugin.sh
+++ b/.claude/hooks/check-ultra11y-plugin.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Hook: UserPromptSubmit
+#
+# LE QUATRIÈME ENDROIT OÙ VIT LA VERSION D'ULTRA11Y, ET LE SEUL QUE LA CI NE VOIT PAS.
+#
+# `ci.yaml` tient ensemble les trois versions DU DÉPÔT (les deux `uses:` de l'Action et la
+# devDependency) via scripts/a11y/check-ultra11y-version.sh. Le plugin Claude Code, lui, est
+# installé sur TA MACHINE : `.claude/settings.json` déclare `"ultra11y@ultra11y": true` sans
+# version, donc l'install prend ce que la marketplace avait ce jour-là — et n'en bouge plus
+# jamais toute seule.
+#
+# Ce n'est pas théorique : mesuré le 31/08/2026, le plugin installé était en **4.5.1** pendant
+# que le dépôt tournait en 5.40.1. L'agent `rgaa-auditor`, qui EST la gate d'accessibilité des
+# sessions locales, auditait donc avec un moteur d'une trentaine de versions mineures en
+# arrière — sans tout le contrat d'automatisation 5.36, sans les correctifs de citation
+# 5.22–5.24. Un audit qui répond, avec assurance, à une autre question.
+#
+# Ce que fait ce hook : une comparaison LOCALE (un fichier JSON, un grep — aucun réseau), et
+# seulement en cas d'écart, la mise à jour. L'écart est rare : le coût réseau est payé une fois
+# par release, jamais à chaque prompt.
+#
+# Silencieux quand tout va bien, et silencieux quand il ne peut pas conclure : un poste sans
+# `claude` sur le PATH, sans plugin installé ou hors ligne n'a pas à voir passer un avertissement
+# qu'il ne peut pas traiter.
+
+set -euo pipefail
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo "")}"
+[ -n "$REPO_ROOT" ] || exit 0
+
+WORKFLOW="$REPO_ROOT/.github/workflows/a11y.yaml"
+INSTALLED="$HOME/.claude/plugins/installed_plugins.json"
+[ -f "$WORKFLOW" ] || exit 0
+[ -f "$INSTALLED" ] || exit 0
+
+# Une fois par session. Même mécanique que check-pr-reviews.sh : le PPID est stable dans une
+# session Claude Code.
+MARKER="/tmp/.claude-ultra11y-plugin-$PPID"
+[ -f "$MARKER" ] && exit 0
+touch "$MARKER"
+
+# LA RÉFÉRENCE EST LE TAG DE L'ACTION, pas la devDependency : c'est le moteur, et la CI garantit
+# déjà que les trois versions du dépôt s'accordent. Une seule source à lire, donc.
+WANT=$(grep -oE '^[[:space:]]*uses:[[:space:]]*maxgfr/ultra11y@v[0-9]+\.[0-9]+\.[0-9]+' "$WORKFLOW" | sed -E 's/.*@v//' | head -1)
+[ -n "$WANT" ] || exit 0
+
+# La plus haute version installée, tous scopes confondus : le plugin peut être posé au scope
+# projet sur un chemin de worktree éphémère, et on ne veut pas crier pour une entrée orpheline.
+installed_version() {
+  python3 -c '
+import json, sys
+try:
+    entries = json.load(open(sys.argv[1]))["plugins"].get("ultra11y@ultra11y", [])
+except Exception:
+    sys.exit(0)
+best = ""
+for e in entries:
+    v = e.get("version") or ""
+    try:
+        parsed = [int(x) for x in v.split(".")]
+    except ValueError:
+        continue
+    if not best or parsed > [int(x) for x in best.split(".")]:
+        best = v
+print(best)
+' "$INSTALLED" 2>/dev/null || true
+}
+
+HAVE=$(installed_version)
+
+# Pas de plugin installé : ce n'est pas une dérive, c'est un choix (ou une machine neuve).
+# `.claude/rules/rgaa.md` dit déjà comment l'installer ; ce hook ne double pas ce message.
+[ -n "$HAVE" ] || exit 0
+[ "$HAVE" = "$WANT" ] && exit 0
+
+command -v claude >/dev/null 2>&1 || {
+  echo "⚠️  Plugin ultra11y en $HAVE, le dépôt tourne en $WANT — mets-le à jour avec \`claude plugin update ultra11y\`."
+  exit 0
+}
+
+echo "⚠️  Plugin ultra11y local en **$HAVE**, dépôt en **$WANT** — le skill review-a11y (agent rgaa-auditor) audite avec un moteur périmé. Mise à jour en cours…"
+
+# Bornés : un miroir GitHub lent ne doit pas retenir un prompt. Un échec n'est pas fatal — on
+# dit quoi taper et on rend la main.
+MANUAL='`claude plugin marketplace update ultra11y && claude plugin update ultra11y --scope project`'
+
+if ! timeout 60 claude plugin marketplace update ultra11y >/dev/null 2>&1 ||
+  ! timeout 60 claude plugin update ultra11y --scope project >/dev/null 2>&1; then
+  echo "⚠️  Mise à jour automatique impossible (réseau ?). À faire à la main : $MANUAL"
+  exit 0
+fi
+
+# ON RELIT PLUTÔT QU'ON N'ANNONCE. `claude plugin update` monte vers le DERNIER tag publié sur
+# la marketplace, pas vers `$WANT` : si le dépôt épingle une version que la marketplace n'a pas
+# encore (ou plus), la commande sort 0 sans avoir rejoint la cible. Annoncer « mis à jour en
+# $WANT » sur ce seul code de retour, c'est réintroduire exactement le silence que ce hook
+# existe pour rompre.
+NOW=$(installed_version)
+if [ "$NOW" = "$WANT" ]; then
+  echo "✅ Plugin ultra11y mis à jour en $NOW. **Redémarre Claude Code** pour l'appliquer."
+elif [ -n "$NOW" ] && [ "$NOW" != "$HAVE" ]; then
+  echo "⚠️  Plugin passé de $HAVE à $NOW, mais le dépôt épingle $WANT — la marketplace n'expose pas encore ce tag. **Redémarre Claude Code**, et vérifie le pin de \`.github/workflows/a11y.yaml\`."
+else
+  echo "⚠️  Le plugin est resté en $NOW alors que le dépôt épingle $WANT. À reprendre à la main : $MANUAL"
+fi
+
+exit 0

--- a/.claude/rules/automation.md
+++ b/.claude/rules/automation.md
@@ -8,9 +8,11 @@ description: Hooks, quality gates et vérifications avant push — toujours char
 
 ## Hooks (`.claude/settings.json`)
 
-Trois hooks, exécutés par le harnais, pas par toi.
+Quatre hooks, exécutés par le harnais, pas par toi.
 
 **`UserPromptSubmit` → `check-pr-reviews.sh`** — au premier message d'une session. Si la branche courante a une PR ouverte avec des commentaires non résolus, il le signale et suggère `/review`. Silencieux sur `alpha`.
+
+**`UserPromptSubmit` → `check-ultra11y-plugin.sh`** — au premier message d'une session. Compare **hors ligne** la version du plugin ultra11y installé au tag épinglé dans `a11y.yaml`, et ne touche au réseau qu'en cas d'écart. C'est le seul des quatre endroits où vit la version d'ultra11y que le dépôt ne peut pas pinner — et c'est celui qui avait dérivé de 4.5.1 à 5.40.1 sans que rien ne le dise. Détail → `.claude/rules/rgaa.md`.
 
 **`PreToolUse` → `block-bad-patterns.sh`** (matcher `Edit|Write`) — **22 patterns bloqués avant l'écriture**. C'est la couche machine : ce qu'elle attrape n'a pas besoin d'être re-vérifié à la main, et ce qu'elle bloque ne se contourne pas.
 

--- a/.claude/rules/rgaa.md
+++ b/.claude/rules/rgaa.md
@@ -16,10 +16,10 @@ Deux surfaces, et deux seulement.
 | Job | Quand | Ce qu'il fait |
 |---|---|---|
 | `a11y-gate` | **chaque PR** (bloquant) | audit statique JSX/TSX de tout `src` — gratuit, quelques secondes, aucun navigateur et aucun modèle. **La seule gate du dispositif qui arrête un merge sur un constat** (`fail-on: blocking`) : SARIF, annotations, commentaire sticky |
-| `a11y-pages` | cron hebdo (lundi 04:00 UTC) + manuel | balayage Playwright, critères décidés **au rendu**, rejeu du registre, puis adjudication Opus high du reliquat par Claude CLI en lots. Non bloquant sur les constats ; bloquant sur une panne, un rendu absent ou une grille incomplète |
-| `a11y-bundle` | cron + manuel | fusionne le tout dans l'artefact `ultra11y-rgaa` |
+| `a11y-pages` | **manuel uniquement** (`gh workflow run a11y.yaml`) | balayage Playwright, critères décidés **au rendu**, rejeu du registre, puis adjudication Sonnet 5 / effort `high` du reliquat par Claude CLI en lots de huit, sans plafond par lot. Non bloquant sur les constats ; bloquant sur une panne, un rendu absent ou une grille incomplète |
+| `a11y-bundle` | manuel | fusionne le tout dans l'artefact `ultra11y-rgaa` |
 
-Ce que ça ne donne pas, et il faut le savoir : **une régression RGAA de rendu peut vivre jusqu'au prochain tick hebdo.** Ce qui la rattrape sur une PR est l'audit statique, qui ne voit pas la page rendue. C'est l'arbitrage, et c'est celui du coût.
+Ce que ça ne donne pas, et il faut le savoir : **une régression RGAA de rendu ne sera rattrapée par personne tant que personne ne lance le workflow.** Le cron hebdomadaire a été retiré parce que, depuis ultra11y 5.36, 103 des 106 critères RGAA exigent une adjudication par le modèle — un run n'est plus une dépense de fond. Ce qui rattrape une régression sur une PR est l'audit statique, qui ne voit pas la page rendue. C'est l'arbitrage, et c'est celui du coût.
 
 > Câblage complet, coûts mesurés, registre de verdicts, `undecidable.json`, runner CLI par lots, choix du cron plutôt que `push: alpha`, commandes locales et procédure de bump → **[`docs/accessibilite-ultra11y.md`](../../docs/accessibilite-ultra11y.md)**. À lire avant de toucher à `a11y.yaml` ou à la version d'ultra11y — plusieurs de ces choix ont déjà été faits, défaits, puis refaits.
 

--- a/.claude/rules/rgaa.md
+++ b/.claude/rules/rgaa.md
@@ -23,6 +23,36 @@ Ce que ça ne donne pas, et il faut le savoir : **une régression RGAA de rendu 
 
 > Câblage complet, coûts mesurés, registre de verdicts, `undecidable.json`, runner CLI par lots, choix du cron plutôt que `push: alpha`, commandes locales et procédure de bump → **[`docs/accessibilite-ultra11y.md`](../../docs/accessibilite-ultra11y.md)**. À lire avant de toucher à `a11y.yaml` ou à la version d'ultra11y — plusieurs de ces choix ont déjà été faits, défaits, puis refaits.
 
+## La version, et pourquoi elle vit à quatre endroits
+
+Le moteur ultra11y est **embarqué** dans chaque surface, donc « la version » n'est pas un
+numéro unique mais quatre copies qui doivent s'accorder :
+
+| Où | Quoi | Tenu par |
+|---|---|---|
+| `a11y.yaml`, `uses:` ×2 | le moteur de la CI (gate PR + `a11y-pages`) | `a11y-version-coherence` (ci.yaml) |
+| `packages/app/package.json` | le binaire et le plugin Playwright qui **écrivent** les instantanés | idem |
+| le plugin Claude Code | le skill `review-a11y`, donc l'agent `rgaa-auditor` | hook `check-ultra11y-plugin.sh` |
+
+Les deux premières doivent être identiques pour une raison mécanique : la suite Playwright écrit
+les instantanés avec la **devDependency**, et l'Action les réingère avec **son** moteur. Deux
+versions, deux formats — et la divergence ne lève aucune erreur, elle se lit comme des critères
+« à évaluer » dans un rapport qui a l'air complet. `scripts/a11y/check-ultra11y-version.sh`
+refuse une demi-montée de version, et tourne dans la CI sur chaque push.
+
+Dependabot propose les montées : `github-actions` et `npm` sont sur la **même cadence** (lundi
+01:00) précisément pour que les deux PR arrivent ensemble — il ne sait pas grouper à travers
+deux écosystèmes, donc c'est la CI qui tranche.
+
+**Le plugin est le seul que rien dans le dépôt ne pin.** `.claude/settings.json` déclare
+`"ultra11y@ultra11y": true` sans version : l'install prend ce que la marketplace avait ce
+jour-là et n'en bouge plus. Mesuré le 31/08/2026 : plugin en **4.5.1**, dépôt en **5.40.1** —
+l'agent `rgaa-auditor` auditait avec un moteur d'une trentaine de versions mineures en arrière.
+Le hook `UserPromptSubmit` compare hors ligne la version installée au pin d'`a11y.yaml`, et ne
+touche au réseau qu'en cas d'écart. Il **relit** la version après coup plutôt que d'annoncer un
+succès sur un code de retour : `claude plugin update` monte vers le dernier tag de la
+marketplace, pas forcément vers celui que le dépôt épingle.
+
 ## Ce qui n'est PAS le dispositif
 
 - **Lighthouse** rapporte un score d'accessibilité en `warn`. Sa notion d'accessibilité n'est pas celle des 106 critères ; deux seuils concurrents donnent deux verdicts à réconcilier à la main.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-pr-reviews.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-ultra11y-plugin.sh"
           }
         ]
       }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,31 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: "/"
+    # MÊME CADENCE ET MÊME BRANCHE QUE L'ÉCOSYSTÈME NPM CI-DESSOUS, ET C'EST LOAD-BEARING.
+    #
+    # `maxgfr/ultra11y` existe des deux côtés : comme Action épinglée dans a11y.yaml et comme
+    # devDependency dans packages/app. Les deux doivent porter la même version — le balayage
+    # Playwright écrit les instantanés avec la devDependency, l'Action les réingère avec son
+    # moteur embarqué. Dependabot ne peut pas grouper à travers deux écosystèmes, donc le mieux
+    # qu'on puisse faire ici est de faire ARRIVER les deux PR le même matin ; ce qui REFUSE une
+    # moitié de montée est le job `a11y-version-coherence` de ci.yaml.
+    #
+    # Avant, ce bloc était mensuel et sans `target-branch` : les mises à jour d'Action
+    # atterrissaient sur la branche par défaut à un rythme différent de leurs jumelles npm.
+    target-branch: alpha
+    labels:
+      - bot
+      - dependencies
     schedule:
-      interval: monthly
+      interval: weekly
+      day: monday
+      time: "01:00"
+      timezone: Europe/Paris
+    groups:
+      # Une seule PR pour les deux `uses:` d'ultra11y, jamais deux qui se marchent dessus.
+      ultra11y:
+        patterns:
+          - "maxgfr/ultra11y"
   - package-ecosystem: "npm"
     labels:
       - bot

--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -16,36 +16,43 @@ name: "♿ Accessibilité (ultra11y RGAA)"
 #                           depuis `require-decided: pages`, une grille incomplète aussi.
 #   a11y-bundle  LIVRABLE — fusionne les parties en un seul artefact `ultra11y-rgaa`.
 #
-# Il n'y a plus de `a11y-report` hebdomadaire séparé : le `schedule` et le déclenchement manuel
-# lancent tous deux `a11y-pages`, qui produit le même livrable AVEC le navigateur. Le job statique
-# ne tourne plus une seconde fois sur ces événements : l'Action du tier rendu réaudite déjà tout
-# `src`, et le doublon ne renforçait aucune porte.
+# Il n'y a plus de `a11y-report` hebdomadaire séparé, et plus de cron non plus : le déclenchement
+# manuel lance `a11y-pages`, qui produit le livrable AVEC le navigateur. Le job statique ne tourne
+# pas une seconde fois sur cet événement : l'Action du tier rendu réaudite déjà tout `src`, et le
+# doublon ne renforçait aucune porte.
 #
 # Le tier LIGHTHOUSE (score a11y 100 %) reste dans lighthouse.yaml.
 #
 # DEUX DÉCLENCHEMENTS, ET ILS NE PAIENT PAS LA MÊME CHOSE.
 #
-#   pull_request                  → `a11y-gate` SEUL. Statique, gratuit, quelques secondes,
-#                                   aucun modèle, et BLOQUANT (`fail-on: blocking`).
-#   schedule (hebdo) + dispatch   → la chaîne complète. Balayage des pages, critères de rendu,
-#                                   rejeu du registre puis adjudication IA du reliquat, livrable.
+#   pull_request       → `a11y-gate` SEUL. Statique, gratuit, quelques secondes, aucun modèle,
+#                        et BLOQUANT (`fail-on: blocking`).
+#   workflow_dispatch  → la chaîne complète. Balayage des pages, critères de rendu, rejeu du
+#                        registre puis adjudication IA du reliquat, livrable.
 #
-# La moitié chère ne peut pas tourner sur chaque PR : 16 à 21 $ pour un premier run, 40 à 90
-# minutes, et une grille qui n'est pas reproductible d'un run à l'autre. La moitié statique, elle,
-# ne coûte rien — c'est ce qui lui permet d'être la gate, et c'est le SEUL rouge de tout ce
-# fichier qui arrête un merge.
+# La moitié chère ne peut pas tourner sur chaque PR : 40 à 90 minutes, une grille qui n'est pas
+# reproductible d'un run à l'autre, et une facture qui a MONTÉ. La moitié statique, elle, ne coûte
+# rien — c'est ce qui lui permet d'être la gate, et c'est le SEUL rouge de tout ce fichier qui
+# arrête un merge.
 #
-# POURQUOI UN CRON ET NON `push: alpha`, puisque c'est bien sur alpha qu'on veut le run complet.
-# `adjudicate: agent` passe par `claude-code-action`, qui REFUSE l'événement `push` — l'Action y
-# dégrade en avertissement et la grille repart « à évaluer » sans que rien ne rougisse. Les
-# événements qu'il accepte sont `pull_request`, `workflow_dispatch`, `schedule`, `workflow_run` et
-# `repository_dispatch`. Or **la branche par défaut de ce dépôt est `alpha`** : un `schedule` lit
-# le fichier depuis alpha et s'exécute sur alpha. Le cron donne donc ce qu'un `push: alpha` aurait
-# donné, avec le modèle en plus, et une facture bornée à un run par semaine au lieu d'un par merge.
+# POURQUOI PLUS DE CRON, alors qu'il y en a eu un (lundi 04:00 UTC), et qu'on avait pris soin de
+# le choisir plutôt qu'un `push: alpha` que `claude-code-action` aurait refusé.
 #
-# CE QUE ÇA NE DONNE PAS, dit franchement : une régression RGAA de RENDU peut vivre jusqu'au
-# prochain tick. Ce qui la rattrape sur une PR est l'audit statique, qui ne voit pas la page
-# rendue. C'est l'arbitrage, et c'est celui du coût.
+# Parce que le prix d'un run a changé sous nos pieds. ultra11y 5.36 a rendu le contrat
+# d'automatisation EXHAUSTIF : un critère n'obtient un `C` par mesure que si son contrat démontre
+# que CHAQUE test numéroté a un instrument décisif — et sur les 106 critères RGAA, TROIS
+# remplissent cette condition (8.3, 8.5, 10.1). Les autres passent par le modèle. Mesuré sur ce
+# dépôt, même commit et mêmes 37 captures : la worklist est passée de 27 critères (run
+# 33383329004, action v5.34.2) à 84 (run 33389189227, action v5.40.1).
+#
+# Ce n'est pas une régression, c'est un durcissement, et il se défend : avant, un dépôt sans image
+# marquait 100 % sur « chaque image a-t-elle une alternative pertinente ? ». Mais un run qui adjuge
+# 84 critères n'est plus une dépense de fond qu'on laisse tourner toutes les semaines. Il est
+# lancé quand on en veut le résultat.
+#
+# CE QUE ÇA NE DONNE PAS, dit franchement : une régression RGAA de RENDU ne sera rattrapée par
+# personne tant que personne ne lance ce workflow. Ce qui la rattrape sur une PR est l'audit
+# statique, qui ne voit pas la page rendue. C'est l'arbitrage, et c'est celui du coût.
 #
 # LES CRITÈRES DE JUGEMENT SONT ADJUGÉS, TOUS, À CHAQUE RUN. Ceux que le moteur ne peut pas
 # trancher — pertinence des alt, intitulé de lien dans son contexte, ordre de lecture — passent
@@ -138,19 +145,29 @@ on:
   # LA GATE. Statique, gratuite, aucun modèle : elle peut se permettre de tourner sur chaque PR,
   # et c'est le seul endroit du dispositif qui BLOQUE un merge.
   pull_request:
-  # LE RUN COMPLET, sur alpha. `schedule` s'exécute sur la branche par défaut du dépôt, qui EST
-  # `alpha` — c'est ce qui rend ce cron équivalent au `push: alpha` que `claude-code-action`
-  # aurait refusé (voir l'en-tête). Lundi 04:00 UTC.
-  schedule:
-    - cron: "0 4 * * 1"
-  # Le même run complet, à la demande, depuis n'importe quelle branche.
+  # LE RUN COMPLET, À LA DEMANDE ET UNIQUEMENT À LA DEMANDE.
+  #
+  # Il y avait ici un cron hebdomadaire (lundi 04:00 UTC). Il est retiré, et la raison est le
+  # prix : depuis ultra11y 5.36, 103 des 106 critères RGAA exigent une adjudication par le
+  # modèle pour obtenir un `C` — le silence d'une règle ne prouve plus la conformité si le
+  # contrat de test du critère ne démontre pas que CHAQUE test numéroté a un instrument
+  # décisif. Mesuré sur ce dépôt, la worklist est passée de 27 critères à 84 pour le même
+  # commit et les mêmes captures. Un run n'est plus une dépense de fond, c'est une décision.
+  #
+  # CE QUE ÇA COÛTE, ET IL FAUT LE DIRE : une régression RGAA de rendu ne sera plus rattrapée
+  # par personne tant que quelqu'un ne lance pas ce workflow. La gate statique reste bloquante
+  # sur chaque PR, mais elle ne voit pas la page rendue. C'est l'arbitrage, et il est assumé.
+  #
+  # À lancer avant une mise en production, après un changement d'UI significatif, ou quand on
+  # veut un livrable RGAA daté : `gh workflow run a11y.yaml --ref alpha`.
   workflow_dispatch:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   # Une PR qui repousse annule son run précédent — il n'a plus rien à dire sur un code qui a
-  # changé. Un run complet (cron ou manuel) est un LIVRABLE : deux lancements coup sur coup ne
-  # doivent pas s'annuler l'un l'autre, le second n'ayant aucune raison d'être « plus à jour ».
+  # changé. Un run complet (manuel) est un LIVRABLE, et il est PAYÉ : deux lancements coup sur
+  # coup ne doivent pas s'annuler l'un l'autre, le second n'ayant aucune raison d'être « plus à
+  # jour » — et un run annulé a dépensé sans rien produire.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -165,7 +182,7 @@ jobs:
   a11y-gate:
     name: "RGAA · audit statique du code"
     # Le run complet réaudite déjà tout `src` dans `a11y-pages`. Garder cette gate sur les PR
-    # seulement évite deux invocations identiques sur le cron et le dispatch.
+    # seulement évite deux invocations identiques sur le dispatch.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -175,7 +192,7 @@ jobs:
           fetch-depth: 0
       - name: ultra11y — audit RGAA statique
         # Tag de release explicite : garder les deux usages de l'Action sur la même version.
-        uses: maxgfr/ultra11y@v5.40.1
+        uses: maxgfr/ultra11y@v5.40.2
         with:
           working-directory: packages/app
           # `src` et NON `src/**/*.tsx` : l'Action interpole `paths` sans quotes dans bash,
@@ -211,7 +228,7 @@ jobs:
           #
           # Le grief tombe exactement là où les deux jobs ne coexistent plus. Sur une PR,
           # `a11y-pages` ne tourne pas : un seul producteur, un seul commentaire et un seul
-          # rapport. Sur cron/dispatch, ce job est sauté et le livrable appartient exclusivement
+          # rapport. Sur un dispatch, ce job est sauté et le livrable appartient exclusivement
           # à `a11y-pages`.
           #
           # `digest` et non `pages` : sans instantané, cette gate n'a pas de grille par page à
@@ -233,7 +250,7 @@ jobs:
     # reproductible d'un run à l'autre. Sur une PR, la gate statique fait le travail.
     if: github.event_name != 'pull_request'
     # Ce tier a besoin de la stack complète — base, S3, ProConnect — et donc des secrets du
-    # dépôt. Sur `schedule` et `workflow_dispatch` ils sont toujours exposés : la condition qui
+    # dépôt. Sur `workflow_dispatch` ils sont toujours exposés : la condition qui
     # excluait les PR de fork n'a plus d'objet, ce job ne tournant plus jamais sur une PR.
     #
     # Les CONSTATS d'accessibilité ne font pas rougir (`fail-on: ""`) ; ce qui rougit, c'est une
@@ -434,7 +451,7 @@ jobs:
       # page, crops de preuve, HTML.
       - name: ultra11y — audit, rapport page par page et adjudication
         # Même tag de release que la gate PR ; ne jamais laisser les deux tiers diverger.
-        uses: maxgfr/ultra11y@v5.40.1
+        uses: maxgfr/ultra11y@v5.40.2
         env:
           # Lu depuis l'ENV DU JOB, jamais depuis un input : c'est ce qui rend le tier
           # inoffensif sur une PR de fork, où les secrets ne sont pas exposés — il se
@@ -465,15 +482,42 @@ jobs:
           adjudicate-runner: cli
           adjudicate-grain: worklist
           adjudicate-passes: "3"
-          # Opus high est réservé au cron/dispatch, jamais aux PR. Le CLI applique le budget à
-          # CHAQUE lot de huit, pas à la passe entière : 106 critères font au plus 14 lots, donc
-          # 0,70 $ borne une passe complète à 9,80 $ hors rares retries de transport. Les passes
-          # suivantes ne reçoivent que le reliquat et s'arrêtent dès que la grille est complète.
-          # `opus` est volontairement l'alias Claude CLI : le tier reste Opus, sa version peut
-          # évoluer avec le CLI.
-          adjudicate-model: opus
+          # LE MODÈLE, ET C'EST LE SEUL GARDE-FOU DE COÛT QUI RESTE.
+          #
+          # Sonnet 5, et le choix est MESURÉ, pas préféré. C'est le seul modèle qui ait fermé la
+          # grille de ce dépôt : run 33383329004, trois passes, `0 sans verdict` sur les 106.
+          # Opus n'a jamais rien fermé ici — sa seule tentative (run 33389189227) a rendu 12
+          # verdicts sur 84 pour 38,90 $, et le modèle n'y était pour rien : voir le budget
+          # ci-dessous. Ce qui coûte cher sur ce tier n'est pas la difficulté de la décision,
+          # c'est le VOLUME — depuis ultra11y 5.36, 103 des 106 critères RGAA exigent une
+          # adjudication pour obtenir un `C`, contre une cinquantaine avant.
+          adjudicate-model: claude-sonnet-5
+          # L'EFFORT, ET IL N'EST PAS LE MODÈLE. Ce qui arrive ici est ce qu'aucun moteur n'a pu
+          # décider : la difficulté n'est pas de choisir entre deux réponses, c'est de LIRE
+          # l'évidence sans se tromper. Mesuré sur le run 32782282651 (effort par défaut) : 13
+          # verdicts refusés à la première passe, 12 à la deuxième, 2 à la troisième — que des
+          # citations fabriquées et des snippets retapés, aucun désaccord de fond. `high` a
+          # réparé ça sans changer de tier de facturation.
           adjudicate-effort: high
-          adjudicate-budget-usd: "0.70"
+          # PAS DE PLAFOND PAR LOT, ET C'EST UN CHOIX APRÈS MESURE.
+          #
+          # `adjudicate-budget-usd` borne CHAQUE INVOCATION du CLI — pas une passe, pas le run.
+          # Ce fichier a longtemps affirmé le contraire (« 0,70 $ borne une passe complète à
+          # 9,80 $ »), et c'était faux dans les deux sens : un lot de huit coûte 0,88 à 2,00 $
+          # en Opus/`high`, donc le plafond était SOUS le coût d'un lot, et le pire cas n'était
+          # pas 9,80 $ mais `lots × passes × plafond`.
+          #
+          # Ce qu'un plafond trop bas produit n'est pas une économie, c'est une perte sèche : le
+          # CLI abandonne le lot ENTIER sur `error_max_budget_usd`, après l'avoir payé. Mesuré
+          # sur le run 33389189227 : 30 invocations, 38,90 $ dépensés, 12 verdicts gardés, 69
+          # critères sur 106 laissés « à évaluer », et le job rouge sur `require-decided`.
+          #
+          # Vide, donc. Ce qui borne réellement la dépense : le mur horaire du CLI (10 min par
+          # invocation, tué par le moteur), le `timeout-minutes` du job, les trois passes qui ne
+          # reçoivent que le reliquat, et le registre rejoué avant tout appel. ultra11y 5.40.2
+          # découpe en plus un lot abandonné en deux moitiés plutôt que de le perdre — le filet,
+          # pas la ceinture.
+          adjudicate-budget-usd: ""
           # Le registre : écrit à chaque run avec les verdicts que la porte a acceptés, rejoué au
           # run suivant. Il EST versionné (`packages/app/.ultra11y/verdicts/rgaa.json`) — rien
           # ici ne le commite pour autant, c'est un geste humain. Voir l'en-tête.
@@ -546,7 +590,7 @@ jobs:
           # survit pas à ce qu'elle excusait. Chacune est imprimée dans le log du job, donc
           # aucune ne s'oublie. C'est un renvoi nommé vers l'auditeur humain, pas un silence.
           undecidable-file: .ultra11y/undecidable.json
-          # PAS DE COMMENTAIRE : ni `schedule` ni `workflow_dispatch` n'ont de PR où le poster.
+          # PAS DE COMMENTAIRE : un `workflow_dispatch` n'a pas de PR où le poster.
           #
           # Le bilan page par page qu'il portait — une ligne par page avec sa base, ses C, ses NC
           # et ses sévérités, puis un bloc par page en échec — n'est pas perdu : c'est le rapport

--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -192,7 +192,7 @@ jobs:
           fetch-depth: 0
       - name: ultra11y — audit RGAA statique
         # Tag de release explicite : garder les deux usages de l'Action sur la même version.
-        uses: maxgfr/ultra11y@v5.40.2
+        uses: maxgfr/ultra11y@v5.41.0
         with:
           working-directory: packages/app
           # `src` et NON `src/**/*.tsx` : l'Action interpole `paths` sans quotes dans bash,
@@ -451,7 +451,7 @@ jobs:
       # page, crops de preuve, HTML.
       - name: ultra11y — audit, rapport page par page et adjudication
         # Même tag de release que la gate PR ; ne jamais laisser les deux tiers diverger.
-        uses: maxgfr/ultra11y@v5.40.2
+        uses: maxgfr/ultra11y@v5.41.0
         env:
           # Lu depuis l'ENV DU JOB, jamais depuis un input : c'est ce qui rend le tier
           # inoffensif sur une PR de fork, où les secrets ne sont pas exposés — il se

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,6 +121,24 @@ jobs:
       - name: Check cahier de tests correlation
         run: pnpm --filter app check:cahier
 
+  a11y-version-coherence:
+    # LA SEULE CHOSE QUI EMPÊCHE UNE DEMI-MONTÉE DE VERSION D'ULTRA11Y.
+    #
+    # Le tag de l'Action (deux fois dans a11y.yaml) et la devDependency `ultra11y` doivent
+    # porter la même version : le balayage Playwright ÉCRIT les instantanés avec la
+    # devDependency, l'Action les RÉINGÈRE avec son moteur embarqué. Dependabot les met à jour
+    # dans deux PR distinctes, sur deux écosystèmes qui s'ignorent — rien de son côté ne sait
+    # qu'elles vont ensemble. C'est ce job qui le sait.
+    #
+    # Ni pnpm ni node : trois greps, quelques secondes.
+    name: "App · Cohérence des versions ultra11y"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Check ultra11y version coherence
+        run: ./scripts/a11y/check-ultra11y-version.sh
+
   app-check-journal:
     name: App · Journal monotone check
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ La pipeline `/analyse` → `/implement` ajoute ses propres agents et gates par-d
 | Fichier | Déclencheur | Rôle |
 |---|---|---|
 | `ci.yaml` | chaque push | build · lint · format · typecheck · tests |
-| `a11y.yaml` | PR, cron hebdo (lundi), manuel | ultra11y. Sur **PR** : `a11y-gate` seul — audit statique de tout `src`, **bloquant**. Sur **cron/manuel** : la chaîne complète (`a11y-pages` + `a11y-bundle`), non bloquante. Voir `.claude/rules/rgaa.md` |
+| `a11y.yaml` | PR, manuel | ultra11y. Sur **PR** : `a11y-gate` seul — audit statique de tout `src`, **bloquant**. Sur **manuel** : la chaîne complète (`a11y-pages` + `a11y-bundle`), non bloquante et payante — le cron hebdo a été retiré, voir `.claude/rules/rgaa.md` |
 | `e2e.yaml` | PR → `alpha`, manuel | suite Playwright complète |
 | `lighthouse.yaml` | `deployment_status` (success, hors env `build-*`) | audit Lighthouse sur l'URL déployée |
 | `review-auto.yaml` | push sur toute branche sauf `master` et `**-persist` (dependabot inclus) | déploiement des review apps |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ pnpm db:studio            # Drizzle Studio
 
 ## Garde-fous automatiques
 
-Rien à lancer : les hooks tournent seuls (`block-bad-patterns` avant chaque édition, `auto-lint` après), et les 4 gates qualité sont dus avant de déclarer une tâche terminée. Détail → `.claude/rules/automation.md` (toujours chargée).
+Rien à lancer : les hooks tournent seuls (`block-bad-patterns` avant chaque édition, `auto-lint` après, `check-ultra11y-plugin` au premier prompt), et les 4 gates qualité sont dus avant de déclarer une tâche terminée. Détail → `.claude/rules/automation.md` (toujours chargée).
 
 La pipeline `/analyse` → `/implement` ajoute ses propres agents et gates par-dessus. Détail → `.claude/pipeline/orchestration.md` (lu à la demande).
 
@@ -126,7 +126,7 @@ La pipeline `/analyse` → `/implement` ajoute ses propres agents et gates par-d
 
 | Fichier | Déclencheur | Rôle |
 |---|---|---|
-| `ci.yaml` | chaque push | build · lint · format · typecheck · tests |
+| `ci.yaml` | chaque push | build · lint · format · typecheck · tests · cohérence des versions ultra11y |
 | `a11y.yaml` | PR, manuel | ultra11y. Sur **PR** : `a11y-gate` seul — audit statique de tout `src`, **bloquant**. Sur **manuel** : la chaîne complète (`a11y-pages` + `a11y-bundle`), non bloquante et payante — le cron hebdo a été retiré, voir `.claude/rules/rgaa.md` |
 | `e2e.yaml` | PR → `alpha`, manuel | suite Playwright complète |
 | `lighthouse.yaml` | `deployment_status` (success, hors env `build-*`) | audit Lighthouse sur l'URL déployée |

--- a/docs/accessibilite-ultra11y.md
+++ b/docs/accessibilite-ultra11y.md
@@ -250,6 +250,26 @@ chaque moitié repartant avec son propre plafond — une perte de huit critères
 perte d'un. Ce dépôt ne pose plus de plafond du tout (voir « Ce que coûte l'adjudication ») ;
 ce découpage est le filet, pas la ceinture.
 
+### RGAA 10.7 et les contrôles DSFR — ce que 5.41.0 corrige
+
+La sonde `dyn-focus-visible` proxifiait bien un radio/checkbox visuellement masqué vers son
+label — c'est la forme DSFR, et c'était le bon réflexe. Mais elle lisait ensuite le style
+**propre** du label, c'est-à-dire la seule boîte qu'un design system ne peint pas : DSFR dessine
+la case, la coche et l'anneau de focus dans `label::before`.
+
+Mesuré sur le run 33389189227 : **12 constats 10.7**, tous des `<label class="fr-label">`, tous
+faux — 9 sur les cases « années » de `admin-stats`, 2 sur les radios de l'avis du CSE, 1 sur le
+choix de parcours de conformité.
+
+Et le dégât dépassait le bruit. **10.7 n'est pas sur l'allowlist `completeBySilence`**, donc un
+NC fabriqué sur 3 pages laissait le critère « à évaluer » sur les **34 autres** — hors d'atteinte
+de toute adjudication, puisqu'un critère déjà tranché pour le run n'entre jamais dans la
+worklist. C'était, à lui seul, ce qui rendait `require-decided: pages` inatteignable.
+
+La règle générale, qui vaut au-delà de ce cas : **un critère jugé NC quelque part et absent de
+l'allowlist reste « à évaluer » sur chaque page où le défaut ne tire pas.** Un `C` d'agent, lui,
+ferme les 37 pages — mesuré, 31 verdicts sur 31.
+
 ### En local, la même chose sans CI
 
 Depuis `packages/app` :
@@ -294,14 +314,20 @@ Trois surfaces à bouger ensemble — deux dans le dépôt, une hors dépôt :
 ```bash
 pnpm --filter app add -D ultra11y@<version>   # version EXACTE, pas de ^
 # puis aligner les DEUX `maxgfr/ultra11y@v<version>` de .github/workflows/a11y.yaml
-claude plugin update ultra11y@ultra11y        # hors dépôt, à lancer à la main
+./scripts/a11y/check-ultra11y-version.sh      # le job CI qui refuse une demi-montée
 ```
 
-La devDependency et les deux usages de l'Action sont alignés sur **5.40.1**. Cette release contient
-les correctifs de complétude des worklists et de performance validés sur le dépôt réel. Le
-**plugin Claude Code** est une troisième surface, hors dépôt : il se met à jour à la main et peut
-donc rester très en retard sans que rien ne le signale — vérifier son cache si le skill
-`review-a11y` se comporte autrement que la CI.
+La devDependency et les deux usages de l'Action sont alignés sur **5.41.0**, et ce n'est plus une
+consigne : `scripts/a11y/check-ultra11y-version.sh` tourne dans `ci.yaml` sur chaque push et
+refuse un désalignement. Ce n'est pas de l'hygiène — la suite Playwright ÉCRIT les instantanés
+avec la devDependency et l'Action les RÉINGÈRE avec son moteur embarqué ; deux versions, deux
+formats, et rien ne lève d'erreur.
+
+Le **plugin Claude Code** est la quatrième surface, hors dépôt, et la seule que rien ici ne peut
+pinner. Le hook `check-ultra11y-plugin.sh` compare hors ligne la version installée au tag
+d'`a11y.yaml` au premier prompt de chaque session, et ne touche au réseau qu'en cas d'écart. Il a
+été écrit pour une raison mesurée : le 31/08/2026, le plugin était en **4.5.1** pendant que le
+dépôt tournait en 5.40.1.
 
 À noter si un bump échoue : la publication npm de la 5.3.0 est
 tombée sur la signature de provenance (`CA_CREATE_SIGNING_CERTIFICATE_ERROR`, 403 du CA) alors

--- a/docs/accessibilite-ultra11y.md
+++ b/docs/accessibilite-ultra11y.md
@@ -15,19 +15,37 @@ tag de version explicite :
 | Job | Quand | Ce qu'il fait |
 |---|---|---|
 | `a11y-gate` | **chaque PR** (bloquant) | Audit statique JSX/TSX de tout `src`. Gratuit, quelques secondes, aucun navigateur et aucun modèle. **C'est la seule gate du dispositif qui arrête un merge sur un constat** (`fail-on: blocking`) : SARIF, annotations, commentaire sticky `digest` et rapport `ultra11y-pr-static`. |
-| `a11y-pages` | **cron hebdo (lundi 04:00 UTC) + manuel** | La suite Playwright `src/e2e/a11y/` enregistre **39 pages** en épinglant l'état applicatif que chaque écran de tunnel exige — dont **37 sont effectivement capturées**, les 2 restantes étant gardées par un `test.skip` faute de données ; **24** seulement sont déclarées dans `.ultra11yrc.json`, et c'est ce sous-ensemble que `require-sample` tient. L'Action réaudite tout `src`, réingère les instantanés, rejoue le registre puis soumet seulement le reliquat à Claude CLI par lots de huit (`opus`, effort `high`). Produit LE rapport page par page. Les constats ne bloquent pas — on mesure. Une panne, une grille incomplète (`require-decided: pages`), un rendu requis mais absent (`require-rendered`) ou un balayage amputé (`require-sample`) bloquent. |
-| `a11y-bundle` | cron + manuel | Fusionne les parties en un seul artefact `ultra11y-rgaa`. |
+| `a11y-pages` | **manuel uniquement** (`workflow_dispatch`) | La suite Playwright `src/e2e/a11y/` enregistre **39 pages** en épinglant l'état applicatif que chaque écran de tunnel exige — dont **37 sont effectivement capturées**, les 2 restantes étant gardées par un `test.skip` faute de données ; **24** seulement sont déclarées dans `.ultra11yrc.json`, et c'est ce sous-ensemble que `require-sample` tient. L'Action réaudite tout `src`, réingère les instantanés, rejoue le registre puis soumet seulement le reliquat à Claude CLI par lots de huit (`claude-sonnet-5`, effort `high`, sans plafond par lot). Produit LE rapport page par page. Les constats ne bloquent pas — on mesure. Une panne, une grille incomplète (`require-decided: pages`), un rendu requis mais absent (`require-rendered`) ou un balayage amputé (`require-sample`) bloquent. |
+| `a11y-bundle` | manuel | Fusionne les parties en un seul artefact `ultra11y-rgaa`. |
 
 **Deux déclenchements, et ils ne paient pas la même chose.** `pull_request` ne lance que la gate
-statique — gratuite, sans modèle, bloquante. `schedule` (hebdo) et `workflow_dispatch` lancent la
-chaîne complète : balayage navigateur, critères de rendu, rejeu du registre puis adjudication IA
-du reliquat, livrable.
+statique — gratuite, sans modèle, bloquante. `workflow_dispatch` lance la chaîne complète :
+balayage navigateur, critères de rendu, rejeu du registre puis adjudication IA du reliquat,
+livrable.
 
-**Pourquoi un cron et non `push: alpha`**, alors que le runner CLI sait désormais traiter un
-`push`. Le run complet construit la stack, parcourt les pages et paie le reliquat au modèle ; le
-lancer à chaque merge multiplierait le coût sans améliorer le feedback immédiat, déjà fourni par
-la gate statique. La branche par défaut étant `alpha`, le `schedule` lit et exécute son workflow :
-le même périmètre exhaustif, une fois par semaine, plus le `workflow_dispatch` à la demande.
+### Pourquoi il n'y a plus de cron
+
+Il y en a eu un — lundi 04:00 UTC — et on avait pris soin de le choisir plutôt qu'un
+`push: alpha` que `claude-code-action` aurait refusé. Il est retiré, et la raison est le prix.
+
+**ultra11y 5.36 a rendu le contrat d'automatisation exhaustif.** Un critère n'obtient un `C` par
+mesure que si son contrat de test démontre que *chaque* test numéroté a un instrument décisif.
+Sur les 106 critères RGAA, **trois** remplissent cette condition : 8.3, 8.5 et 10.1. Les 103
+autres exigent une adjudication. Mesuré sur ce dépôt, même commit et mêmes 37 captures :
+
+| | run 33383329004 (action `v5.34.2`) | run 33389189227 (action `v5.40.1`) |
+|---|---|---|
+| Grille | `26 moteur, 32 mesure (scan), 48 agent, 0 sans verdict` | `3 moteur, 0 mesure (scan), 32 agent, 69 sans verdict` |
+| Worklist modèle | 27 critères | 84 critères |
+
+Ce n'est pas une régression, c'est un durcissement, et il se défend : avant, un dépôt sans image
+marquait 100 % sur « chaque image a-t-elle une alternative pertinente ? ». Mais un run qui adjuge
+84 critères n'est plus une dépense de fond qu'on laisse tourner toutes les semaines — il est
+lancé quand on en veut le résultat : `gh workflow run a11y.yaml --ref alpha`.
+
+**Ce que ça coûte, dit franchement :** une régression RGAA de rendu ne sera rattrapée par
+personne tant que personne ne lance ce workflow. La gate statique reste bloquante sur chaque PR,
+mais elle ne voit pas la page rendue.
 
 Ce que ça ne donne pas, et il faut le savoir : **une régression RGAA de rendu peut vivre jusqu'au
 prochain tick.** Ce qui la rattrape sur une PR est l'audit statique, qui ne voit pas la page
@@ -177,15 +195,36 @@ jq '.standard' audits/audit-latest.json    # doit dire "rgaa", jamais "wcag"
 
 ### Ce que coûte l'adjudication
 
-Sans registre à rejouer, l'ancien runner Sonnet a coûté **9,59 $**, mesuré sur le run du
-24/08/2026 (3 passes — 5,91 + 2,43 + 1,25). Le registre **est** commité depuis
-(`packages/app/.ultra11y/verdicts/rgaa.json`, 47 verdicts) : les runs suivants rejouent ce qui
-tient et ne paient que le reliquat. Le runner actuel utilise Opus high.
-`adjudicate-budget-usd` borne **chaque lot CLI**, et non une passe entière : avec des lots de
-huit, les 106 critères RGAA représentent au plus 14 appels. La valeur `0.70` borne donc une passe
-complète à **9,80 $** hors rares retries de transport, et trois passes à **29,40 $** dans le pire
-cas nominal. Chaque passe suivante ne reçoit que le reliquat ; une grille complète arrête les
-passes restantes.
+Le chiffre historique — **9,59 $** sur le run du 24/08/2026, 3 passes — a été mesuré quand la
+worklist faisait ~27 critères. Depuis 5.36 elle en fait ~84 (voir « Pourquoi il n'y a plus de
+cron »), donc ce chiffre n'est plus la référence : **un run à froid coûte plusieurs fois cela.**
+
+**`adjudicate-budget-usd` borne CHAQUE INVOCATION du CLI** — pas une passe, pas le run. Ce
+document a longtemps affirmé le contraire (« 0,70 $ borne une passe complète à 9,80 $ ») et
+c'était faux dans les deux sens :
+
+- le plafond était **sous le coût d'un lot** : mesuré, un lot de huit coûte 0,88 à 2,00 $ en
+  Opus / effort `high` ;
+- le pire cas n'était pas 9,80 $ mais `lots × passes × plafond`, un retry de transport repartant
+  avec un plafond neuf.
+
+Et un plafond trop bas ne produit pas une économie, il produit une **perte sèche** : le CLI
+abandonne le lot ENTIER sur `error_max_budget_usd`, après l'avoir payé. Mesuré sur le run
+33389189227 : **30 invocations, 38,90 $ dépensés, 12 verdicts gardés**, 69 critères sur 106
+laissés « à évaluer », job rouge sur `require-decided`.
+
+D'où la configuration actuelle : **`adjudicate-budget-usd: ""`** (aucun plafond par lot) et
+**`adjudicate-model: claude-sonnet-5`**. Ce qui borne la dépense est le mur horaire du CLI (10
+min par invocation), le `timeout-minutes` du job, les trois passes qui ne reçoivent que le
+reliquat, et le registre rejoué avant tout appel. Sonnet 5 est le seul modèle qui ait fermé la
+grille de ce dépôt (run 33383329004, `0 sans verdict`) ; Opus n'y est jamais parvenu.
+
+**Le registre est devenu la pièce maîtresse**, et il n'amortit qu'à moitié.
+`packages/app/.ultra11y/verdicts/rgaa.json` (48 verdicts) est rejoué avant le moindre appel, mais
+au dernier run **27 entrées sur 48 étaient périmées** (« l'évidence a changé ») : l'empreinte
+bouge d'un balayage à l'autre. Rien dans la CI ne commite ce fichier — c'est un geste humain,
+délibéré. Après un run vert : récupérer `verdicts-rgaa.json` dans l'artefact `ultra11y-rgaa`,
+relire le diff, commiter.
 
 **L'effort est le second levier, et il n'est pas le modèle.** `adjudicate-effort: high` (5.34.0).
 Ce qui arrive à ce tier est ce qu'aucun moteur n'a pu décider, donc la difficulté n'est pas de
@@ -206,9 +245,10 @@ dans ce dépôt sont corrigés : le grain par défaut est valide, l'indisponibil
 les retries extérieurs et une passe entièrement inopérante fait échouer la porte finale au lieu de
 laisser une grille vide paraître exploitable.
 
-Le coût de chaque lot est borné par `adjudicate-budget-usd: "0.70"`, avec au plus 14 lots par
-passe et trois passes. Le tier et l'effort sont configurés sur `opus` et `high` ; `opus` est
-l'alias du Claude CLI, donc le tier reste Opus mais sa version précise peut évoluer avec le CLI.
+Depuis **5.40.2**, un lot que le plafond fait abandonner est **coupé en deux et remis en file**,
+chaque moitié repartant avec son propre plafond — une perte de huit critères devient au pire une
+perte d'un. Ce dépôt ne pose plus de plafond du tout (voir « Ce que coûte l'adjudication ») ;
+ce découpage est le filet, pas la ceinture.
 
 ### En local, la même chose sans CI
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -102,7 +102,7 @@
 		"swagger-ui-dist": "^5.32.2",
 		"tsx": "^4.21.0",
 		"typescript": "^6.0.2",
-		"ultra11y": "5.40.2",
+		"ultra11y": "5.41.0",
 		"vite-tsconfig-paths": "^6.1.1",
 		"vitest": "^4.1.4"
 	},

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -102,7 +102,7 @@
 		"swagger-ui-dist": "^5.32.2",
 		"tsx": "^4.21.0",
 		"typescript": "^6.0.2",
-		"ultra11y": "5.40.1",
+		"ultra11y": "5.40.2",
 		"vite-tsconfig-paths": "^6.1.1",
 		"vitest": "^4.1.4"
 	},

--- a/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.module.scss
@@ -26,3 +26,21 @@
 .spinning {
 	animation: spin 1s linear infinite;
 }
+
+// RGAA 13.8 — une animation qui se répète indéfiniment doit pouvoir être neutralisée.
+// Le critère vise d'abord le contenu clignotant porteur d'information ; ce spinner n'en est
+// pas un et il est transitoire, mais `prefers-reduced-motion` est le réglage SYSTÈME par
+// lequel quelqu'un déclare que le mouvement lui pose problème — vestibulaire, migraine,
+// trouble de l'attention. Le respecter ne coûte rien ici.
+//
+// On neutralise plutôt qu'on ne masque : l'icône reste visible et garde son rôle
+// d'indicateur, elle cesse seulement de tourner. La supprimer retirerait l'information.
+//
+// `@media` de préférence utilisateur, pas de point de rupture : la règle SCSS du dépôt
+// interdit les media queries de largeur (il faut `respond-from`/`respond-to`), et celle-ci
+// n'en est pas une.
+@media (prefers-reduced-motion: reduce) {
+	.spinning {
+		animation: none;
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       ultra11y:
-        specifier: 5.40.2
-        version: 5.40.2(playwright-core@1.62.1)
+        specifier: 5.41.0
+        version: 5.41.0(playwright-core@1.62.1)
       vite-tsconfig-paths:
         specifier: ^6.1.1
         version: 6.1.1(typescript@6.0.2)(vite@7.3.1(@types/node@26.4.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -6560,8 +6560,8 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  ultra11y@5.40.2:
-    resolution: {integrity: sha512-38ikzJV9MQq236HWpQalKXFMdeGnHtAeLIdDq6FQRCBc3sH+uigYoQgmItAdA0+4vvGeJb9fzjl4wgtXK2h0og==}
+  ultra11y@5.41.0:
+    resolution: {integrity: sha512-2lPRd9+JNsA4bQ4tpVxaQrwb0m7lQx4KtYgSA1Maq9M+3eHCqzIHGNa77yh8SCbivV/trsh0ue8HxAOTJuGsGg==}
     engines: {node: '>=22.18.0'}
     hasBin: true
 
@@ -13651,7 +13651,7 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
-  ultra11y@5.40.2(playwright-core@1.62.1):
+  ultra11y@5.41.0(playwright-core@1.62.1):
     dependencies:
       '@axe-core/playwright': 4.13.0(playwright-core@1.62.1)
       '@babel/parser': 8.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       ultra11y:
-        specifier: 5.40.1
-        version: 5.40.1(playwright-core@1.62.1)
+        specifier: 5.40.2
+        version: 5.40.2(playwright-core@1.62.1)
       vite-tsconfig-paths:
         specifier: ^6.1.1
         version: 6.1.1(typescript@6.0.2)(vite@7.3.1(@types/node@26.4.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -5668,10 +5668,6 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6564,8 +6560,8 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  ultra11y@5.40.1:
-    resolution: {integrity: sha512-v9z7qMyl86DlZ6ESlzkUrZ/YaliZ9qE0NJzYcKyWIBFpmMRbqbyQx7sq7DPLeCoDh+w/ZD4MT+6Caob394GMWg==}
+  ultra11y@5.40.2:
+    resolution: {integrity: sha512-38ikzJV9MQq236HWpQalKXFMdeGnHtAeLIdDq6FQRCBc3sH+uigYoQgmItAdA0+4vvGeJb9fzjl4wgtXK2h0og==}
     engines: {node: '>=22.18.0'}
     hasBin: true
 
@@ -12617,12 +12613,6 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.18:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.23:
     dependencies:
       nanoid: 3.3.16
@@ -13661,7 +13651,7 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
-  ultra11y@5.40.1(playwright-core@1.62.1):
+  ultra11y@5.40.2(playwright-core@1.62.1):
     dependencies:
       '@axe-core/playwright': 4.13.0(playwright-core@1.62.1)
       '@babel/parser': 8.0.4
@@ -13795,7 +13785,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.18
+      postcss: 8.5.23
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/scripts/a11y/check-ultra11y-version.sh
+++ b/scripts/a11y/check-ultra11y-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# LA VERSION D'ULTRA11Y VIT À TROIS ENDROITS DANS CE DÉPÔT, ET ILS DOIVENT S'ACCORDER.
+#
+#   1 & 2. `.github/workflows/a11y.yaml` — `uses: maxgfr/ultra11y@vX`, DEUX FOIS : la gate PR
+#          et `a11y-pages`. Le moteur est embarqué dans l'Action, donc ce tag EST le moteur.
+#   3.     `packages/app/package.json` — la devDependency `ultra11y`. Ce n'est pas un doublon
+#          décoratif : c'est le binaire (`pnpm exec ultra11y`) et le plugin Playwright
+#          (`ultra11y/playwright`) dont `src/e2e/a11y/` se sert pour ÉCRIRE les instantanés que
+#          l'Action réingère ensuite avec SON moteur.
+#
+# Deux versions, deux formats d'instantané — et la divergence ne lève aucune erreur : elle se
+# lit comme des critères « à évaluer » dans un rapport qui a l'air complet.
+#
+# Dependabot met bien les trois à jour, mais dans des PR séparées et sur deux écosystèmes
+# (`github-actions` et `npm`) : il n'a aucun moyen de savoir qu'elles vont ensemble. Ce script
+# est ce qui refuse une demi-montée de version.
+#
+# Sortie 0 si tout s'accorde, 1 sinon. Aucune dépendance : grep et sed.
+set -euo pipefail
+
+root="${1:-$(git rev-parse --show-toplevel)}"
+workflow="$root/.github/workflows/a11y.yaml"
+manifest="$root/packages/app/package.json"
+
+fail() {
+  echo "✗ ultra11y : $1" >&2
+  exit 1
+}
+
+[ -f "$workflow" ] || fail "fichier introuvable : $workflow"
+[ -f "$manifest" ] || fail "fichier introuvable : $manifest"
+
+# Les lignes `uses:` seulement — jamais un `maxgfr/ultra11y@<sha>` cité dans un commentaire,
+# et il y en a un dans ce fichier.
+pins=$(grep -oE '^[[:space:]]*uses:[[:space:]]*maxgfr/ultra11y@v[0-9]+\.[0-9]+\.[0-9]+' "$workflow" | sed -E 's/.*@v//')
+count=$(printf '%s\n' "$pins" | grep -c . || true)
+first=$(printf '%s\n' "$pins" | sed -n 1p)
+second=$(printf '%s\n' "$pins" | sed -n 2p)
+dep=$(grep -oE '"ultra11y"[[:space:]]*:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$manifest" | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)"$/\1/')
+
+[ "$count" -eq 2 ] || fail "attendu 2 \`uses: maxgfr/ultra11y@vX\` dans a11y.yaml, trouvé $count. Si un tier a été ajouté ou retiré, mets ce script à jour avec lui."
+[ -n "$dep" ] || fail "devDependency \`ultra11y\` introuvable dans packages/app/package.json"
+
+[ "$first" = "$second" ] ||
+  fail "les deux tiers de l'Action divergent — un job en v$first, l'autre en v$second. Ils doivent porter le même tag."
+
+[ "$first" = "$dep" ] ||
+  fail "l'Action est en v$first et la devDependency en $dep. Le balayage Playwright écrit les instantanés avec la devDependency et l'Action les réingère avec le sien — alignez-les."
+
+echo "✓ ultra11y v$first : les deux tiers de l'Action et la devDependency sont alignés."


### PR DESCRIPTION
## Le problème

Le run [33389189227](https://github.com/SocialGouv/egapro/actions/runs/33389189227) est sorti **rouge** : 69 critères sur 106 « à évaluer », après avoir dépensé **38,90 $** pour **12 verdicts** conservés.

```
ultra11y judge : 84 critère(s) en 11 lot(s)…  → 22,07 $ →  8/84 verdicts
ultra11y judge : 76 critère(s) en 10 lot(s)…  →  8,80 $ →  4/76 verdicts
ultra11y judge : 72 critère(s) en  9 lot(s)…  →  8,04 $ →  0/72 verdicts
```

Deux causes indépendantes.

### 1. Le plafond par lot était sous le coût d'un lot

`adjudicate-budget-usd` borne **chaque invocation** du CLI, pas une passe — le commentaire du workflow affirmait le contraire (« 0,70 $ borne une passe complète à 9,80 $ »). Mesuré, un lot de huit critères coûte **0,88 à 2,00 $** en Opus / effort `high`. Résultat : 29 des 30 invocations abandonnées sur `error_max_budget_usd`, et le CLI **jette le lot entier** quand il abandonne. L'argent part, le travail est perdu.

Le plafond est **vidé** plutôt que relevé. Ce qui borne réellement la dépense : le mur horaire du CLI (10 min/invocation), le `timeout-minutes` du job, les trois passes qui ne reçoivent que le reliquat, et le registre rejoué avant tout appel.

### 2. Depuis ultra11y 5.36, la worklist a triplé

Un critère n'obtient un `C` par mesure que si son contrat de test démontre que *chaque* test numéroté a un instrument décisif. Sur les 106 critères RGAA, **trois** remplissent cette condition (8.3, 8.5, 10.1).

Même commit, mêmes 37 captures, 1 h 30 d'écart :

| | run 33383329004 (`v5.34.2`) | run 33389189227 (`v5.40.1`) |
|---|---|---|
| Grille | `26 moteur, 32 mesure, 48 agent, **0 sans verdict**` | `3 moteur, 0 mesure, 32 agent, **69 sans verdict**` |
| Worklist modèle | 27 critères | 84 critères |

Ce n'est **pas une régression** : c'est un durcissement documenté et verrouillé par des tests en amont, et il se défend — avant, un dépôt sans image marquait 100 % sur « chaque image a-t-elle une alternative pertinente ? ».

## Ce que fait cette PR

- **`adjudicate-budget-usd: ""`** — plus de plafond par lot.
- **`adjudicate-model: claude-sonnet-5`** — le seul modèle qui ait fermé la grille de ce dépôt (`0 sans verdict`). Opus n'y est jamais parvenu, et avec un budget illimité le modèle est le seul garde-fou de coût qui reste.
- **Plus de cron.** Un run qui adjuge 84 critères n'est plus une dépense de fond hebdomadaire — il est lancé quand on en veut le résultat : `gh workflow run a11y.yaml --ref alpha`.
- **ultra11y `v5.40.2`**, aux deux endroits + devDependency.
- Doc remise d'aplomb : `docs/accessibilite-ultra11y.md`, `.claude/rules/rgaa.md`, `CLAUDE.md`.

`adjudicate-grain` reste à `worklist` (lots de huit) et `adjudicate-effort` à `high` — inchangés.

**`packages/app/.ultra11y/undecidable.json` n'est pas touché** : sous 5.40.x le moteur ne tranche plus 13.3/13.4, donc la dispense redevient valide et la porte l'accepte (`2 déclaré(s) indécidable(s)`, sans reproche).

## En amont

Deux correctifs poussés dans `maxgfr/ultra11y`, sortis en **v5.40.2** :

- **`fix(derive)`** — `measuredRescue` refusait sur `pc.automation?.completeBySilence !== true` ; pour un pack qui ne déclare aucun contrat, `undefined !== true` est vrai, donc le tier mesure était mort pour tout pack tiers. Aucun effet sur RGAA (106/106 ont un contrat).
- **`fix(judge)`** — un lot abandonné sur le plafond est désormais **coupé en deux et remis en file**, chaque moitié avec son propre plafond ; l'enveloppe est lue avant d'être jetée ; et l'abandon n'est plus rejoué (un plafond neuf sur le même travail n'est pas un retry, c'est une deuxième facture).

## Ce que ça coûte, dit franchement

Une régression RGAA de rendu ne sera rattrapée par personne tant que personne ne lance le workflow. La gate statique reste bloquante sur chaque PR, mais elle ne voit pas la page rendue.

## Vérification

- ultra11y : `typecheck` · `lint` · `check:build` · **4035 tests** · CI verte sur `main` · lane payant `Adjudication (keyed)` rejoué sur la version publiée.
- egapro : `a11y-gate` doit rester vert sur cette PR (c'est la validation du bump `v5.40.2` sur le chemin PR). Le run complet est à lancer à la main sur la branche avant merge.

## Hors périmètre

Deux constats RGAA **réels**, présents dans les deux runs et non bloquants (`fail-on: ""`) :
- **10.7** — focus clavier non visible, 12 occurrences sur `admin-stats`.
- **13.8** — `SavedIndicator.module.scss:27`, `spin 1s linear infinite` sans garde `prefers-reduced-motion`.
