### PR TITLE
fix(cse-opinion): #4300 — un seul accusé de réception au clic Soumettre

### DIFF
--- a/packages/app/src/app/api/upload/__tests__/route.test.ts
+++ b/packages/app/src/app/api/upload/__tests__/route.test.ts
@@ -5,18 +5,10 @@ const mocks = vi.hoisted(() => ({
 	runUploadPipeline: vi.fn(),
 	logAction: vi.fn().mockResolvedValue(undefined),
 	getActiveLock: vi.fn(),
-	enqueueReceipt: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("~/server/auth", () => ({
 	auth: mocks.auth,
-}));
-
-// The success path fires a confirmation mail via a dynamic import of
-// ~/modules/mail/server; mock it so the receipt kind can be asserted without
-// touching the real queue.
-vi.mock("~/modules/mail/server", () => ({
-	enqueueReceipt: mocks.enqueueReceipt,
 }));
 
 vi.mock("~/server/services/uploadPipeline", () => ({
@@ -660,81 +652,5 @@ describe("POST /api/upload", () => {
 
 		expect(response.status).toBe(200);
 		expect(mocks.runUploadPipeline).toHaveBeenCalled();
-	});
-
-	describe("confirmation mail on success", () => {
-		function mockUploadSuccess() {
-			mocks.runUploadPipeline.mockResolvedValue({
-				ok: true,
-				fileId: "file-uuid",
-				fileName: "avis.pdf",
-				filePath: "123456789/2027/file-uuid.pdf",
-			});
-		}
-
-		// The mail is dispatched from a fire-and-forget IIFE that awaits a dynamic
-		// import of ~/modules/mail/server, so its work lands after the response is
-		// returned. Yield to the microtask queue before asserting the call.
-		const flushMailDispatch = () =>
-			new Promise((resolve) => setTimeout(resolve, 0));
-
-		async function upload(flowType: string) {
-			const { POST } = await import("../route");
-			const response = await POST(
-				buildRequest({
-					"Content-Type": "application/pdf",
-					"X-Filename": "avis.pdf",
-					"X-Flow-Type": flowType,
-				}),
-			);
-			await flushMailDispatch();
-			return response;
-		}
-
-		it("enqueues a cseOpinion receipt for a cse_opinion flow", async () => {
-			validSession();
-			mockUploadSuccess();
-
-			const response = await upload("cse_opinion");
-
-			expect(response.status).toBe(200);
-			expect(mocks.enqueueReceipt).toHaveBeenCalledWith({
-				kind: "cseOpinion",
-				to: "user@example.com",
-				siren: "123456789",
-				year: expect.any(Number),
-				userId: "user-1",
-				isResend: false,
-			});
-		});
-
-		it("enqueues a jointEvaluation receipt for a joint_evaluation flow", async () => {
-			validSession();
-			mockUploadSuccess();
-
-			const response = await upload("joint_evaluation");
-
-			expect(response.status).toBe(200);
-			expect(mocks.enqueueReceipt).toHaveBeenCalledWith({
-				kind: "jointEvaluation",
-				to: "user@example.com",
-				siren: "123456789",
-				year: expect.any(Number),
-				userId: "user-1",
-				isResend: false,
-			});
-		});
-
-		it("does not enqueue any receipt when the session has no email", async () => {
-			mocks.auth.mockResolvedValue({
-				user: { id: "user-1", siret: "12345678901234" },
-			});
-			mockUploadSuccess();
-
-			const response = await upload("cse_opinion");
-
-			expect(response.status).toBe(200);
-			expect(mocks.enqueueReceipt).not.toHaveBeenCalled();
-		});
 	});
 });

--- a/packages/app/src/app/api/upload/route.ts
+++ b/packages/app/src/app/api/upload/route.ts
@@ -299,33 +299,6 @@ export async function POST(request: Request): Promise<Response> {
 			userAgent: requestContext.userAgent,
 			durationMs: Date.now() - startedAt,
 		});
-		if (userEmail) {
-			void (async () => {
-				if (flowType === "cse_opinion") {
-					const { enqueueReceipt } = await import("~/modules/mail/server");
-					await enqueueReceipt({
-						kind: "cseOpinion",
-						to: userEmail,
-						siren,
-						year,
-						userId,
-						isResend: false,
-					});
-					return;
-				}
-				if (flowType === "joint_evaluation") {
-					const { enqueueReceipt } = await import("~/modules/mail/server");
-					await enqueueReceipt({
-						kind: "jointEvaluation",
-						to: userEmail,
-						siren,
-						year,
-						userId,
-						isResend: false,
-					});
-				}
-			})();
-		}
 		return Response.json({
 			fileId: result.fileId,
 			fileName: result.fileName,

--- a/packages/app/src/e2e/helpers/compliance-flows.ts
+++ b/packages/app/src/e2e/helpers/compliance-flows.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 
@@ -151,6 +152,75 @@ export async function submitCseStep2(
 		await page.getByRole("button", { name: "Valider" }).click();
 		await page.waitForURL("**/avis-cse/confirmation", { timeout: 30_000 });
 	});
+}
+
+/**
+ * Deposit files on CSE step 2, one upload request per entry — the form
+ * auto-uploads on selection. Lets a caller observe what a deposit alone
+ * triggers, before anything is submitted (#4300).
+ */
+export async function uploadCseFiles(page: Page, fileNames: string[]) {
+	await page.waitForURL("**/avis-cse/etape/2");
+	const pdf = await readFile(DUMMY_PDF);
+	for (const name of fileNames) {
+		const uploaded = page.waitForResponse(
+			(response) =>
+				response.url().includes("/api/upload") &&
+				response.request().method() === "POST",
+		);
+		await page
+			.locator("#cse-file-upload")
+			.setInputFiles([{ name, mimeType: "application/pdf", buffer: pdf }]);
+		await uploaded;
+		await expect(page.getByText(name, { exact: false }).first()).toBeVisible({
+			timeout: 30_000,
+		});
+	}
+}
+
+/**
+ * Associate deposited files to matrix columns. A column holds exactly one file,
+ * so each pairing is explicit. Each wait matches its own mutation rather than
+ * the next response to arrive: the payload is cumulative, so the response
+ * carrying this column proves every association ticked so far reached the
+ * server, which the optimistic submit gate does not.
+ */
+export async function associateCseContentTypes(
+	page: Page,
+	assignments: { column: CseColumn; fileName: string }[],
+	options: { hasSecondDeclaration?: boolean } = {},
+) {
+	const { hasSecondDeclaration = false } = options;
+	for (const { column, fileName } of assignments) {
+		const persisted = page.waitForResponse((response) => {
+			if (!response.url().includes("setFileContentTypes") || !response.ok()) {
+				return false;
+			}
+			const body = response.request().postData() ?? "";
+			return (
+				body.includes(`"type":"${column.type}"`) &&
+				body.includes(`"declarationNumber":${column.declarationNumber}`)
+			);
+		});
+		await page
+			.getByRole("checkbox", {
+				name: cseCheckboxName(column, fileName, hasSecondDeclaration),
+			})
+			.check();
+		await persisted;
+	}
+}
+
+/** Submit CSE step 2: certify, validate, then land on the confirmation page. */
+export async function submitCseOpinion(page: Page) {
+	const submit = page.getByRole("button", { name: "Soumettre" });
+	await expect(submit).toBeEnabled();
+	await submit.click();
+	await page
+		.getByText(/Je certifie que les avis transmis sont conformes/)
+		.click();
+	await page.getByRole("button", { name: "Valider" }).click();
+	await page.waitForURL("**/avis-cse/confirmation", { timeout: 30_000 });
 }
 
 export async function uploadJointEvalPdf(page: Page) {

--- a/packages/app/src/e2e/helpers/notifications-worker.ts
+++ b/packages/app/src/e2e/helpers/notifications-worker.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import path from "node:path";
+import postgres from "postgres";
 
 const NOTIFICATIONS_DATABASE_URL =
 	process.env.NOTIFICATIONS_DATABASE_URL ??
@@ -78,4 +79,23 @@ export async function killWorker(worker: ChildProcess): Promise<void> {
 
 export function isMailFlowEnabled(): boolean {
 	return process.env.MAIL_ENABLED === "true";
+}
+
+/**
+ * Drop everything still queued in pg-boss.
+ *
+ * The worker only runs while this spec file does, so every receipt other specs
+ * enqueued meanwhile is still pending: starting the worker would drain that
+ * backlog into Mailpit and make "how many receipts did this flow send?" count
+ * other specs' mail. Purging first scopes the mailbox to the test at hand.
+ */
+export async function clearNotificationQueue(): Promise<void> {
+	const sql = postgres(NOTIFICATIONS_DATABASE_URL, { max: 1 });
+	try {
+		await sql`DELETE FROM pgboss.job`;
+	} catch {
+		// The schema only exists once pg-boss has started at least once.
+	} finally {
+		await sql.end();
+	}
 }

--- a/packages/app/src/e2e/notifications-email-flow.e2e.ts
+++ b/packages/app/src/e2e/notifications-email-flow.e2e.ts
@@ -1,8 +1,12 @@
 import type { ChildProcess } from "node:child_process";
 import { expect, test } from "@playwright/test";
 import {
+	associateCseContentTypes,
 	completeSecondDeclaration,
+	fillCseStep1,
 	selectCompliancePath,
+	submitCseOpinion,
+	uploadCseFiles,
 } from "./helpers/compliance-flows";
 import {
 	resetDeclarationToDraft,
@@ -12,10 +16,12 @@ import {
 import { completeDeclaration } from "./helpers/declaration-flows";
 import {
 	clearMailpit,
+	listEmailsTo,
 	mailpitReachable,
 	waitForEmail,
 } from "./helpers/mailpit";
 import {
+	clearNotificationQueue,
 	isMailFlowEnabled,
 	killWorker,
 	spawnNotificationsWorker,
@@ -23,6 +29,12 @@ import {
 } from "./helpers/notifications-worker";
 
 const TEST_USER_EMAIL = "test@fia1.fr";
+const CSE_OPINION_RECEIPT = /Dépôt d'avis CSE et fin de démarche/i;
+
+async function countCseOpinionReceipts(): Promise<number> {
+	const emails = await listEmailsTo(TEST_USER_EMAIL);
+	return emails.filter((m) => CSE_OPINION_RECEIPT.test(m.subject)).length;
+}
 
 test.describe("notifications email flow (publisher → pg-boss → worker → SMTP → mailpit)", () => {
 	let worker: ChildProcess | null = null;
@@ -37,6 +49,7 @@ test.describe("notifications email flow (publisher → pg-boss → worker → SM
 				"MAIL_ENABLED!=true on the app server — publisher is no-op, skipping",
 			);
 		}
+		await clearNotificationQueue();
 		worker = spawnNotificationsWorker();
 		await waitForWorkerReady(worker);
 	});
@@ -46,6 +59,7 @@ test.describe("notifications email flow (publisher → pg-boss → worker → SM
 	});
 
 	test.beforeEach(async () => {
+		await clearNotificationQueue();
 		await clearMailpit();
 		await resetDeclarationToDraft();
 		await setCompanyHasCse(false);
@@ -68,6 +82,59 @@ test.describe("notifications email flow (publisher → pg-boss → worker → SM
 		expect(email.subject).toMatch(/Transmission de déclaration/i);
 		expect(email.to.some((r) => r.address === TEST_USER_EMAIL)).toBe(true);
 		expect(email.html).toMatch(/accuse réception de cette transmission/i);
+	});
+
+	test("CSE opinion receipt is sent once at submission, never on a file deposit (#4300)", async ({
+		page,
+	}) => {
+		test.slow();
+		// A gap declaration settled on the "justify" path opens two matrix columns,
+		// which is what lets two deposited files both be associated: a column holds
+		// exactly one file.
+		await setCompanyWorkforce(200);
+		await setCompanyHasCse(true);
+		await clearMailpit();
+
+		const startedAt = new Date();
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-justify");
+		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+		await fillCseStep1(page, { firstDeclGapConsulted: true });
+
+		const accuracyFile = "avis-cse-exactitude.pdf";
+		const gapFile = "avis-cse-justification.pdf";
+
+		await test.step("depositing two files sends no receipt", async () => {
+			await uploadCseFiles(page, [accuracyFile, gapFile]);
+			// The receipt announces "votre démarche est désormais terminée"; a deposit
+			// must never claim it. Settle past the worker poll so a mail wrongly
+			// enqueued on upload would have been delivered before we assert none.
+			await page.waitForTimeout(10_000);
+			expect(await countCseOpinionReceipts()).toBe(0);
+		});
+
+		await test.step("submitting sends exactly one receipt", async () => {
+			await associateCseContentTypes(page, [
+				{
+					column: { declarationNumber: 1, type: "accuracy" },
+					fileName: accuracyFile,
+				},
+				{ column: { declarationNumber: 1, type: "gap" }, fileName: gapFile },
+			]);
+			await submitCseOpinion(page);
+
+			const receipt = await waitForEmail(
+				TEST_USER_EMAIL,
+				(m) => CSE_OPINION_RECEIPT.test(m.subject),
+				{ since: startedAt },
+			);
+			expect(receipt.to.some((r) => r.address === TEST_USER_EMAIL)).toBe(true);
+			expect(receipt.html).toMatch(/démarche est désormais terminée/i);
+
+			// Any deposit-time receipt would have been queued before this one, so it
+			// would already have been delivered — the total is the real assertion.
+			expect(await countCseOpinionReceipts()).toBe(1);
+		});
 	});
 
 	test("second declaration submission (corrective action) delivers a second-declaration receipt", async ({

--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.finalize.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.finalize.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({
+	enqueueReceipt: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("~/server/auth", () => ({
 	auth: vi.fn(),
 }));
@@ -10,6 +14,13 @@ vi.mock("~/server/db", () => ({
 
 vi.mock("~/server/services/s3", () => ({
 	deleteFile: vi.fn(),
+}));
+
+// finalize() enqueues the "démarche terminée" receipt itself, after the
+// transaction commits — mock the dynamic import so the call can be asserted
+// without touching the real queue (issue #4300).
+vi.mock("~/modules/mail/server", () => ({
+	enqueueReceipt: mocks.enqueueReceipt,
 }));
 
 const DEFAULT_DECLARATION = {
@@ -202,6 +213,7 @@ function createCaller(
 	mockDb: unknown,
 	siret: string | null = "33978727700015",
 	impersonation: { siren: string; name: string } | null = null,
+	email: string | null = "user@example.com",
 ) {
 	return import("../cseOpinion").then(({ cseOpinionRouter }) =>
 		cseOpinionRouter.createCaller({
@@ -209,6 +221,7 @@ function createCaller(
 			session: {
 				user: {
 					id: "user-1",
+					email,
 					siret,
 					isAdmin: impersonation !== null,
 					impersonation,
@@ -223,6 +236,7 @@ function createCaller(
 describe("cseOpinionRouter.finalize", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
+		mocks.enqueueReceipt.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
@@ -250,6 +264,51 @@ describe("cseOpinionRouter.finalize", () => {
 			"cse_opinion_submit",
 			"demarche_complete",
 		]);
+	});
+
+	// Regression guard (#4300): the "démarche terminée" receipt used to fire on
+	// every file upload (route.ts), producing up to MAX_CSE_FILES duplicates and
+	// none on the actual Submit click. It now fires exactly once here, after the
+	// transaction that materialises the Submit action commits — moved from
+	// src/app/api/upload/__tests__/route.test.ts.
+	describe("confirmation mail on finalize", () => {
+		it("enqueues a cseOpinion receipt after the transaction commits", async () => {
+			const ctx = createMockDbForFinalize();
+			const caller = await createCaller(ctx.db);
+
+			const result = await caller.finalize();
+
+			expect(result).toEqual({ success: true });
+			expect(mocks.enqueueReceipt).toHaveBeenCalledTimes(1);
+			expect(mocks.enqueueReceipt).toHaveBeenCalledWith({
+				kind: "cseOpinion",
+				to: "user@example.com",
+				siren: "339787277",
+				year: expect.any(Number),
+				userId: "user-1",
+				isResend: false,
+			});
+		});
+
+		it("does not enqueue any receipt when the session has no email", async () => {
+			const ctx = createMockDbForFinalize();
+			const caller = await createCaller(ctx.db, "33978727700015", null, null);
+
+			const result = await caller.finalize();
+
+			expect(result).toEqual({ success: true });
+			expect(mocks.enqueueReceipt).not.toHaveBeenCalled();
+		});
+
+		it("does not enqueue a receipt when a precondition guard rejects finalize", async () => {
+			const ctx = createMockDbForFinalize({ opinionCount: 0 });
+			const caller = await createCaller(ctx.db);
+
+			await expect(caller.finalize()).rejects.toThrow(
+				"Les avis du CSE doivent être renseignés avant validation.",
+			);
+			expect(mocks.enqueueReceipt).not.toHaveBeenCalled();
+		});
 	});
 
 	it("re-accepts finalize when the declaration is already completed (editable after submission)", async () => {

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -14,8 +14,9 @@ function createLockedCaller(
 	mockDb: unknown,
 	siret?: string | null,
 	impersonation?: { siren: string; name: string } | null,
+	email?: string,
 ) {
-	return createCaller(withLockMiddleware(mockDb), siret, impersonation);
+	return createCaller(withLockMiddleware(mockDb), siret, impersonation, email);
 }
 
 vi.mock("~/server/auth", () => ({
@@ -24,6 +25,19 @@ vi.mock("~/server/auth", () => ({
 
 vi.mock("~/server/db", () => ({
 	db: {},
+}));
+
+const { mockEnqueueReceipt } = vi.hoisted(() => ({
+	mockEnqueueReceipt: vi.fn().mockResolvedValue(undefined),
+}));
+
+// submitDeclaration and submitJointEvaluation enqueue their confirmation
+// receipt themselves, after their transaction commits — mock the dynamic
+// import so it can be asserted without touching the real queue. Most tests
+// below don't pass a session email, so the guarded call never fires and this
+// mock stays untouched (issue #4300).
+vi.mock("~/modules/mail/server", () => ({
+	enqueueReceipt: mockEnqueueReceipt,
 }));
 
 const { mockGetCampaignDeadlines } = vi.hoisted(() => ({
@@ -385,6 +399,7 @@ function createSimpleSelectDb(
 describe("declarationRouter", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
+		mockEnqueueReceipt.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
@@ -1323,6 +1338,73 @@ describe("declarationRouter", () => {
 			expect(purgeCall).toBeDefined();
 			expect(purgeCall?.draft).toBeNull();
 			expect(purgeCall?.draftUpdatedAt).toBeNull();
+		});
+
+		// Regression guard (#4300): the "démarche terminée" receipt used to fire
+		// from the upload route on every file received, ahead of a successful
+		// submit and surviving its failure. It now fires exactly once here, after
+		// the transaction that materialises the Submit action commits — moved
+		// from src/app/api/upload/__tests__/route.test.ts.
+		describe("confirmation mail on submitJointEvaluation", () => {
+			it("enqueues a jointEvaluation receipt after the transaction commits", async () => {
+				const declaration = buildDeclaration({
+					status: "joint_evaluation_chosen",
+					cseRequired: true,
+					firstDeclarationPathChoice: "joint_evaluation",
+				});
+				const ctx = createSimpleSelectDb(declaration);
+				const caller = await createLockedCaller(
+					ctx.db,
+					undefined,
+					undefined,
+					"user@example.com",
+				);
+
+				const result = await caller.submitJointEvaluation();
+
+				expect(result).toEqual({ success: true });
+				expect(mockEnqueueReceipt).toHaveBeenCalledTimes(1);
+				expect(mockEnqueueReceipt).toHaveBeenCalledWith({
+					kind: "jointEvaluation",
+					to: "user@example.com",
+					siren: "339787277",
+					year: expect.any(Number),
+					userId: "user-1",
+					isResend: false,
+				});
+			});
+
+			it("does not enqueue any receipt when the session has no email", async () => {
+				const declaration = buildDeclaration({
+					status: "joint_evaluation_chosen",
+					cseRequired: true,
+					firstDeclarationPathChoice: "joint_evaluation",
+				});
+				const ctx = createSimpleSelectDb(declaration);
+				const caller = await createLockedCaller(ctx.db);
+
+				const result = await caller.submitJointEvaluation();
+
+				expect(result).toEqual({ success: true });
+				expect(mockEnqueueReceipt).not.toHaveBeenCalled();
+			});
+
+			it("does not enqueue a receipt when the declaration is missing", async () => {
+				const selectQueue = createSelectQueue([[]]);
+				const mockDb = {
+					select: selectQueue.select,
+					update: vi.fn(),
+				} as unknown;
+				const caller = await createLockedCaller(
+					mockDb,
+					undefined,
+					undefined,
+					"user@example.com",
+				);
+
+				await expect(caller.submitJointEvaluation()).rejects.toThrow();
+				expect(mockEnqueueReceipt).not.toHaveBeenCalled();
+			});
 		});
 	});
 

--- a/packages/app/src/server/api/routers/__tests__/helpers/declarationTestHelpers.ts
+++ b/packages/app/src/server/api/routers/__tests__/helpers/declarationTestHelpers.ts
@@ -47,6 +47,7 @@ export function createCaller(
 	mockDb: unknown,
 	siret: string | null = "33978727700015",
 	impersonation: { siren: string; name: string } | null = null,
+	email?: string,
 ) {
 	return import("~/server/api/routers/declaration").then(
 		({ declarationRouter }) =>
@@ -55,6 +56,7 @@ export function createCaller(
 				session: {
 					user: {
 						id: "user-1",
+						email,
 						siret,
 						isAdmin: impersonation !== null,
 						impersonation,

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -6,7 +6,7 @@ import {
 	saveOpinionsSchema,
 	setFileContentTypesSchema,
 } from "~/modules/cseOpinion/schemas";
-import { hasGapsAboveThreshold } from "~/modules/domain";
+import { getCurrentYear, hasGapsAboveThreshold } from "~/modules/domain";
 import {
 	createTRPCRouter,
 	declarationProcedure,
@@ -384,6 +384,19 @@ export const cseOpinionRouter = createTRPCRouter({
 					.where(eq(declarations.id, ctx.declarationId));
 			}
 		});
+
+		const email = ctx.session.user.email;
+		if (email) {
+			const { enqueueReceipt } = await import("~/modules/mail/server");
+			await enqueueReceipt({
+				kind: "cseOpinion",
+				to: email,
+				siren: ctx.siren,
+				year: getCurrentYear(),
+				userId: ctx.session.user.id,
+				isResend: false,
+			});
+		}
 
 		return { success: true };
 	}),

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -956,6 +956,19 @@ export const declarationRouter = createTRPCRouter({
 				await purgeDraftSlice(tx, siren, year, "joint");
 			});
 
+			const email = ctx.session.user.email;
+			if (email) {
+				const { enqueueReceipt } = await import("~/modules/mail/server");
+				await enqueueReceipt({
+					kind: "jointEvaluation",
+					to: email,
+					siren,
+					year,
+					userId: ctx.session.user.id,
+					isResend: false,
+				});
+			}
+
 			return { success: true };
 		}),
 


### PR DESCRIPTION
Closes #4300

## Résumé

L'accusé de réception « Dépôt d'avis CSE et fin de démarche » (et son équivalent évaluation conjointe) partait depuis la route d'upload à chaque fichier reçu, alors qu'il annonce la fin de la démarche — jusqu'à 4 doublons pour un dépôt de plusieurs fichiers, et aucun envoi si la soumission elle-même échouait.

Le mail est désormais enfilé depuis `cseOpinion.finalize` et `declaration.submitJointEvaluation`, juste après le commit de leur transaction — sur le modèle déjà utilisé par `declaration.submitDeclaration`. Aucun verrou supplémentaire n'a été ajouté : `applyAction` lève sur une transition invalide, donc un second appel séquentiel échoue avant d'atteindre l'envoi.

Les 3 tests qui verrouillaient l'ancien comportement dans `route.test.ts` ont été déplacés (pas affaiblis) vers les tests des deux routeurs concernés, avec une assertion `toHaveBeenCalledTimes(1)` ajoutée en plus.

## Vérification

**Revert-verify (TU)** : les nouveaux tests `enqueues a cseOpinion receipt after the transaction commits` et `enqueues a jointEvaluation receipt after the transaction commits` échouent (RED) quand le fix source est retiré, et passent (GREEN) une fois réappliqué.

**Vérification one-shot (bout en bout, real DB + real pg-boss + real SMTP)** : via le dev server du worktree, une déclaration `awaiting_cse_opinion` a été seedée avec ses avis/fichiers/associations, puis `cseOpinion.finalize()` appelé réellement (pas mocké). Résultat observé sur Mailpit :
- **avant** l'appel : 0 message pour l'adresse de test
- **après** l'appel : exactement **1** message, sujet « Dépôt d'avis CSE et fin de démarche »

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (5922 tests, suite complète verte)
- [x] Revert-verify RED/GREEN sur les 2 nouveaux tests de régression
- [x] Vérification one-shot end-to-end (DB + pg-boss + SMTP réels) — 0 → 1 message, sujet correct
- [ ] CI (typecheck/lint/format/tests) — en cours
- [ ] SonarCloud
