### PR TITLE
fix(ci): la suppression d'une branche *-persist ne détruit plus l'env de test

### DIFF
--- a/.github/workflows/deactivate.yaml
+++ b/.github/workflows/deactivate.yaml
@@ -2,19 +2,57 @@ name: ♻️ Deactivate
 on:
   pull_request:
     types: [closed]
+  # No `branches:` filter here, on purpose: GitHub applies branch and tag
+  # filters to `push` and `pull_request` only. On `delete` they are silently
+  # ignored, so an exclusion written here reads as a protection while doing
+  # nothing at all. Deleting the leftover `rgaa-persist` branch on 2026-08-26
+  # destroyed the persistent RGAA test environment exactly that way, past an
+  # `!**-persist` line that looked like it covered the case. The exclusions
+  # now live in the `guard` job below, which does run.
   delete:
-    branches:
-      - "**"
-      - "!v*"
-      - "!master"
-      - "!alpha"
-      - "!**-persist"
 
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.event.ref || github.event.pull_request.head.ref }}
 
 jobs:
+  guard:
+    name: "🛡️ Protected refs"
+    runs-on: ubuntu-latest
+    outputs:
+      protected: ${{ steps.check.outputs.protected }}
+    steps:
+      - name: 🛡️ Decide whether this ref may be deactivated
+        id: check
+        env:
+          REF_TYPE: ${{ github.event.ref_type }}
+          REF: ${{ github.event.ref || github.event.pull_request.head.ref }}
+        run: |
+          # `github.event.ref` is already the short name on `delete`
+          # (`rgaa-persist`), as is `head.ref` on `pull_request` — the strip is
+          # a belt, not a need.
+          BRANCH=${REF#refs/heads/}
+          protected=false
+
+          # A deleted tag has no environment behind it.
+          if [ "$REF_TYPE" = "tag" ]; then
+            protected=true
+          fi
+
+          # `*-persist` are the persistent test environments (rgaa, perf).
+          # They are deployed only by promote-test-env.yaml, from a release
+          # tag, and never track a branch — nothing about a branch of that
+          # name should tear them down. `master` and `alpha` are the long
+          # lived environments.
+          case "$BRANCH" in
+            *-persist | master | alpha) protected=true ;;
+          esac
+
+          echo "protected=$protected" >> "$GITHUB_OUTPUT"
+          echo "ref_type=${REF_TYPE:-branch} ref=${BRANCH} protected=${protected}"
+
   kontinuous:
+    needs: guard
+    if: needs.guard.outputs.protected == 'false'
     uses: socialgouv/workflows/.github/workflows/use-ks-gh-deactivate-atlas.yaml@v1
     secrets: inherit


### PR DESCRIPTION
## Le problème

`deactivate.yaml` prétendait exclure les environnements de test persistants :

```yaml
on:
  delete:
    branches:
      - "**"
      - "!v*"
      - "!master"
      - "!alpha"
      - "!**-persist"   # ← n'a jamais rien filtré
```

**GitHub n'applique les filtres `branches` / `tags` qu'aux événements `push` et `pull_request`.** Sur `delete`, ils sont ignorés sans un mot. Tout le bloc était donc décoratif — `!v*`, `!master`, `!alpha` comme `!**-persist`.

## Ce que ça a coûté

Le 26/08/2026 à 20:02 UTC, la suppression de la branche `rgaa-persist` a déclenché la désactivation de l'environnement d'audit RGAA — [run 33008317350](https://github.com/SocialGouv/egapro/actions/runs/33008317350) :

```
job-dev-egapro-rgaa-persist-delete-namespace-deactiva-5uuy1hpk
☸️  job.batch/job-dev-egapro-rgaa-persist-delete-namespace-deactiva-… serverside-applied
```

Namespace détruit → ingress détruit → external-dns retire l'enregistrement. `https://egapro-rgaa-persist.ovh.fabrique.social.gouv.fr` répond `NXDOMAIN` depuis, et le namespace est absent du cluster dev.

La branche supprimée n'avait plus aucun rôle : `c1de2abf6` a retiré l'étape « Point the branch to the release » de la promotion, qui poussait jusque-là une vraie branche `<target>-persist`. Les environnements persistants sont désormais pilotés par `KS_GIT_BRANCH` seul, sans branche git. La suppression ressemblait donc à du ménage inoffensif.

`perf-persist` existe encore et arme exactement le même piège sur l'environnement de perf.

## Le correctif

Le bloc `branches:` est supprimé — il mentait sur ce qu'il faisait — et l'exclusion passe dans un job `guard` qui, lui, s'exécute vraiment :

| ref | `protected` | Deactivate |
|---|---|---|
| `ticket/4324-…` | `false` | s'exécute |
| `rgaa-persist`, `perf-persist` | `true` | skipped |
| `master`, `alpha` | `true` | skipped |
| tag (`ref_type=tag`) | `true` | skipped |

Le `!v*` de l'ancien bloc visait les tags ; ils sont maintenant couverts par `ref_type`, ce qui évite d'exclure à tort une branche du genre `visual-…`.

La décision est imprimée dans le log du job (`ref_type=… ref=… protected=…`), donc auditable après coup — ce qui manquait précisément pour comprendre l'incident du 26/08.

## Vérification

Logique du garde rejouée hors CI sous `bash -eo pipefail` (le shell d'Actions) sur `rgaa-persist`, `perf-persist`, `zz-test-persist`, `ticket/4324-foo`, `alpha`, `master`, `visual-refonte`, un tag et un `head.ref` de PR : verdicts conformes au tableau, exit 0 partout.

Après merge :

1. Pousser puis supprimer une branche jetable `zz-test-persist` — attendu : `guard` imprime `protected=true`, `kontinuous` en `skipped`, aucun environnement touché.
2. Supprimer une branche `ticket/*` obsolète — attendu : `protected=false`, désactivation normale.

L'environnement `rgaa-persist` est redéployé séparément par `🎯 Promote test env` ; il ne dépend d'aucune branche, donc il ne re-tombera pas par ce chemin.