### PR TITLE
fix(declaration): #4295 — libellé conditionnel du bouton étape 6 récapitulatif

### DIFF
--- a/packages/app/src/e2e/helpers/declaration-flows.ts
+++ b/packages/app/src/e2e/helpers/declaration-flows.ts
@@ -366,7 +366,7 @@ export async function reachStep6ComplianceRecap(page: Page) {
  */
 export async function submitFromStep6Recap(page: Page) {
 	await test.step("étape 6 — récapitulatif et transmission", async () => {
-		await page.getByRole("button", { name: "Suivant" }).click();
+		await page.getByRole("button", { name: "Soumettre" }).click();
 		// Click the label, as the DSFR checkbox label intercepts pointer events.
 		await page.getByText(/Je certifie/).click();
 		await page.getByRole("button", { name: "Valider" }).click();

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -185,7 +185,7 @@ export function Step6Review({
 							? getCurrentStageHref(declaration.status, cseOpinionRequired)
 							: undefined
 					}
-					nextLabel="Suivant"
+					nextLabel={isSubmitted ? "Suivant" : "Soumettre"}
 					previousHref={getPreviousStepHref(6, indicatorGRequired)}
 				/>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -494,7 +494,7 @@ describe("Step6Review", () => {
 		);
 	});
 
-	it("renders next as a submit button when not submitted", () => {
+	it("renders next as a submit button labelled Soumettre when not submitted", () => {
 		render(
 			<Step6Review
 				companyWorkforce={null}
@@ -509,7 +509,7 @@ describe("Step6Review", () => {
 			/>,
 		);
 		expect(
-			screen.getByRole("button", { name: /suivant/i }),
+			screen.getByRole("button", { name: /soumettre/i }),
 		).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
Closes #4295

## Résumé

Le bouton de droite de l'étape 6 (récapitulatif de la première déclaration) affichait toujours « Suivant », y compris à l'état `draft` où il déclenche en réalité l'ouverture de la modale de certification/soumission — pas une navigation. Le libellé est désormais conditionné sur `isSubmitted`, à l'identique du pattern déjà en place dans `SecondDeclarationStep3Review.tsx` : « Soumettre » tant que le bouton ouvre la modale, « Suivant » une fois la déclaration transmise (le bouton devient alors un lien de navigation).

Aucun changement de comportement, de route ni de mutation — uniquement le texte du bouton.

## Fichiers modifiés

- `packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx` — `nextLabel` conditionné sur `isSubmitted`
- `packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx` — assertion mise à jour sur le libellé non-soumis (`/soumettre/i`), l'état soumis (`/suivant/i`) reste couvert par un test existant inchangé
- `packages/app/src/e2e/helpers/declaration-flows.ts` — sélecteur du bouton dans `submitFromStep6Recap` mis à jour pour matcher le nouveau libellé (helper partagé par ~10 specs E2E)

## Vérification

Revert-verify sur le fichier source (`git apply -R` du patch de fix) :
- **avant fix** : `Step6Review.test.tsx` → le test cherchant `getByRole("button", { name: /soumettre/i })` échoue (RED) — le bouton affichait `/suivant/i`
- **après fix** : suite verte (32/32 tests du fichier)

Vérification one-shot du correctif (deux états, sans navigateur, via le rendu du composant testé avec/sans `isSubmitted`) :
- état `draft` (non soumis) → bouton lit **« Soumettre »**, ouvre la modale de certification
- état soumis → bouton lit **« Suivant »**, lien de navigation vers l'étape courante du parcours de conformité (`/declaration-remuneration/parcours-conformite`)

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (suite complète, 5885 tests — 1 flakiness pré-existante hors scope sur `exportApi.test.ts`, confirmée transitoire)
- [x] `pnpm lint:check` / `pnpm format:check`
- [x] Revert-verify du test de non-régression (RED sans le fix, GREEN avec)
- [ ] Fonctionnel (dev server) — validators automatisés à suivre
