### PR TITLE
fix(declaration-remuneration): #4287 — champ bénéficiaires figé/erreur incohérente au-delà du plafond

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -96,9 +96,7 @@ function deriveBenefError(
 	};
 }
 
-// Re-derives from the field's current value rather than trusting stale
-// error state, so a value written outside a keystroke (dev fill, GIP
-// prefill, draft rehydration) is never missed.
+// Re-derives from the current value — a stale error state would miss a value written outside a keystroke.
 function deriveBenefErrors(
 	values: Pick<Step3Data, "indicatorEWomen" | "indicatorEMen">,
 	maxWomen: number | undefined,

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -81,6 +81,40 @@ const BENEFICIARY_LABELS = {
 	indicatorEMen: "d'hommes bénéficiaires",
 } as const;
 
+function deriveBenefError(
+	field: "indicatorEWomen" | "indicatorEMen",
+	value: string,
+	max: number | undefined,
+): FieldError | null {
+	if (value === "") return null;
+	const n = Number.parseInt(value, 10);
+	if (Number.isNaN(n) || max === undefined || n <= max) return null;
+	return {
+		fieldId: BENEFICIARY_FIELD_IDS[field],
+		category: "invalid",
+		message: `Le nombre ${BENEFICIARY_LABELS[field]} ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
+	};
+}
+
+// Re-derives from the field's current value rather than trusting stale
+// error state, so a value written outside a keystroke (dev fill, GIP
+// prefill, draft rehydration) is never missed.
+function deriveBenefErrors(
+	values: Pick<Step3Data, "indicatorEWomen" | "indicatorEMen">,
+	maxWomen: number | undefined,
+	maxMen: number | undefined,
+): FieldError[] {
+	return (["indicatorEWomen", "indicatorEMen"] as const)
+		.map((field) =>
+			deriveBenefError(
+				field,
+				values[field],
+				field === "indicatorEWomen" ? maxWomen : maxMen,
+			),
+		)
+		.filter((error): error is FieldError => error !== null);
+}
+
 export function Step3VariablePay({
 	declarationSiren,
 	declarationYear,
@@ -174,35 +208,13 @@ export function Step3VariablePay({
 		max: number | undefined,
 		value: string,
 	) {
-		if (value === "") {
-			form.setValue(field, "");
-			setBenefErrors((errors) =>
-				errors.filter(
-					(error) => error.fieldId !== BENEFICIARY_FIELD_IDS[field],
-				),
-			);
-			return;
-		}
-		if (/\D/.test(value)) return;
-		const n = Number.parseInt(value, 10);
-		if (Number.isNaN(n) || n < 0) return;
-		if (max !== undefined && n > max) {
-			setBenefErrors((errors) => [
-				...errors.filter(
-					(error) => error.fieldId !== BENEFICIARY_FIELD_IDS[field],
-				),
-				{
-					fieldId: BENEFICIARY_FIELD_IDS[field],
-					category: "invalid",
-					message: `Le nombre ${BENEFICIARY_LABELS[field]} ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
-				},
-			]);
-			return;
-		}
-		setBenefErrors((errors) =>
-			errors.filter((error) => error.fieldId !== BENEFICIARY_FIELD_IDS[field]),
-		);
+		if (value !== "" && /\D/.test(value)) return;
 		form.setValue(field, value);
+		const error = deriveBenefError(field, value, max);
+		setBenefErrors((errors) => [
+			...errors.filter((e) => e.fieldId !== BENEFICIARY_FIELD_IDS[field]),
+			...(error ? [error] : []),
+		]);
 	}
 
 	const womenBeneficiaryError = findFieldError(
@@ -230,14 +242,19 @@ export function Step3VariablePay({
 				category: "empty" as const,
 				message: `Renseignez le nombre ${BENEFICIARY_LABELS[field]}.`,
 			}));
+		const exceedsMaxBeneficiaries = deriveBenefErrors(
+			{ indicatorEWomen: beneficiaryWomen, indicatorEMen: beneficiaryMen },
+			maxWomen,
+			maxMen,
+		).filter(
+			(error) =>
+				!missingBeneficiaries.some(
+					(missing) => missing.fieldId === error.fieldId,
+				),
+		);
 		const beneficiaryErrors = [
-			...benefErrors.filter(
-				(error) =>
-					!missingBeneficiaries.some(
-						(missing) => missing.fieldId === error.fieldId,
-					),
-			),
 			...missingBeneficiaries,
+			...exceedsMaxBeneficiaries,
 		];
 		setBenefErrors(beneficiaryErrors);
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	nullGipStep2,
 	nullGipStep3,
@@ -38,6 +38,10 @@ const emptyStep3Data = () => ({
 });
 
 describe("Step3VariablePay", () => {
+	beforeEach(() => {
+		mockMutate.mockClear();
+	});
+
 	it("renders the pay gap table with 4 rows", () => {
 		render(
 			<Step3VariablePay
@@ -231,7 +235,7 @@ describe("Step3VariablePay", () => {
 		expect(menInput).toHaveValue("20");
 	});
 
-	it("blocks beneficiary count exceeding max workforce", async () => {
+	it("blocks beneficiary count exceeding max workforce, keeping the typed value visible", async () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
@@ -249,8 +253,77 @@ describe("Step3VariablePay", () => {
 		await user.clear(womenInput);
 		await user.type(womenInput, "20");
 
-		// Should show validation error since 20 > 15
-		expect(screen.getByText(/ne peut pas dépasser/i)).toBeInTheDocument();
+		// The field keeps the value the user typed — the error message names
+		// that same number, not one the user never entered.
+		expect(womenInput).toHaveValue("20");
+		expect(
+			screen.getByText(
+				"Le nombre de femmes bénéficiaires ne peut pas dépasser l'effectif de l'étape 1 (15).",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("lets an over-max beneficiary value be corrected downward via backspace", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				indicatorGRequired
+				initialData={emptyStep3Data()}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+
+		await user.clear(womenInput);
+		await user.type(womenInput, "20");
+		expect(womenInput).toHaveValue("20");
+
+		await user.type(womenInput, "{backspace}");
+		expect(womenInput).toHaveValue("2");
+		expect(womenInput).not.toHaveAttribute("aria-invalid");
+		expect(screen.queryByText(/ne peut pas dépasser/i)).not.toBeInTheDocument();
+	});
+
+	it("blocks submit when a beneficiary value exceeding max workforce was set outside a keystroke", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				indicatorGRequired
+				initialData={{
+					indicatorBAnnualWomen: "100",
+					indicatorBAnnualMen: "100",
+					indicatorBHourlyWomen: "100",
+					indicatorBHourlyMen: "100",
+					indicatorDAnnualWomen: "100",
+					indicatorDAnnualMen: "100",
+					indicatorDHourlyWomen: "100",
+					indicatorDHourlyMen: "100",
+					indicatorEWomen: "20",
+					indicatorEMen: "10",
+				}}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+		expect(womenInput).toHaveValue("20");
+
+		await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+		expect(mockMutate).not.toHaveBeenCalled();
+		expect(
+			screen.getByText(
+				"Le nombre de femmes bénéficiaires ne peut pas dépasser l'effectif de l'étape 1 (15).",
+			),
+		).toBeInTheDocument();
+		expect(womenInput).toHaveAttribute("aria-invalid", "true");
 	});
 
 	it("associates the beneficiaries error with the women input (RGAA 11.10)", async () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -253,8 +253,7 @@ describe("Step3VariablePay", () => {
 		await user.clear(womenInput);
 		await user.type(womenInput, "20");
 
-		// The field keeps the value the user typed — the error message names
-		// that same number, not one the user never entered.
+		// The error message must name the value the field actually shows.
 		expect(womenInput).toHaveValue("20");
 		expect(
 			screen.getByText(


### PR DESCRIPTION
Closes #4287

## Résumé

`handleBenefChange` appliquait le plafond « bénéficiaires ≤ effectif de l'étape 1 » dans le handler de frappe et sortait sans `form.setValue` quand la valeur le dépassait. Le champ étant contrôlé, React réécrivait aussitôt la valeur précédente : l'erreur nommait un nombre que l'utilisateur ne voyait plus, et une valeur déjà trop haute (dev-fill, préremplissage GIP, réhydratation de brouillon, effectif d'étape 1 abaissé après coup) restait incorrigible autrement qu'en vidant le champ — puisque rien de tout cela ne passe par `handleBenefChange`, et que `onSubmit` ne revalidait que les champs vides.

## Correctif

- `handleBenefChange` committe désormais la valeur saisie dans tous les cas via `form.setValue`, puis dérive l'erreur du plafond depuis cette même valeur (`deriveBenefError`) — le champ et le message parlent toujours du même nombre.
- `onSubmit` re-dérive l'erreur de dépassement à partir des valeurs actuelles du formulaire (`deriveBenefErrors`) plutôt que de se fier à l'état `benefErrors`, potentiellement obsolète — ce qui bloque désormais toute valeur écrite hors frappe.

Fichiers modifiés :
- `packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx`
- `packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx`

## Vérification

Sous-stratégie choisie par `bug-analyst` pour la reproduction (« fonctionnel local, rejouée au niveau composant — les deux symptômes sont purement client, pas de dev server nécessaire »), reprise ici pour le correctif : les 3 scénarios de la procédure de vérification sont exécutés en test composant (jsdom), avec preuve par revert-verify (`git apply -R` du diff source → RED, ré-application → GREEN).

| Scénario | Avant (RED, source revert) | Après (GREEN, avec fix) |
|---|---|---|
| Taper `20` sur un plafond de `15` | le champ affiche `2`, l'erreur ne s'affiche pas sur la bonne valeur | le champ affiche `20`, l'erreur nomme `20` / le plafond `15` |
| Valeur `20` déjà en place (hors frappe) + « Suivant » | `mutation.mutate` appelé avec `indicatorEWomen: "20"` — passage à l'étape 4 | `mutation.mutate` non appelé, erreur affichée, `aria-invalid` posé |
| Retour arrière (backspace) depuis `20` | — | le champ passe à `2`, l'erreur disparaît |

Suite complète : `pnpm test` — 5887/5887 verts.

## Triage des tests

Le test existant « blocks beneficiary count exceeding max workforce » figeait le comportement fautif (n'assertait que la présence du message). Évolution légitime : renommé et complété pour asserter aussi la valeur affichée. Deux tests ajoutés (backspace, valeur écrite hors frappe). Aucune assertion retirée ni relâchée.
