### PR TITLE
fix(declaration-remuneration): #4282 — le choix du parcours n'est plus fermé par une date

### DIFF
--- a/packages/app/src/e2e/campaign-deadlines-gating.e2e.ts
+++ b/packages/app/src/e2e/campaign-deadlines-gating.e2e.ts
@@ -2,9 +2,15 @@ import { expect, test } from "@playwright/test";
 
 import { getCurrentYear } from "~/modules/domain";
 import { TEST_USER_PHONE } from "./constants";
+import { withCampaignYear } from "./helpers/campaign-year";
+import {
+	COMPLIANCE_PATH,
+	selectCompliancePath,
+} from "./helpers/compliance-flows";
 import {
 	resetDeclarationToDraft,
 	setCompanyHasCse,
+	setCompanyWorkforce,
 	setDeclarationComplianceState,
 	setUserPhone,
 } from "./helpers/db";
@@ -12,6 +18,7 @@ import {
 	deleteCampaignDeadlines,
 	setCampaignDeadlines,
 } from "./helpers/db-campaign";
+import { completeDeclaration } from "./helpers/declaration-flows";
 import { loginWithProConnect } from "./helpers/login";
 
 // Panel deadline rendering is covered by my-space/__tests__/DeclarationProcessPanel.test.tsx; this keeps the route-level re-entry gating.
@@ -107,5 +114,50 @@ test.describe("Campaign deadlines gating", () => {
 				page.getByText(/modification close depuis le/i),
 			).toBeVisible();
 		});
+	});
+});
+
+// The path-choice deadline is the one campaign date that gates nothing (#4282).
+// It is derived from the campaign year rather than read from app_campaign_deadline,
+// so the only way to observe a stale one is to pin a past year: 2025 puts the
+// round-2 milestone (1 January N+1) and the round-1 one (1 July N) both behind us.
+const STALE_PATH_CHOICE_YEAR = 2025;
+const STALE_ROUND1_DEADLINE = "1ᵉʳ juillet 2025";
+const READ_ONLY_TAIL = /le choix du parcours ne peut plus être modifié/i;
+
+test.describe("Path-choice deadline is informational, never a gate", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test("a campaign year whose path-choice deadline has passed still lets the user choose and submit a path", async ({
+		page,
+	}) => {
+		test.slow();
+		await withCampaignYear(
+			{ page, year: STALE_PATH_CHOICE_YEAR, workforce: 250 },
+			async () => {
+				await setCompanyWorkforce(200);
+				await completeDeclaration(page, { hasGap: true });
+				await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 15_000 });
+
+				await expect(page.getByText(READ_ONLY_TAIL)).toHaveCount(0);
+				await expect(page.locator("#path-corrective")).toBeEnabled();
+				await expect(page.locator("#path-justify")).toBeEnabled();
+				await expect(page.locator("#path-joint")).toBeEnabled();
+
+				// The milestone outlives the gate it used to drive: still rendered, still
+				// the round the company is in, now purely to nudge.
+				await expect(
+					page.getByText(
+						"Date limite pour choisir un parcours de mise en conformité",
+					),
+				).toBeVisible();
+				await expect(page.getByText(STALE_ROUND1_DEADLINE)).toBeVisible();
+
+				await selectCompliancePath(page, "path-corrective");
+				await page.waitForURL(`**${COMPLIANCE_PATH}/etape/1`, {
+					timeout: 15_000,
+				});
+			},
+		);
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/PayGapTable.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/PayGapTable.test.tsx
@@ -3,8 +3,8 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import type { PayGapRow } from "~/modules/declaration-remuneration/types";
-import type { FieldError } from "../formError/types";
 import { DIVERGENT_HOURLY_MEDIAN } from "~/test/gipGapFixtures";
+import type { FieldError } from "../formError/types";
 import {
 	DEFAULT_PAY_GAP_ROWS,
 	handlePayGapRowChange,

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -5,7 +5,6 @@ import {
 	hasGapsAboveThreshold,
 	isComplianceProcessCompleted,
 	isCseOpinionRequired,
-	isDeadlinePassed,
 	isDraft,
 } from "~/modules/domain";
 import { auth } from "~/server/auth";
@@ -50,8 +49,6 @@ export function getCompliancePathReadOnlyReason(params: {
 	hasSubmittedSecondDeclaration: boolean;
 	hasSubmittedCseOpinion: boolean;
 	hasSubmittedJointEvaluation: boolean;
-	pathChoiceDeadline: Date;
-	now?: Date;
 }): CompliancePathReadOnlyReason | null {
 	const {
 		status,
@@ -59,8 +56,6 @@ export function getCompliancePathReadOnlyReason(params: {
 		hasSubmittedSecondDeclaration,
 		hasSubmittedCseOpinion,
 		hasSubmittedJointEvaluation,
-		pathChoiceDeadline,
-		now,
 	} = params;
 
 	if (isComplianceProcessCompleted(status)) return "demarche_completed";
@@ -70,8 +65,6 @@ export function getCompliancePathReadOnlyReason(params: {
 		return "second_declaration_submitted";
 	if (pathChoice === "joint_evaluation" && hasSubmittedJointEvaluation)
 		return "joint_evaluation_submitted";
-	if (isDeadlinePassed(pathChoiceDeadline, now))
-		return "path_choice_deadline_passed";
 	return null;
 }
 
@@ -133,9 +126,6 @@ export async function CompliancePathPage() {
 		hasSubmittedSecondDeclaration: data.hasSubmittedSecondDeclaration,
 		hasSubmittedCseOpinion: data.hasSubmittedCseOpinion,
 		hasSubmittedJointEvaluation: data.hasSubmittedJointEvaluation,
-		// Round 2's date on purpose, both rounds: the round-1 date is shown to nudge,
-		// it must not close the choice. Do not swap in selectPathChoiceDeadline.
-		pathChoiceDeadline: campaignDeadlines.pathChoiceDeadline,
 	});
 
 	return (

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -476,6 +476,50 @@ describe("CompliancePathChoice", () => {
 	});
 });
 
+// A third-party lock (or admin impersonation) freezes the controls without any
+// read-only *reason*: #4282 removed the only calendar one, so the alert must stay
+// absent here while the radios stay disabled. "Suivant" is then a link forward when
+// a path was already saved, and a disabled button when none was (#3230).
+describe("CompliancePathChoice under a third-party lock", () => {
+	it("disables the radios without showing a read-only alert", () => {
+		const { container } = render(
+			<LockProvider isReadOnly>
+				{compliancePathChoice({ initialPath: "justify" })}
+			</LockProvider>,
+		);
+
+		expect(
+			screen.getByLabelText("Justifier les écarts de rémunération ≥ 5 %"),
+		).toBeDisabled();
+		expect(container.querySelector(".fr-alert--info")).not.toBeInTheDocument();
+	});
+
+	it("renders Suivant as a link to the rest of the path when a choice is saved", () => {
+		render(
+			<LockProvider isReadOnly>
+				{compliancePathChoice({ initialPath: "justify" })}
+			</LockProvider>,
+		);
+
+		expect(screen.getByRole("link", { name: /suivant/i })).toHaveAttribute(
+			"href",
+			"/avis-cse",
+		);
+		expect(
+			screen.queryByRole("button", { name: /suivant/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("keeps Suivant a disabled button when no choice was saved", () => {
+		render(<LockProvider isReadOnly>{compliancePathChoice()}</LockProvider>);
+
+		expect(screen.getByRole("button", { name: /suivant/i })).toBeDisabled();
+		expect(
+			screen.queryByRole("link", { name: /suivant/i }),
+		).not.toBeInTheDocument();
+	});
+});
+
 describe("CompliancePathChoice read-only mode", () => {
 	it("renders the read-only alert and disables the radios", () => {
 		render(

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.redirect.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.redirect.test.tsx
@@ -166,11 +166,13 @@ describe("CompliancePathPage — skipping the choice page", () => {
 	});
 });
 
-// The page must keep feeding the read-only gate the round-2 deadline for BOTH
-// rounds. Rebranching it on `selectPathChoiceDeadline` (the display helper) would
-// close the choice on 1 July N instead of 1 January N+1 — 5 months too early —
-// and typecheck would stay green. These two tests are that safety net.
-describe("CompliancePathPage — the path-choice deadline is indicative", () => {
+// #4282 removed the calendar gate outright, which turns the older invariant
+// («close on 1 January N+1, never on 1 July N») into the strictly stronger one
+// pinned below: NO date closes the choice, however late. Reintroducing any clock
+// read — `selectPathChoiceDeadline`, `campaignDeadlines.pathChoiceDeadline` or a
+// bare `new Date()` — would leave typecheck green. These tests are that safety
+// net, kept at page level because the page is what reads the clock.
+describe("CompliancePathPage — the path-choice deadline never closes the choice", () => {
 	beforeEach(() => {
 		mockRedirect.mockClear();
 		mockAuth.mockReset();
@@ -200,13 +202,22 @@ describe("CompliancePathPage — the path-choice deadline is indicative", () => 
 
 		expect(
 			props?.readOnlyReason,
-			"the round-1 path choice must stay open past 1 July — the gate has to keep reading campaignDeadlines.pathChoiceDeadline (1 January N+1), never selectPathChoiceDeadline",
+			"the round-1 path choice must stay open past 1 July — the displayed deadline is a milestone, not a lock",
 		).toBeUndefined();
 	});
 
-	it("closes the choice only once 1 January N+1 has passed", async () => {
+	it("leaves the choice open past 1 January N+1 too: no date closes it", async () => {
 		const props = await renderRound1ChoiceAt(new Date(2027, 0, 15));
 
-		expect(props?.readOnlyReason).toBe("path_choice_deadline_passed");
+		expect(
+			props?.readOnlyReason,
+			"no calendar date may make the path choice read-only (#4282) — only a business reason can: démarche finalised, or a downstream step already submitted",
+		).toBeUndefined();
+	});
+
+	it("leaves the choice open years after every campaign deadline", async () => {
+		const props = await renderRound1ChoiceAt(new Date(2031, 5, 30));
+
+		expect(props?.readOnlyReason).toBeUndefined();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { getDefaultCampaignDeadlines } from "~/modules/domain";
 import {
 	getCompliancePathReadOnlyReason,
 	getComplianceState,
@@ -85,9 +84,11 @@ describe("getCompliancePathReadOnlyReason", () => {
 		hasSubmittedSecondDeclaration: false,
 		hasSubmittedCseOpinion: false,
 		hasSubmittedJointEvaluation: false,
-		pathChoiceDeadline: new Date("2026-12-01T00:00:00"),
-		now: new Date("2026-06-15T00:00:00"),
 	} satisfies Parameters<typeof getCompliancePathReadOnlyReason>[0];
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
 	it("returns null when no condition is met", () => {
 		expect(getCompliancePathReadOnlyReason(baseParams)).toBeNull();
@@ -168,63 +169,28 @@ describe("getCompliancePathReadOnlyReason", () => {
 		).toBeNull();
 	});
 
-	it("returns path_choice_deadline_passed once the deadline is in the past", () => {
-		expect(
-			getCompliancePathReadOnlyReason({
-				...baseParams,
-				pathChoice: "justify",
-				pathChoiceDeadline: new Date("2026-06-01T00:00:00"),
-				now: new Date("2026-06-02T00:00:00"),
-			}),
-		).toBe("path_choice_deadline_passed");
+	// #4282 removed the calendar branch: read-only is now a pure function of the
+	// business state. The date-driven cases moved to CompliancePathPage.redirect.test.tsx,
+	// which renders the page and is therefore the only place that can prove no clock
+	// is read at all.
+	it("stays a pure function of the business state, whatever the current date is", () => {
+		const beforeAnyDeadline = new Date(2026, 0, 2);
+		const longAfterEveryDeadline = new Date(2030, 0, 15);
+		vi.useFakeTimers({ toFake: ["Date"] });
+
+		for (const now of [beforeAnyDeadline, longAfterEveryDeadline]) {
+			vi.setSystemTime(now);
+			expect(getCompliancePathReadOnlyReason(baseParams)).toBeNull();
+			expect(
+				getCompliancePathReadOnlyReason({
+					...baseParams,
+					pathChoice: "justify",
+					hasSubmittedCseOpinion: true,
+				}),
+			).toBe("cse_opinion_submitted");
+		}
 	});
 
-	it("prioritises a submitted next step over a passed deadline", () => {
-		expect(
-			getCompliancePathReadOnlyReason({
-				...baseParams,
-				pathChoice: "justify",
-				hasSubmittedCseOpinion: true,
-				pathChoiceDeadline: new Date("2026-06-01T00:00:00"),
-				now: new Date("2026-06-02T00:00:00"),
-			}),
-		).toBe("cse_opinion_submitted");
-	});
-
-	it("returns path_choice_deadline_passed even without a chosen path", () => {
-		expect(
-			getCompliancePathReadOnlyReason({
-				...baseParams,
-				pathChoice: null,
-				pathChoiceDeadline: new Date("2026-06-01T00:00:00"),
-				now: new Date("2026-06-02T00:00:00"),
-			}),
-		).toBe("path_choice_deadline_passed");
-	});
-
-	// The gate is fed the round-2 deadline for both rounds on purpose: the round-1
-	// date (1 July) is a nudge shown to the user, not a lock. The wiring that keeps
-	// it that way is pinned in CompliancePathPage.redirect.test.tsx.
-	it("keeps the round-1 choice open past 1 July: the path-choice deadline is indicative, never blocking", () => {
-		const deadlines = getDefaultCampaignDeadlines(2026);
-		const afterRound1Nudge = new Date(2026, 8, 15);
-
-		expect(
-			getCompliancePathReadOnlyReason({
-				...baseParams,
-				pathChoiceDeadline: deadlines.pathChoiceDeadline,
-				now: afterRound1Nudge,
-			}),
-		).toBeNull();
-
-		expect(
-			getCompliancePathReadOnlyReason({
-				...baseParams,
-				pathChoiceDeadline: deadlines.pathChoiceRound1Deadline,
-				now: afterRound1Nudge,
-			}),
-		).toBe("path_choice_deadline_passed");
-	});
 	it("does not lock the second-round revision choice when only the first-round second declaration was submitted", () => {
 		expect(
 			getCompliancePathReadOnlyReason({

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathReadOnlyAlert.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathReadOnlyAlert.test.tsx
@@ -12,10 +12,6 @@ const CASES: Array<[CompliancePathReadOnlyReason, RegExp]> = [
 		"joint_evaluation_submitted",
 		/Le rapport d'évaluation conjointe a déjà été transmis/,
 	],
-	[
-		"path_choice_deadline_passed",
-		/La date limite pour choisir un parcours de mise en conformité est dépassée/,
-	],
 ];
 
 describe("CompliancePathReadOnlyAlert", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathReadOnlyAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathReadOnlyAlert.tsx
@@ -9,8 +9,6 @@ const READ_ONLY_MESSAGES: Record<CompliancePathReadOnlyReason, string> = {
 		"La seconde déclaration a déjà été soumise. Le choix du parcours ne peut plus être modifié.",
 	joint_evaluation_submitted:
 		"Le rapport d'évaluation conjointe a déjà été transmis. Le choix du parcours ne peut plus être modifié.",
-	path_choice_deadline_passed:
-		"La date limite pour choisir un parcours de mise en conformité est dépassée. Le choix du parcours ne peut plus être modifié.",
 };
 
 export function CompliancePathReadOnlyAlert({

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/constants.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/constants.ts
@@ -10,5 +10,4 @@ export type CompliancePathReadOnlyReason =
 	| "demarche_completed"
 	| "cse_opinion_submitted"
 	| "second_declaration_submitted"
-	| "joint_evaluation_submitted"
-	| "path_choice_deadline_passed";
+	| "joint_evaluation_submitted";

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -115,10 +115,10 @@ export function CompanyDeclarationsPage({
 				declarationFsmStatus={currentDeclaration?.fsmStatus ?? null}
 				displayContext={displayContext}
 				hasPrefillData={currentDeclaration?.hasPrefillData ?? false}
-				indicatorGRequired={indicatorGRequired}
 				hasSubmittedSecondDeclaration={
 					currentDeclaration?.hasSubmittedSecondDeclaration ?? false
 				}
+				indicatorGRequired={indicatorGRequired}
 				lastActionDate={lastActionDate}
 				lockedByOther={lockedByOther}
 				lockHolder={lockHolder}

--- a/packages/app/src/modules/my-space/VerticalStepper.tsx
+++ b/packages/app/src/modules/my-space/VerticalStepper.tsx
@@ -64,8 +64,8 @@ export function VerticalStepper({
 				<StepCircle number={1} status={step1} />
 				<Step1Content
 					campaignDeadlines={campaignDeadlines}
-					indicatorGRequired={indicatorGRequired}
 					hasPrefillData={hasPrefillData}
+					indicatorGRequired={indicatorGRequired}
 					siren={siren}
 					status={step1}
 					variant={variant}


### PR DESCRIPTION
Closes #4282

## Résumé

`path_choice_deadline_passed` était la cinquième cause de lecture seule de l'écran de choix du parcours de conformité, et la seule sans contrepartie serveur : `declaration.saveCompliancePath` n'a jamais porté de garde d'échéance. Le blocage était donc purement d'interface — et il captait le libellé de l'alerte dès qu'il se déclenchait en même temps qu'une cause réelle, affichant « la date limite pour choisir un parcours est dépassée » à un utilisateur dont la déclaration était en fait verrouillée par un collègue, ou consultée en mimoquage.

Le motif disparaît entièrement (D1). Le retirer du type union fait tomber son libellé, sa branche et son cas de test **par erreur de type** plutôt que par relecture : `READ_ONLY_MESSAGES` est un `Record<CompliancePathReadOnlyReason, string>`, garder le membre aurait maintenu en vie un libellé inatteignable sans que le typecheck ne dise rien.

`getCompliancePathReadOnlyReason` perd du même coup ses paramètres `pathChoiceDeadline` et `now` (D2) : elle devient une fonction pure de l'état métier — statut FSM et soumissions aval — sans aucune lecture d'horloge.

## Ce qui ne bouge pas

- **Les dates restent affichées.** `getCampaignDeadlines` continue d'alimenter l'encart « Date limite pour choisir un parcours » et les dates des options (D3) ; `selectPathChoiceDeadline` et les helpers du domaine sont intacts (D4) — ce sont des jalons informatifs.
- **Les quatre motifs métier** (`demarche_completed`, `cse_opinion_submitted`, `second_declaration_submitted`, `joint_evaluation_submitted`) et leurs libellés sont inchangés, tests compris.
- **Les protections réelles restent** (D6) : le verrou collaboratif et le mimoquage passent par `useLockContext()` / `useIsImpersonating()`, indépendants de `readOnlyReason` ; côté serveur `hasLockingEventForRound` rejette toujours en `CONFLICT` un changement de parcours après un avis CSE ou une évaluation conjointe du round.
- **Aucun fichier sous `src/server/`** n'est modifié (D5).

## Tests

L'invariant épinglé par #4209 / PR #4253 n'est pas supprimé, il est **remplacé au même endroit par sa version plus forte** (D7). L'ancien disait « la gate doit lire le 1ᵉʳ janvier N+1, jamais le 1ᵉʳ juillet » — c'est-à-dire « ne ferme pas cinq mois trop tôt ». Ce ticket rend la question sans objet : le nouvel invariant est **aucune date ne ferme le choix, si tardive soit-elle**. Le `describe` dédié reste au niveau page, parce que la page est ce qui lit l'horloge : y réintroduire un `selectPathChoiceDeadline`, un `campaignDeadlines.pathChoiceDeadline` ou un simple `new Date()` laisserait le typecheck vert, ces tests sont le filet.

- `CompliancePathPage.redirect.test.tsx` — le test du 15 septembre 2026 est conservé ; celui du 15 janvier 2027 est **inversé** (`readOnlyReason` doit désormais valoir `undefined`), avec un troisième cas à 2031 pour couvrir « des années après toute échéance ».
- `CompliancePathPage.test.ts` — `baseParams` perd ses paramètres de date. Les quatre tests datés tombent : privés de leur date, trois étaient devenus des doublons littéraux des cas métier déjà présents plus haut dans le fichier et le quatrième n'avait plus d'objet. Ils sont remplacés par un test qui, sous faux timers, vérifie la neutralité au calendrier des deux côtés (avant toute échéance, et longtemps après). Les onze tests qui protègent les motifs métier sont inchangés.
- `CompliancePathReadOnlyAlert.test.tsx` — le cas retiré de `CASES` l'est sous la contrainte du typecheck.
- `CompliancePathChoice.test.tsx` — **couverture ajoutée**, jusque-là absente pour le verrou tiers : sous `LockProvider isReadOnly`, les radios sont désactivées *sans* alerte de lecture seule, « Suivant » est un lien vers la suite du parcours si un choix est enregistré, et un bouton désactivé sinon (#3230).

Suite complète verte : **5885 tests / 458 fichiers**. `CompliancePathPage.tsx` à 100 % lignes et instructions.

## Vérification

- Recherche exhaustive de `path_choice_deadline_passed` dans `packages/app/src` → **aucune occurrence** (avant : 10, réparties sur 6 fichiers).
- `getCompliancePathReadOnlyReason` avec le nouvel invariant, horloge au 15 janvier 2027 sur une déclaration `awaiting_compliance_path_choice` sans motif métier → **avant** : `"path_choice_deadline_passed"` / **après** : `undefined`.
- `pnpm typecheck`, `pnpm test`, `pnpm lint:check`, `pnpm format:check` : verts.

## Hors périmètre assumé

Trois hunks de formatage seul (`PayGapTable.test.tsx` ordre d'import, `CompanyDeclarationsPage.tsx` et `VerticalStepper.tsx` tri de props JSX) sont une **dérive biome préexistante sur `alpha`** : `pnpm biome check` échoue sur ces trois fichiers au commit de base, avant toute modification de ce ticket. Ils ont été corrigés par le hook auto-lint du dépôt et sont conservés parce que les laisser rendrait `format:check` rouge sur cette PR sans rapport avec son contenu. Aucun changement de comportement.

## Screenshots

Aucune évolution visuelle attendue : la seule différence perceptible est la disparition d'une alerte DSFR existante, dans le cas où elle se déclenchait à tort.
