### PR TITLE
fix(my-space): #4291 — retirer l'étape parcours de mise en conformité quand elle ne s'applique pas

### DIFF
--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -215,11 +215,17 @@ test.describe("Declaration process panel", () => {
 	});
 
 	// #3939 follow-up: a GIP-derived >= 100 company that declared "sans CSE" is still
-	// subject to indicator G, so the panel keeps the indicator-G path step (step 2),
-	// but must never ask it to deposit a CSE opinion — step 3 and the "avis CSE
-	// modifiables" closing note are hidden, during the démarche and after completion.
-	// Step visibility is driven by isCseOpinionRequired({ workforce, hasCse }), not the
-	// workforce alone, so this differs from the < 100 case where step 2 is hidden too.
+	// subject to indicator G, so the panel shows the indicator-G path step (step 2)
+	// during the démarche — but must never ask it to deposit a CSE opinion — step 3
+	// and the "avis CSE modifiables" closing note are hidden, both during the démarche
+	// and after completion. Step 3 visibility is driven by
+	// isCseOpinionRequired({ workforce, hasCse }), not the workforce alone, so this
+	// differs from the < 100 case where step 2 is hidden too.
+	// #4291 follow-up: step 2 itself is not simply gated by company size any more —
+	// once `demarche_completed` is reached with no compliance path ever chosen, the
+	// démarche skipped it (the ≥5% gap never applied) and it disappears from the
+	// closed panel too. It only survives past completion when a path was actually
+	// chosen (see `isCompliancePathStepApplicable`).
 	test.describe("GIP >= 100 without CSE: indicator-G step shown, CSE step hidden", () => {
 		const STEP2_TITLE =
 			"Parcours de mise en conformité pour l'indicateur par catégories de salariés";

--- a/packages/app/src/e2e/grille/scenarios.ts
+++ b/packages/app/src/e2e/grille/scenarios.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 import { withCampaignYear } from "../helpers/campaign-year";
 import {
 	COMPLIANCE_PATH,
@@ -82,16 +82,49 @@ function transmittedRow(page: Page, label: string) {
 		.locator("xpath=../..");
 }
 
+async function openPanneauDemarche(page: Page): Promise<Locator> {
+	await page.goto("/mon-espace");
+	await waitForDsfrModal(page, PROCESS_PANEL_ID);
+	const trigger = page.getByRole("button", { name: "Rémunération" }).first();
+	await expect(trigger).toBeVisible();
+	await clickAndExpectDialogOpen(page, trigger, PROCESS_PANEL_ID);
+	return page.locator(`#${PROCESS_PANEL_ID}`);
+}
+
+const ETAPE_PARCOURS_CONFORMITE =
+	"Parcours de mise en conformité pour l'indicateur par catégories de salariés";
+
+// #4291 — CAS-01 closes its démarche without ever opening the compliance path,
+// and the panel used to derive that step from the company characteristics alone
+// (>= 100 salariés owing indicator G), dropping the ">= 5 % gap" conjunct. The
+// closed variant therefore showed the step ticked « Étape terminée », claiming a
+// parcours this company never had to take.
+async function expectPanneauFinDeDemarcheSansParcours(
+	page: Page,
+): Promise<void> {
+	await test.step("panneau « Mon espace » d'une fin de démarche sans parcours", async () => {
+		const panel = await openPanneauDemarche(page);
+		await expect(panel.getByText("Démarche close")).toBeVisible();
+		await expect(panel.getByText(ETAPE_PARCOURS_CONFORMITE)).toHaveCount(0);
+
+		const row = transmittedRow(page, "Votre déclaration a été transmise");
+		// Pin the row before reading the negative assertion above as a result: an
+		// empty panel would satisfy toHaveCount(0) without proving anything.
+		await expect(row).toBeVisible();
+		await expect(
+			row.getByRole("link", {
+				name: "Voir le récapitulatif de la déclaration",
+			}),
+		).toBeVisible();
+	});
+}
+
 // #4222 — on a closed démarche the panel used to derive "Modifier" from the
 // campaign deadline alone, so it offered edits the FSM then refused. The
 // affordance now follows the FSM, which only still accepts a CSE opinion.
 async function expectPanneauDemarcheClose(page: Page): Promise<void> {
 	await test.step("panneau « Mon espace » d'une démarche close", async () => {
-		await page.goto("/mon-espace");
-		await waitForDsfrModal(page, PROCESS_PANEL_ID);
-		const trigger = page.getByRole("button", { name: "Rémunération" }).first();
-		await expect(trigger).toBeVisible();
-		await clickAndExpectDialogOpen(page, trigger, PROCESS_PANEL_ID);
+		await openPanneauDemarche(page);
 
 		const readOnlyRows: Array<{ label: string; view?: string }> = [
 			{
@@ -142,6 +175,7 @@ export const FICHE_SCENARIOS = {
 			await page.goto("/avis-cse/etape/1");
 			await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
 		});
+		await expectPanneauFinDeDemarcheSansParcours(page);
 	},
 
 	"CAS-02": async ({ page }) => {

--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -4,6 +4,7 @@ import {
 	getCurrentCompliancePath,
 	hasStartedSecondDeclaration,
 	isCancelled,
+	isCompliancePathStepApplicable,
 	isComplianceProcessCompleted,
 	isDeclarationSubmitted,
 	isDeclarationWritingClosed,
@@ -332,6 +333,68 @@ describe("isSecondDeclarationDeadlineApplicable", () => {
 				status,
 				secondDeclarationStep: null,
 				secondDeclarationPathChoice: "justify",
+			}),
+		).toBe(true);
+	});
+});
+
+describe("isCompliancePathStepApplicable", () => {
+	const NO_PATH_CHOICE = {
+		firstDeclarationPathChoice: null,
+		secondDeclarationPathChoice: null,
+	};
+
+	const NON_TERMINAL_STATUSES: (DeclarationFsmStatus | null)[] = [
+		null,
+		"draft",
+		"awaiting_compliance_path_choice",
+		"corrective_actions_chosen",
+		"joint_evaluation_chosen",
+		"awaiting_revision_choice",
+		"revised_joint_evaluation_chosen",
+	];
+
+	it.each(
+		NON_TERMINAL_STATUSES,
+	)("returns true for the non-terminal status %s, even with no path choice recorded", (status) => {
+		expect(isCompliancePathStepApplicable({ status, ...NO_PATH_CHOICE })).toBe(
+			true,
+		);
+	});
+
+	const TERMINAL_STATUSES: DeclarationFsmStatus[] = [
+		"awaiting_cse_opinion",
+		"demarche_completed",
+	];
+
+	it.each(
+		TERMINAL_STATUSES,
+	)("returns false for the terminal status %s reached with no path choice (skipped via a direct transition)", (status) => {
+		expect(isCompliancePathStepApplicable({ status, ...NO_PATH_CHOICE })).toBe(
+			false,
+		);
+	});
+
+	it.each(
+		TERMINAL_STATUSES,
+	)("returns true for the terminal status %s once a first-declaration path was chosen", (status) => {
+		expect(
+			isCompliancePathStepApplicable({
+				status,
+				firstDeclarationPathChoice: "justify",
+				secondDeclarationPathChoice: null,
+			}),
+		).toBe(true);
+	});
+
+	it.each(
+		TERMINAL_STATUSES,
+	)("returns true for the terminal status %s once a second-declaration path was chosen", (status) => {
+		expect(
+			isCompliancePathStepApplicable({
+				status,
+				firstDeclarationPathChoice: null,
+				secondDeclarationPathChoice: "corrective_action",
 			}),
 		).toBe(true);
 	});

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -97,6 +97,7 @@ export {
 	getCurrentCompliancePath,
 	hasStartedSecondDeclaration,
 	isCancelled,
+	isCompliancePathStepApplicable,
 	isComplianceProcessCompleted,
 	isDeclarationSubmitted,
 	isDeclarationWritingClosed,

--- a/packages/app/src/modules/domain/shared/declarationStatus.ts
+++ b/packages/app/src/modules/domain/shared/declarationStatus.ts
@@ -86,6 +86,36 @@ export function isSecondDeclarationDeadlineApplicable(declaration: {
 	}
 }
 
+// Whether the compliance-path step (indicator G, ≥5% gap) should still be shown
+// as part of the démarche. Company-characteristics alone (workforce, CSE,
+// indicator G applicability) are not sufficient: the gap itself decides
+// `phase2Required` in the rule engine, and that fact is not available on this
+// page. Two direct transitions skip the compliance path entirely when it does
+// not apply (`submit_to_cse_opinion_directly`, `submit_to_demarche_completed_directly`,
+// both guarded by `not phase2Required`) and neither records a path choice — so
+// a terminal state reached with no path choice at all proves the path never
+// applied. `awaiting_compliance_path_choice` also has a null path choice, but
+// that state means the path is still open, not skipped.
+export function isCompliancePathStepApplicable(declaration: {
+	status: DeclarationFsmStatus | null;
+	firstDeclarationPathChoice: CompliancePath | null;
+	secondDeclarationPathChoice: CompliancePath | null;
+}): boolean {
+	switch (declaration.status) {
+		case null:
+		case "draft":
+		case "awaiting_compliance_path_choice":
+		case "corrective_actions_chosen":
+		case "joint_evaluation_chosen":
+		case "awaiting_revision_choice":
+		case "revised_joint_evaluation_chosen":
+			return true;
+		case "awaiting_cse_opinion":
+		case "demarche_completed":
+			return getCurrentCompliancePath(declaration) !== null;
+	}
+}
+
 // The corrective-action second declaration may only be written while its funnel
 // is actually open: right after the corrective-action path choice, or once the
 // declaration has been re-opened for revision. Any other status means round 2

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -6,6 +6,7 @@ import {
 	getCurrentYear,
 	getDeclarationDisplayContext,
 	getObligationWorkforce,
+	isCompliancePathStepApplicable,
 	isCseOpinionRequired,
 	isCseRequired,
 	isIndicatorGRequired,
@@ -72,11 +73,20 @@ export function CompanyDeclarationsPage({
 		obligationWorkforce,
 		currentYear,
 	);
-	const compliancePathApplicable = cseApplicable && indicatorGRequired;
 	const lastActionDate = getLastActionDate(declarations, currentYear);
 	const currentDeclaration = declarations.find(
 		(d) => d.type === "remuneration" && d.year === currentYear,
 	);
+	const compliancePathApplicable =
+		cseApplicable &&
+		indicatorGRequired &&
+		isCompliancePathStepApplicable({
+			status: currentDeclaration?.fsmStatus ?? null,
+			firstDeclarationPathChoice:
+				currentDeclaration?.firstDeclarationPathChoice ?? null,
+			secondDeclarationPathChoice:
+				currentDeclaration?.secondDeclarationPathChoice ?? null,
+		});
 	const panelVariant = computePanelVariant(currentDeclaration);
 	const ctaHref = computeCtaHref(currentDeclaration, company.siren);
 	const displayContext = getDeclarationDisplayContext({
@@ -115,10 +125,10 @@ export function CompanyDeclarationsPage({
 				declarationFsmStatus={currentDeclaration?.fsmStatus ?? null}
 				displayContext={displayContext}
 				hasPrefillData={currentDeclaration?.hasPrefillData ?? false}
-				indicatorGRequired={indicatorGRequired}
 				hasSubmittedSecondDeclaration={
 					currentDeclaration?.hasSubmittedSecondDeclaration ?? false
 				}
+				indicatorGRequired={indicatorGRequired}
 				lastActionDate={lastActionDate}
 				lockedByOther={lockedByOther}
 				lockHolder={lockHolder}

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -151,6 +151,65 @@ describe("CompanyDeclarationsPage", () => {
 		).not.toBeInTheDocument();
 	});
 
+	describe("CAS-01 (#4291) — compliance-path step keyed off the declared trajectory, not company size alone", () => {
+		const cas01Company = { ...company, gipWorkforce: 250, hasCse: false };
+
+		it("hides the compliance-path step once démarche_completed is reached with no path choice recorded", () => {
+			renderPage({
+				company: cas01Company,
+				declarations: [
+					makeDeclaration("remuneration", {
+						status: "done",
+						fsmStatus: "demarche_completed",
+					}),
+					makeDeclaration("representation"),
+				],
+			});
+
+			expect(
+				screen.queryAllByText(/Parcours de mise en conformité/),
+			).toHaveLength(0);
+			expect(
+				screen.getByText("Votre déclaration a été transmise"),
+			).toBeInTheDocument();
+			expect(
+				screen.getByTitle("Voir le récapitulatif de la déclaration"),
+			).toBeInTheDocument();
+		});
+
+		it("keeps the compliance-path step visible on a draft, since whether a ≥5% gap applies is not known yet", () => {
+			renderPage({
+				company: cas01Company,
+				declarations: [
+					makeDeclaration("remuneration"),
+					makeDeclaration("representation"),
+				],
+			});
+
+			expect(
+				screen.queryAllByText(/Parcours de mise en conformité/),
+			).toHaveLength(1);
+		});
+
+		it("keeps the compliance-path step visible after completion when a compliance path was actually chosen", () => {
+			renderPage({
+				company: cas01Company,
+				declarations: [
+					makeDeclaration("remuneration", {
+						status: "done",
+						fsmStatus: "demarche_completed",
+						firstDeclarationPathChoice: "justify",
+					}),
+					makeDeclaration("representation"),
+				],
+			});
+
+			expect(
+				screen.queryAllByText(/Parcours de mise en conformité/),
+			).toHaveLength(1);
+		});
+	});
+
 	it("hides the 'Archives' section while archives are unavailable", () => {
 		renderPage();
 		expect(


### PR DESCRIPTION
Closes #4291

## Contexte

Sur les trois points du ticket, deux étaient déjà satisfaits sur `alpha` (corrigés par #4222 / PR #4313, mergée cinq jours après l'ouverture du ticket) : « Votre déclaration a été transmise » et le bouton de visualisation de la déclaration. La capture du ticket est donc antérieure à ce correctif.

Seul le troisième point restait : l'étape « Parcours de mise en conformité pour l'indicateur par catégorie de salariés si écarts ≥ 5 % » du panneau latéral de Mon espace continuait à s'afficher — et cochée « Étape terminée » — même quand la démarche l'avait sautée (pas de CSE, ou écart jamais ≥ 5 %).

## Cause racine

`CompanyDeclarationsPage.tsx` dérivait `compliancePathApplicable` uniquement des caractéristiques de l'entreprise (`cseApplicable && indicatorGRequired`), en laissant tomber le troisième conjoint de la règle métier `phase2Required` du moteur de règles (`server/rules/v2027.1.json`) : le gap réellement déclaré. Ce gap n'est pas disponible sur cette page sans nouvelle lecture en base.

## Correctif

Nouveau prédicat pur `isCompliancePathStepApplicable` (`modules/domain/shared/declarationStatus.ts`, à côté de `isSecondDeclarationDeadlineApplicable`, même style) : un état terminal (`awaiting_cse_opinion`, `demarche_completed`) atteint **sans aucun choix de parcours enregistré** prouve que la démarche l'a sauté via l'une des deux transitions directes de la FSM gardées par `not phase2Required` (`submit_to_cse_opinion_directly`, `submit_to_demarche_completed_directly`) — ni l'une ni l'autre n'enregistre de `path_choice`. Tout autre état garde l'étape visible, car l'issue n'est pas encore connue (`awaiting_compliance_path_choice` a aussi un choix nul, mais le parcours y est ouvert, pas sauté).

`compliancePathApplicable` croise maintenant ce signal avec les caractéristiques d'entreprise existantes.

Le commentaire de `src/e2e/declaration-process-panel.e2e.ts:216-222`, qui affirmait à tort que l'étape survivait toujours à la complétion, est mis à jour en conséquence (aucune assertion de test modifiée).

## Vérification

**Vérification one-shot** (dev server local, entreprise ≥250 salariés, sans CSE, démarche `demarche_completed` sans choix de parcours) :

| | Avant | Après |
|---|---|---|
| Étape « Parcours de mise en conformité » affichée | 1 (cochée « Étape terminée ») | 0 |
| « Votre déclaration a été transmise » | 1 | 1 (inchangé) |
| Lien « Voir le récapitulatif de la déclaration » | 1 | 1 (inchangé) |

Témoins vérifiés (restent à 1 après le fix) : même entreprise en `draft` (issue pas encore connue — étape visible), et en `demarche_completed` avec `firstDeclarationPathChoice: "justify"` (le parcours a bien eu lieu — étape visible).

**Revert-verify** : `git apply -R` sur le diff source → le nouveau test `hides the compliance-path step once démarche_completed is reached with no path choice recorded` est **RED** (1 occurrence trouvée au lieu de 0) ; ré-appliqué → **GREEN**.

## Tests

- `modules/domain/__tests__/declarationStatus.test.ts` — `isCompliancePathStepApplicable`, exhaustif sur les 8 états FSM + `null`, avec et sans choix de parcours.
- `modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx` — nouveau bloc CAS-01 (#4291) : masquage à la complétion sans choix, visibilité en brouillon, visibilité si parcours effectivement choisi.
- Suite complète : 458 fichiers / 5901 tests verts, typecheck clean, lint/format clean.

Aucun test E2E ajouté par ce ticket (hors périmètre `code-dev` — `e2e-dev` passera en fin de pipeline).
