### PR TITLE
fix(cse): #4301 — retire la question de consultation au 2e tour

### DIFF
--- a/packages/app/src/app/avis-cse/etape/[step]/page.tsx
+++ b/packages/app/src/app/avis-cse/etape/[step]/page.tsx
@@ -62,6 +62,9 @@ export default async function CseOpinionStepPage({ params }: StepPageProps) {
 					hasSecondDeclaration={hasSecondDeclaration}
 					initialData={initialData}
 					previousHref={previousHref}
+					secondDeclarationPathChoice={
+						declarationData.declaration.secondDeclarationPathChoice
+					}
 					siren={declarationData.declaration.siren}
 					year={declarationData.declaration.year}
 				/>

--- a/packages/app/src/e2e/grille/scenarios.ts
+++ b/packages/app/src/e2e/grille/scenarios.ts
@@ -285,9 +285,13 @@ export const FICHE_SCENARIOS = {
 		});
 		await selectCompliancePath(page, "path-justify");
 		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
+		await expect(page.locator("#first-decl-gap-question-legend")).toBeVisible();
+		await expect(page.locator("#second-decl-gap-question-legend")).toHaveCount(
+			0,
+		);
 		await fillCseStep1(page, {
 			hasSecondDeclaration: true,
-			secondDeclGapConsulted: true,
+			secondDeclGapConsultationImplicit: true,
 		});
 		await submitCseStep2(page, {
 			hasSecondDeclaration: true,

--- a/packages/app/src/e2e/helpers/compliance-flows.ts
+++ b/packages/app/src/e2e/helpers/compliance-flows.ts
@@ -16,6 +16,8 @@ type CseStep1Options = {
 	firstDeclGapConsulted?: boolean;
 	/** Same, for the corrective (second) declaration. */
 	secondDeclGapConsulted?: boolean;
+	/** The second-round justification choice already establishes consultation, so the yes/no radios are absent. */
+	secondDeclGapConsultationImplicit?: boolean;
 	/** Opinion on accuracy (and on gap when consulted). Defaults to "favorable" so existing specs are unaffected. */
 	opinion?: "favorable" | "unfavorable";
 };
@@ -27,12 +29,15 @@ async function fillGapConsultation(
 	consulted: boolean,
 	date: string,
 	opinion: "favorable" | "unfavorable" = "favorable",
+	consultationIsImplicit = false,
 ) {
 	if (!consulted) {
 		await page.locator(`label[for="${idPrefix}-no"]`).click();
 		return;
 	}
-	await page.locator(`label[for="${idPrefix}-yes"]`).click();
+	if (!consultationIsImplicit) {
+		await page.locator(`label[for="${idPrefix}-yes"]`).click();
+	}
 	await page.locator(`label[for="${idPrefix}-${opinion}"]`).click();
 	await page.locator(`#${idPrefix}-date`).fill(date);
 }
@@ -42,6 +47,7 @@ export async function fillCseStep1(page: Page, options: CseStep1Options = {}) {
 		hasSecondDeclaration = false,
 		firstDeclGapConsulted = false,
 		secondDeclGapConsulted = false,
+		secondDeclGapConsultationImplicit = false,
 		opinion = "favorable",
 	} = options;
 	await test.step("avis CSE — étape 1 : avis rendus", async () => {
@@ -64,9 +70,10 @@ export async function fillCseStep1(page: Page, options: CseStep1Options = {}) {
 			await fillGapConsultation(
 				page,
 				"second-decl-gap",
-				secondDeclGapConsulted,
+				secondDeclGapConsulted || secondDeclGapConsultationImplicit,
 				"2025-06-15",
 				opinion,
+				secondDeclGapConsultationImplicit,
 			);
 		}
 		await page.getByRole("button", { name: "Suivant" }).click();

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -41,6 +41,7 @@ type Props = {
 	firstDeclarationPathChoice?: string | null;
 	hasSecondDeclaration?: boolean;
 	previousHref?: string;
+	secondDeclarationPathChoice?: string | null;
 };
 
 export function Step1Opinions({
@@ -52,8 +53,11 @@ export function Step1Opinions({
 	firstDeclarationPathChoice,
 	hasSecondDeclaration = true,
 	previousHref = "/declaration-remuneration/etape/6",
+	secondDeclarationPathChoice,
 }: Props) {
 	const isJointEvaluation = firstDeclarationPathChoice === "joint_evaluation";
+	const isSecondDeclarationJustification =
+		hasSecondDeclaration && secondDeclarationPathChoice === "justify";
 	const router = useRouter();
 	const readOnlyGuard = useReadOnlyGuard();
 	const { isReadOnly } = useLockContext();
@@ -72,13 +76,15 @@ export function Step1Opinions({
 						accuracyOpinion:
 							initialData?.secondDeclAccuracyOpinion ?? undefined,
 						accuracyDate: initialData?.secondDeclAccuracyDate ?? "",
-						gapConsulted: initialData?.secondDeclGapConsulted ?? undefined,
+						gapConsulted: isSecondDeclarationJustification
+							? true
+							: (initialData?.secondDeclGapConsulted ?? undefined),
 						gapOpinion: initialData?.secondDeclGapOpinion ?? null,
 						gapDate: initialData?.secondDeclGapDate ?? null,
 					}
 				: undefined,
 		}),
-		[initialData, hasSecondDeclaration],
+		[initialData, hasSecondDeclaration, isSecondDeclarationJustification],
 	);
 
 	const { draft, setField, isLoadingDraft } = useDeclarationDraft({
@@ -103,7 +109,9 @@ export function Step1Opinions({
 						accuracyOpinion:
 							initialData?.secondDeclAccuracyOpinion ?? undefined,
 						accuracyDate: initialData?.secondDeclAccuracyDate ?? "",
-						gapConsulted: initialData?.secondDeclGapConsulted ?? undefined,
+						gapConsulted: isSecondDeclarationJustification
+							? true
+							: (initialData?.secondDeclGapConsulted ?? undefined),
 						gapOpinion: initialData?.secondDeclGapOpinion ?? null,
 						gapDate: initialData?.secondDeclGapDate ?? null,
 					}
@@ -128,6 +136,9 @@ export function Step1Opinions({
 		}
 		if (hasSecondDeclaration) {
 			const sd = draft.secondDeclaration;
+			if (isSecondDeclarationJustification) {
+				form.setValue("secondDeclaration.gapConsulted", true);
+			}
 			if (sd) {
 				if (sd.accuracyOpinion !== undefined)
 					form.setValue(
@@ -136,7 +147,7 @@ export function Step1Opinions({
 					);
 				if (sd.accuracyDate !== undefined)
 					form.setValue("secondDeclaration.accuracyDate", sd.accuracyDate);
-				if (sd.gapConsulted !== undefined)
+				if (!isSecondDeclarationJustification && sd.gapConsulted !== undefined)
 					form.setValue("secondDeclaration.gapConsulted", sd.gapConsulted);
 				if (sd.gapOpinion !== undefined)
 					form.setValue("secondDeclaration.gapOpinion", sd.gapOpinion);
@@ -144,7 +155,13 @@ export function Step1Opinions({
 					form.setValue("secondDeclaration.gapDate", sd.gapDate);
 			}
 		}
-	}, [isLoadingDraft, draft, form, hasSecondDeclaration]);
+	}, [
+		isLoadingDraft,
+		draft,
+		form,
+		hasSecondDeclaration,
+		isSecondDeclarationJustification,
+	]);
 
 	const triggerDraftSave = useCallback(() => {
 		if (isReadOnly) return;
@@ -160,13 +177,25 @@ export function Step1Opinions({
 	});
 
 	const onSubmit = form.handleSubmit((data) => {
+		const submittedData =
+			isSecondDeclarationJustification && data.secondDeclaration
+				? {
+						...data,
+						secondDeclaration: {
+							...data.secondDeclaration,
+							gapConsulted: true,
+						},
+					}
+				: data;
 		const firstGapIncomplete =
-			data.firstDeclaration.gapConsulted === true &&
-			(!data.firstDeclaration.gapOpinion || !data.firstDeclaration.gapDate);
+			submittedData.firstDeclaration.gapConsulted === true &&
+			(!submittedData.firstDeclaration.gapOpinion ||
+				!submittedData.firstDeclaration.gapDate);
 		const secondGapIncomplete =
 			hasSecondDeclaration &&
-			data.secondDeclaration?.gapConsulted === true &&
-			(!data.secondDeclaration?.gapOpinion || !data.secondDeclaration?.gapDate);
+			submittedData.secondDeclaration?.gapConsulted === true &&
+			(!submittedData.secondDeclaration?.gapOpinion ||
+				!submittedData.secondDeclaration?.gapDate);
 
 		if (firstGapIncomplete) {
 			form.setError("firstDeclaration.gapOpinion", {
@@ -182,7 +211,7 @@ export function Step1Opinions({
 			return;
 		}
 
-		mutation.mutate(data);
+		mutation.mutate(submittedData);
 	});
 
 	const firstDeclOpinion = form.watch("firstDeclaration.accuracyOpinion");
@@ -331,7 +360,11 @@ export function Step1Opinions({
 								name="secondDeclaration.gapConsulted"
 								render={({ field }) => (
 									<GapConsultationCard
-										consulted={field.value ?? null}
+										consulted={
+											isSecondDeclarationJustification
+												? true
+												: (field.value ?? null)
+										}
 										date={secondDeclGapDate ?? ""}
 										id="second-decl-gap"
 										onConsultedChange={(v) => {
@@ -348,6 +381,7 @@ export function Step1Opinions({
 										}}
 										opinion={secondDeclGapOpinion ?? null}
 										readOnly={isReadOnly}
+										showConsultationQuestion={!isSecondDeclarationJustification}
 									/>
 								)}
 							/>

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -62,7 +62,7 @@ export function Step1Opinions({
 	const readOnlyGuard = useReadOnlyGuard();
 	const { isReadOnly } = useLockContext();
 
-	const dbValues = useMemo(
+	const initialFormValues = useMemo(
 		() => ({
 			firstDeclaration: {
 				accuracyOpinion: initialData?.firstDeclAccuracyOpinion ?? undefined,
@@ -92,31 +92,11 @@ export function Step1Opinions({
 		year,
 		step: "opinions",
 		kind: "cse",
-		dbValues,
+		dbValues: initialFormValues,
 	});
 
 	const form = useZodForm(saveOpinionsSchema, {
-		defaultValues: {
-			firstDeclaration: {
-				accuracyOpinion: initialData?.firstDeclAccuracyOpinion ?? undefined,
-				accuracyDate: initialData?.firstDeclAccuracyDate ?? "",
-				gapConsulted: initialData?.firstDeclGapConsulted ?? undefined,
-				gapOpinion: initialData?.firstDeclGapOpinion ?? null,
-				gapDate: initialData?.firstDeclGapDate ?? null,
-			},
-			secondDeclaration: hasSecondDeclaration
-				? {
-						accuracyOpinion:
-							initialData?.secondDeclAccuracyOpinion ?? undefined,
-						accuracyDate: initialData?.secondDeclAccuracyDate ?? "",
-						gapConsulted: isSecondDeclarationJustification
-							? true
-							: (initialData?.secondDeclGapConsulted ?? undefined),
-						gapOpinion: initialData?.secondDeclGapOpinion ?? null,
-						gapDate: initialData?.secondDeclGapDate ?? null,
-					}
-				: undefined,
-		},
+		defaultValues: initialFormValues,
 	});
 
 	useEffect(() => {

--- a/packages/app/src/modules/cseOpinion/__tests__/GapConsultationCard.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/GapConsultationCard.test.tsx
@@ -32,6 +32,26 @@ describe("GapConsultationCard", () => {
 		).toBeInTheDocument();
 	});
 
+	it("hides the consultation question and shows the opinion when consultation is implicit", () => {
+		render(
+			<GapConsultationCard
+				{...defaultProps}
+				consulted={true}
+				showConsultationQuestion={false}
+			/>,
+		);
+
+		expect(
+			screen.queryByText(
+				/Avez-vous informé et consulté le CSE sur la justification des écarts/,
+			),
+		).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Oui")).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Non")).not.toBeInTheDocument();
+		expect(screen.getByText("Quel est l'avis du CSE ?")).toBeInTheDocument();
+		expect(screen.getByLabelText(/Date de l'avis/)).toBeInTheDocument();
+	});
+
 	it("checks Oui radio when consulted is true", () => {
 		render(<GapConsultationCard {...defaultProps} consulted={true} />);
 

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -213,6 +213,32 @@ describe("Step1Opinions", () => {
 		expect(screen.getByText("Deuxième déclaration")).toBeInTheDocument();
 	});
 
+	it("hides only the second consultation question for the second-round justification path", () => {
+		const { container } = render(
+			<Step1Opinions
+				cseDeadline={cseDeadline}
+				hasSecondDeclaration={true}
+				secondDeclarationPathChoice="justify"
+				siren="123456789"
+				year={2026}
+			/>,
+		);
+
+		expect(
+			screen.getAllByText(
+				/Avez-vous informé et consulté le CSE sur la justification des écarts/,
+			),
+		).toHaveLength(1);
+		expect(container.querySelector("#first-decl-gap-yes")).toBeInTheDocument();
+		expect(container.querySelector("#second-decl-gap-yes")).toBeNull();
+		expect(
+			container.querySelector("#second-decl-gap-favorable"),
+		).toBeInTheDocument();
+		expect(
+			container.querySelector("#second-decl-gap-date"),
+		).toBeInTheDocument();
+	});
+
 	it("drops both declaration headings when there is only one declaration", () => {
 		render(
 			<Step1Opinions
@@ -352,6 +378,40 @@ describe("Step1Opinions", () => {
 				gapDate: null,
 			},
 		});
+		expect(mockPush).toHaveBeenCalledWith("/avis-cse/etape/2");
+	});
+
+	it("normalizes the second gap consultation to true for the second-round justification path", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step1Opinions
+				cseDeadline={cseDeadline}
+				hasSecondDeclaration={true}
+				initialData={{
+					firstDeclAccuracyOpinion: "favorable",
+					firstDeclAccuracyDate: "2026-01-15",
+					firstDeclGapConsulted: false,
+					firstDeclGapOpinion: null,
+					firstDeclGapDate: null,
+					secondDeclAccuracyOpinion: "favorable",
+					secondDeclAccuracyDate: "2026-02-01",
+					secondDeclGapConsulted: false,
+					secondDeclGapOpinion: "favorable",
+					secondDeclGapDate: "2026-02-02",
+				}}
+				secondDeclarationPathChoice="justify"
+				siren="123456789"
+				year={2026}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /Suivant/ }));
+
+		expect(mockMutate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				secondDeclaration: expect.objectContaining({ gapConsulted: true }),
+			}),
+		);
 		expect(mockPush).toHaveBeenCalledWith("/avis-cse/etape/2");
 	});
 
@@ -500,6 +560,38 @@ describe("Step1Opinions", () => {
 						secondDeclGapOpinion: null,
 						secondDeclGapDate: null,
 					}}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			await user.click(screen.getByRole("button", { name: /Suivant/ }));
+
+			expect(
+				screen.getByText("Veuillez remplir tous les champs obligatoires."),
+			).toBeInTheDocument();
+			expect(mockMutate).not.toHaveBeenCalled();
+		});
+
+		it("blocks an incomplete implicit second-declaration consultation even when stored as false", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					hasSecondDeclaration={true}
+					initialData={{
+						firstDeclAccuracyOpinion: "favorable",
+						firstDeclAccuracyDate: "2026-01-15",
+						firstDeclGapConsulted: false,
+						firstDeclGapOpinion: null,
+						firstDeclGapDate: null,
+						secondDeclAccuracyOpinion: "favorable",
+						secondDeclAccuracyDate: "2026-02-01",
+						secondDeclGapConsulted: false,
+						secondDeclGapOpinion: null,
+						secondDeclGapDate: null,
+					}}
+					secondDeclarationPathChoice="justify"
 					siren="123456789"
 					year={2026}
 				/>,

--- a/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
@@ -10,6 +10,7 @@ type Props = {
 	onOpinionChange: (value: OpinionType) => void;
 	onDateChange: (value: string) => void;
 	readOnly?: boolean;
+	showConsultationQuestion?: boolean;
 };
 
 export function GapConsultationCard({
@@ -21,6 +22,7 @@ export function GapConsultationCard({
 	onOpinionChange,
 	onDateChange,
 	readOnly = false,
+	showConsultationQuestion = true,
 }: Props) {
 	const legendId = `${id}-legend`;
 	const opinionLegendId = `${id}-opinion-legend`;
@@ -33,54 +35,56 @@ export function GapConsultationCard({
 				sexistes de l'indicateur de rémunération par catégories de salariés
 			</p>
 
-			<fieldset aria-labelledby={legendId} className="fr-fieldset">
-				<legend
-					className="fr-fieldset__legend--regular fr-fieldset__legend"
-					id={`${id}-question-legend`}
-				>
-					Avez-vous informé et consulté le CSE sur la justification des écarts
-					&ge; 5 % ?
-				</legend>
-				<div className="fr-fieldset__element fr-fieldset__element--inline">
-					<div className="fr-radio-group fr-radio-rich">
-						<input
-							checked={consulted === true}
-							disabled={readOnly}
-							id={`${id}-yes`}
-							name={`${id}-consulted`}
-							onChange={() => onConsultedChange(true)}
-							required
-							type="radio"
-							value="yes"
-						/>
-						<label className="fr-label" htmlFor={`${id}-yes`}>
-							Oui
-						</label>
+			{showConsultationQuestion && (
+				<fieldset aria-labelledby={legendId} className="fr-fieldset">
+					<legend
+						className="fr-fieldset__legend--regular fr-fieldset__legend"
+						id={`${id}-question-legend`}
+					>
+						Avez-vous informé et consulté le CSE sur la justification des écarts
+						&ge; 5 % ?
+					</legend>
+					<div className="fr-fieldset__element fr-fieldset__element--inline">
+						<div className="fr-radio-group fr-radio-rich">
+							<input
+								checked={consulted === true}
+								disabled={readOnly}
+								id={`${id}-yes`}
+								name={`${id}-consulted`}
+								onChange={() => onConsultedChange(true)}
+								required
+								type="radio"
+								value="yes"
+							/>
+							<label className="fr-label" htmlFor={`${id}-yes`}>
+								Oui
+							</label>
+						</div>
 					</div>
-				</div>
-				<div className="fr-fieldset__element fr-fieldset__element--inline">
-					<div className="fr-radio-group fr-radio-rich">
-						<input
-							checked={consulted === false}
-							disabled={readOnly}
-							id={`${id}-no`}
-							name={`${id}-consulted`}
-							onChange={() => onConsultedChange(false)}
-							required
-							type="radio"
-							value="no"
-						/>
-						<label className="fr-label" htmlFor={`${id}-no`}>
-							Non
-						</label>
+					<div className="fr-fieldset__element fr-fieldset__element--inline">
+						<div className="fr-radio-group fr-radio-rich">
+							<input
+								checked={consulted === false}
+								disabled={readOnly}
+								id={`${id}-no`}
+								name={`${id}-consulted`}
+								onChange={() => onConsultedChange(false)}
+								required
+								type="radio"
+								value="no"
+							/>
+							<label className="fr-label" htmlFor={`${id}-no`}>
+								Non
+							</label>
+						</div>
 					</div>
-				</div>
-				<div
-					aria-live="polite"
-					className="fr-messages-group"
-					id={`${id}-messages`}
-				/>
-			</fieldset>
+					<div
+						aria-live="polite"
+						className="fr-messages-group"
+						id={`${id}-messages`}
+					/>
+				</fieldset>
+			)}
 
 			{consulted && (
 				<>


### PR DESCRIPTION
## Résumé

- masque la question oui/non sur la justification des écarts uniquement pour la deuxième déclaration lorsque le parcours choisi est « justification »
- considère alors la consultation du CSE comme acquise et persiste `gapConsulted: true`, y compris en présence d'un ancien brouillon ou d'une valeur enregistrée à `false`
- affiche directement l'avis du CSE et sa date, sans modifier le comportement des autres parcours
- adapte le helper Playwright et le scénario CAS-10 pour couvrir ce parcours

Closes #4301

## Vérifications

- `pnpm --filter app exec vitest run src/modules/cseOpinion/__tests__/GapConsultationCard.test.tsx src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx` — 51 tests passés
- `pnpm typecheck:app`
- `pnpm --filter app exec biome check <7 fichiers modifiés>`
- Playwright `[CAS-10]` de bout en bout — 2 tests passés (setup + scénario)
- `pnpm build:app` avec la configuration locale de compilation
