### PR TITLE
feat(my-space): #3759 — badges Clôturée - incomplète / Clôturée - non effectuée

### DIFF
--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -3,6 +3,10 @@ import { expect, type Page, test } from "@playwright/test";
 import { getCurrentYear } from "~/modules/domain";
 import { TEST_USER_PHONE } from "./constants";
 import {
+	pinCampaignYear,
+	setServerCampaignYear,
+} from "./helpers/campaign-year";
+import {
 	deleteCseOpinions,
 	deleteJointEvaluationFiles,
 	ensureCurrentYearDeclaration,
@@ -10,11 +14,16 @@ import {
 	insertJointEvaluationFile,
 	resetDeclarationToDraft,
 	resetGipWorkforce,
+	seedDeclarationForYear,
 	setCompanyHasCse,
 	setDeclarationComplianceState,
 	setGipWorkforce,
 	setUserPhone,
 } from "./helpers/db";
+import {
+	resetCampaignYear as resetCampaignYearData,
+	setCampaignDeadlines,
+} from "./helpers/db-campaign";
 import { clickAndExpectDialogOpen, waitForDsfrModal } from "./helpers/dsfr";
 import { loginWithProConnect } from "./helpers/login";
 
@@ -453,6 +462,138 @@ test.describe("Mon espace — Ressources cell of the rémunération row", () => 
 			await expect(
 				panel.getByRole("link", { name: RECAP_TRANSMITTED_TITLE }),
 			).toHaveCount(0);
+		});
+	});
+});
+
+// Closure badges of the "Années précédentes" table (#3759). The projection is a second pass laid
+// over computeDeclarationStatus, and only a real past-year row exercises it end to end: the
+// campaign year comes from the pinned clock, while the step deadline is resolved on the row's OWN
+// year — from app_campaign_deadline when a row exists, from the domain defaults when it does not.
+// Those two resolutions have to agree across getWithDeclarations, buildDeclarationList and the
+// badge, which is precisely what no unit test can observe. Per-status projection is covered by
+// domain/__tests__/declarationStatus.test.ts, per-variant markup by StatusBadge.test.tsx.
+const CLOSURE_PINNED_YEAR = 2031;
+const YEAR_CLOSED_NOT_DONE = 2021;
+const YEAR_CLOSED_INCOMPLETE = 2022;
+const YEAR_STILL_OPEN = 2023;
+const YEAR_DONE = 2024;
+
+const REAL_PAST_DEADLINES = {
+	decl1ModificationDeadline: "2020-06-01",
+	decl1JustificationDeadline: "2020-06-01",
+	decl1JointEvaluationDeadline: "2020-08-01",
+	decl2ModificationDeadline: "2020-12-01",
+	decl2JustificationDeadline: "2020-12-01",
+	decl2JointEvaluationDeadline: "2021-01-01",
+	decl2CseOpinionDeadline: "2021-02-01",
+} as const;
+
+const OPEN_CSE_OPINION_DEADLINES = {
+	...REAL_PAST_DEADLINES,
+	decl2CseOpinionDeadline: "2099-02-01",
+} as const;
+
+test.describe("Mon espace — closure badges of the previous-years table", () => {
+	test.describe.configure({ mode: "serial" });
+	test.setTimeout(90_000);
+
+	const SEEDED_YEARS = [
+		YEAR_CLOSED_NOT_DONE,
+		YEAR_CLOSED_INCOMPLETE,
+		YEAR_STILL_OPEN,
+		YEAR_DONE,
+		CLOSURE_PINNED_YEAR,
+	];
+
+	test.beforeAll(async () => {
+		for (const year of SEEDED_YEARS) {
+			await resetCampaignYearData(year);
+		}
+		// YEAR_CLOSED_NOT_DONE deliberately gets no app_campaign_deadline row: its closure has to
+		// fall back on getDefaultCampaignDeadlines(), whose modification deadline for that year is
+		// already behind the wall clock. The other two closed-side years carry an explicit row, so
+		// the DB branch of the resolution is exercised too.
+		await setCampaignDeadlines(YEAR_CLOSED_INCOMPLETE, REAL_PAST_DEADLINES);
+		await setCampaignDeadlines(YEAR_STILL_OPEN, OPEN_CSE_OPINION_DEADLINES);
+		// The pinned year gets the same expired deadlines as the closed rows, so the "current year
+		// is never closed" assertion below bites on the year guard rather than on the deadline one.
+		await setCampaignDeadlines(CLOSURE_PINNED_YEAR, REAL_PAST_DEADLINES);
+		await seedDeclarationForYear(CLOSURE_PINNED_YEAR, "draft", 0);
+		await seedDeclarationForYear(YEAR_CLOSED_NOT_DONE, "draft", 0);
+		await seedDeclarationForYear(
+			YEAR_CLOSED_INCOMPLETE,
+			"corrective_actions_chosen",
+			6,
+		);
+		await seedDeclarationForYear(YEAR_STILL_OPEN, "awaiting_cse_opinion", 6);
+		await seedDeclarationForYear(YEAR_DONE, "demarche_completed", 6);
+		await setCompanyHasCse(true);
+		await setUserPhone(TEST_USER_PHONE);
+	});
+
+	test.afterAll(async () => {
+		// The server clock override lives on the Node process and outlives the page, so it goes
+		// first: any later unpinned spec would otherwise keep reading CLOSURE_PINNED_YEAR (#4067).
+		await setServerCampaignYear(null);
+		for (const year of SEEDED_YEARS) {
+			await resetCampaignYearData(year);
+		}
+		// resetCampaignYearData flattens the two app_company columns, which are not year-scoped.
+		await resetGipWorkforce();
+		await setCompanyHasCse(true);
+		await setUserPhone(TEST_USER_PHONE);
+	});
+
+	function previousYearBadge(page: Page, year: number) {
+		return page
+			.locator('table[aria-labelledby="annees-precedentes-title"] tbody tr')
+			.filter({ has: page.locator(`td:nth-child(2):text-is("${year}")`) })
+			.locator(".fr-badge");
+	}
+
+	test("a past year past its own step deadline is closed, one still inside it is not", async ({
+		page,
+	}) => {
+		await pinCampaignYear(page, CLOSURE_PINNED_YEAR);
+		await page.goto("/mon-espace");
+		await expect(
+			page.getByRole("heading", { name: "Années précédentes" }),
+		).toBeVisible();
+
+		await test.step("started, never finalised, deadline passed → Clôturée - incomplète", async () => {
+			const badge = previousYearBadge(page, YEAR_CLOSED_INCOMPLETE);
+			await expect(badge).toHaveText("Clôturée - incomplète");
+			await expect(badge).toHaveClass(/fr-badge--warning/);
+		});
+
+		await test.step("draft never filled in, closed on the domain default deadlines → Clôturée - non effectuée", async () => {
+			const badge = previousYearBadge(page, YEAR_CLOSED_NOT_DONE);
+			await expect(badge).toHaveText("Clôturée - non effectuée");
+			await expect(badge).toHaveClass(/fr-badge--error/);
+		});
+
+		await test.step("past year whose CSE-opinion deadline is still open keeps its badge", async () => {
+			await expect(previousYearBadge(page, YEAR_STILL_OPEN)).toHaveText(
+				"En cours",
+			);
+		});
+
+		await test.step("a finalised démarche stays Effectué whatever the deadline", async () => {
+			await expect(previousYearBadge(page, YEAR_DONE)).toHaveText("Effectué");
+		});
+
+		await test.step("the current year is never closed, expired deadlines included", async () => {
+			const currentYearBadge = page
+				.locator('table[aria-labelledby="demarches-en-cours-title"] tbody tr')
+				.filter({ has: page.getByText("Rémunération", { exact: true }) })
+				.filter({
+					has: page.locator(
+						`td:nth-child(2):text-is("${CLOSURE_PINNED_YEAR}")`,
+					),
+				})
+				.locator(".fr-badge");
+			await expect(currentYearBadge).toHaveText("À compléter");
 		});
 	});
 });

--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -512,8 +512,8 @@ test.describe("Mon espace — closure badges of the previous-years table", () =>
 		}
 		// YEAR_CLOSED_NOT_DONE deliberately gets no app_campaign_deadline row: its closure has to
 		// fall back on getDefaultCampaignDeadlines(), whose modification deadline for that year is
-		// already behind the wall clock. The other two closed-side years carry an explicit row, so
-		// the DB branch of the resolution is exercised too.
+		// already behind the pinned campaign clock. The other two closed-side years carry an
+		// explicit row, so the DB branch of the resolution is exercised too.
 		await setCampaignDeadlines(YEAR_CLOSED_INCOMPLETE, REAL_PAST_DEADLINES);
 		await setCampaignDeadlines(YEAR_STILL_OPEN, OPEN_CSE_OPINION_DEADLINES);
 		// The pinned year gets the same expired deadlines as the closed rows, so the "current year

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -1,5 +1,8 @@
 import postgres from "postgres";
-import { REPRESENTATION_SUBJECTION_WINDOW_YEARS } from "~/modules/domain";
+import {
+	type DeclarationFsmStatus,
+	REPRESENTATION_SUBJECTION_WINDOW_YEARS,
+} from "~/modules/domain";
 import { TEST_GIP_WORKFORCE, TEST_SIREN } from "../constants";
 
 const DEFAULT_DB_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
@@ -159,6 +162,32 @@ export async function pushCampaignDeadlinesFarFuture(year?: number) {
 				decl2_justification_deadline = '2099-12-31'::date,
 				decl2_joint_evaluation_deadline = '2099-12-31'::date,
 				decl2_cse_opinion_deadline = '2099-12-31'::date
+		`;
+	} finally {
+		await sql.end();
+	}
+}
+
+/**
+ * Seed the rémunération declaration of one arbitrary campaign year, FSM status included.
+ *
+ * `setDeclarationComplianceState` updates every declaration row of the test SIREN at once, so a
+ * past-year fixture cannot reuse it without overwriting the current-year row the rest of the
+ * suite depends on — hence a year-scoped writer. Pair it with `resetCampaignYear(year)` for
+ * teardown, which purges the row and everything hanging off it.
+ */
+export async function seedDeclarationForYear(
+	year: number,
+	status: DeclarationFsmStatus,
+	currentStep: number,
+) {
+	await ensureCurrentYearDeclaration(year);
+	const sql = createConnection();
+	try {
+		await sql`
+			UPDATE app_declaration
+			SET status = ${status}, current_step = ${currentStep}, updated_at = NOW()
+			WHERE siren = ${TEST_SIREN} AND year = ${year} AND cancelled_at IS NULL
 		`;
 	} finally {
 		await sql.end();

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+	getCurrentDate,
 	getCurrentYear,
 	getDeclarationDeadline,
 	getDeclarationReferencePeriod,
@@ -152,6 +153,52 @@ describe("getCurrentYear", () => {
 		delete (globalThis as { __egaproCampaignYear?: number })
 			.__egaproCampaignYear;
 		expect(getCurrentYear()).toBe(2025);
+	});
+});
+
+describe("getCurrentDate", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		// Never leak the override: every other domain test calls getCurrentYear().
+		delete (globalThis as { __egaproCampaignYear?: number })
+			.__egaproCampaignYear;
+	});
+
+	it("returns the system date when no override is pinned", () => {
+		vi.setSystemTime(new Date(2025, 5, 15, 10, 30, 45, 123));
+		expect(getCurrentDate()).toEqual(new Date(2025, 5, 15, 10, 30, 45, 123));
+	});
+
+	it("carries the calendar date over to the pinned campaign year", () => {
+		vi.setSystemTime(new Date(2025, 5, 15, 10, 30));
+		(globalThis as { __egaproCampaignYear?: number }).__egaproCampaignYear =
+			2029;
+		expect(getCurrentDate()).toEqual(new Date(2029, 5, 15, 10, 30));
+	});
+
+	it("agrees with getCurrentYear under a pinned year", () => {
+		vi.setSystemTime(new Date(2025, 5, 15));
+		(globalThis as { __egaproCampaignYear?: number }).__egaproCampaignYear =
+			2029;
+		expect(getCurrentDate().getFullYear()).toBe(getCurrentYear());
+	});
+
+	it("clamps 29 February to 28 February in a non-leap pinned year", () => {
+		vi.setSystemTime(new Date(2024, 1, 29, 8, 0));
+		(globalThis as { __egaproCampaignYear?: number }).__egaproCampaignYear =
+			2029;
+		expect(getCurrentDate()).toEqual(new Date(2029, 1, 28, 8, 0));
+	});
+
+	it("ignores a non-numeric override and falls back to the system date", () => {
+		vi.setSystemTime(new Date(2025, 5, 15, 10, 30));
+		(globalThis as { __egaproCampaignYear?: unknown }).__egaproCampaignYear =
+			"2029";
+		expect(getCurrentDate()).toEqual(new Date(2025, 5, 15, 10, 30));
 	});
 });
 

--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	applyDeclarationClosure,
 	computeDeclarationStatus,
 	getCurrentCompliancePath,
 	hasStartedSecondDeclaration,
@@ -14,7 +15,7 @@ import {
 	isSecondDeclarationDeadlineApplicable,
 	isSecondDeclarationWritable,
 } from "../shared/declarationStatus";
-import type { DeclarationFsmStatus } from "../types";
+import type { CampaignDeadlines, DeclarationFsmStatus } from "../types";
 import { DECLARATION_FSM_STATUSES } from "../types";
 
 describe("isDraft", () => {
@@ -454,5 +455,145 @@ describe("isJointEvaluationWritable", () => {
 
 	it("returns false once the démarche is completed, which only reopens submit_cse_opinion", () => {
 		expect(isJointEvaluationWritable("demarche_completed")).toBe(false);
+	});
+});
+
+describe("applyDeclarationClosure", () => {
+	const ROW_YEAR = 2026;
+	const CURRENT_YEAR = 2028;
+	// Step deadline for `corrective_actions_chosen` (decl2ModificationDeadline)
+	// and for `draft`/null (decl1ModificationDeadline) both fall well inside
+	// this window, so a single deadlines fixture can drive every scenario.
+	const DEADLINES: CampaignDeadlines = {
+		gipPublicationDate: null,
+		campaignStartDate: null,
+		decl1ModificationDeadline: new Date(2026, 5, 1),
+		decl1JustificationDeadline: new Date(2027, 2, 1),
+		decl1JointEvaluationDeadline: new Date(2026, 7, 1),
+		decl2ModificationDeadline: new Date(2026, 11, 1),
+		decl2JustificationDeadline: new Date(2026, 11, 1),
+		decl2JointEvaluationDeadline: new Date(2027, 0, 1),
+		decl2CseOpinionDeadline: new Date(2027, 1, 1),
+		pathChoiceDeadline: new Date(2027, 0, 1),
+		pathChoiceRound1Deadline: new Date(2026, 6, 1),
+	};
+	const PAST_DEADLINE_NOW = new Date(CURRENT_YEAR, 0, 1);
+	const BEFORE_DEADLINE_NOW = new Date(ROW_YEAR, 0, 15);
+
+	it("S1 — closes an in_progress past-year row past its step deadline as closed_incomplete", () => {
+		expect(
+			applyDeclarationClosure({
+				status: "in_progress",
+				fsmStatus: "corrective_actions_chosen",
+				year: ROW_YEAR,
+				currentYear: CURRENT_YEAR,
+				deadlines: DEADLINES,
+				now: PAST_DEADLINE_NOW,
+			}),
+		).toBe("closed_incomplete");
+	});
+
+	it("S2 — closes a to_complete past-year row past its step deadline as closed_not_done", () => {
+		expect(
+			applyDeclarationClosure({
+				status: "to_complete",
+				fsmStatus: "draft",
+				year: ROW_YEAR,
+				currentYear: CURRENT_YEAR,
+				deadlines: DEADLINES,
+				now: PAST_DEADLINE_NOW,
+			}),
+		).toBe("closed_not_done");
+	});
+
+	it("S3 — a past year whose step deadline has not yet elapsed stays in_progress", () => {
+		expect(
+			applyDeclarationClosure({
+				status: "in_progress",
+				fsmStatus: "awaiting_cse_opinion",
+				year: ROW_YEAR,
+				currentYear: ROW_YEAR + 1,
+				deadlines: DEADLINES,
+				now: BEFORE_DEADLINE_NOW,
+			}),
+		).toBe("in_progress");
+	});
+
+	it("S4 — done never closes, however far past the deadline", () => {
+		expect(
+			applyDeclarationClosure({
+				status: "done",
+				fsmStatus: "demarche_completed",
+				year: ROW_YEAR,
+				currentYear: CURRENT_YEAR,
+				deadlines: DEADLINES,
+				now: PAST_DEADLINE_NOW,
+			}),
+		).toBe("done");
+	});
+
+	it("S5 — the current year never closes, even past its own deadline", () => {
+		expect(
+			applyDeclarationClosure({
+				status: "to_complete",
+				fsmStatus: "draft",
+				year: CURRENT_YEAR,
+				currentYear: CURRENT_YEAR,
+				deadlines: DEADLINES,
+				now: PAST_DEADLINE_NOW,
+			}),
+		).toBe("to_complete");
+	});
+
+	it("never closes a future year relative to currentYear", () => {
+		expect(
+			applyDeclarationClosure({
+				status: "in_progress",
+				fsmStatus: "corrective_actions_chosen",
+				year: CURRENT_YEAR + 1,
+				currentYear: CURRENT_YEAR,
+				deadlines: DEADLINES,
+				now: PAST_DEADLINE_NOW,
+			}),
+		).toBe("in_progress");
+	});
+
+	it("treats the deadline instant itself as not yet passed (strict inequality)", () => {
+		expect(
+			applyDeclarationClosure({
+				status: "to_complete",
+				fsmStatus: "draft",
+				year: ROW_YEAR,
+				currentYear: CURRENT_YEAR,
+				deadlines: DEADLINES,
+				now: DEADLINES.decl1ModificationDeadline,
+			}),
+		).toBe("to_complete");
+	});
+
+	it("never closes when the FSM status carries no step deadline (demarche_completed's null)", () => {
+		expect(
+			applyDeclarationClosure({
+				status: "in_progress",
+				fsmStatus: "demarche_completed",
+				year: ROW_YEAR,
+				currentYear: CURRENT_YEAR,
+				deadlines: DEADLINES,
+				now: PAST_DEADLINE_NOW,
+			}),
+		).toBe("in_progress");
+	});
+
+	it("is a no-op on an already-closed status", () => {
+		expect(
+			applyDeclarationClosure({
+				status: "closed_incomplete",
+				fsmStatus: "corrective_actions_chosen",
+				year: ROW_YEAR,
+				currentYear: CURRENT_YEAR,
+				deadlines: DEADLINES,
+				now: PAST_DEADLINE_NOW,
+			}),
+		).toBe("closed_incomplete");
 	});
 });

--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCurrentDate, getCurrentYear } from "../shared/campaign";
 import {
 	applyDeclarationClosure,
 	computeDeclarationStatus,
@@ -595,5 +596,61 @@ describe("applyDeclarationClosure", () => {
 				now: PAST_DEADLINE_NOW,
 			}),
 		).toBe("closed_incomplete");
+	});
+
+	// The two time inputs come from the clock helpers here rather than from
+	// fixtures: the call site feeds them together, and the bug was that they
+	// disagreed under a pinned campaign year.
+	describe("under a pinned campaign year", () => {
+		const PINNED_YEAR = 2029;
+		const PINNED_ROW_YEAR = 2028;
+		const PINNED_DEADLINES: CampaignDeadlines = {
+			...DEADLINES,
+			decl1ModificationDeadline: new Date(PINNED_ROW_YEAR, 5, 1),
+		};
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			// A wall clock BEFORE the row's deadline, so the two clocks can only
+			// agree if the deadline check honours the override too.
+			vi.setSystemTime(new Date(2026, 0, 15));
+			(globalThis as { __egaproCampaignYear?: number }).__egaproCampaignYear =
+				PINNED_YEAR;
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+			delete (globalThis as { __egaproCampaignYear?: number })
+				.__egaproCampaignYear;
+		});
+
+		it("closes a past-year row when both inputs come from the campaign clock", () => {
+			expect(
+				applyDeclarationClosure({
+					status: "to_complete",
+					fsmStatus: "draft",
+					year: PINNED_ROW_YEAR,
+					currentYear: getCurrentYear(),
+					deadlines: PINNED_DEADLINES,
+					now: getCurrentDate(),
+				}),
+			).toBe("closed_not_done");
+		});
+
+		it("contradicts itself when the deadline check falls back on the wall clock", () => {
+			// Regression guard, not an endorsement: this is the state the call site
+			// was in. The year guard calls the row past while the wall clock leaves
+			// its deadline in the future, so the row renders 'En cours' where
+			// production renders 'Clôturée - non effectuée'.
+			expect(
+				applyDeclarationClosure({
+					status: "to_complete",
+					fsmStatus: "draft",
+					year: PINNED_ROW_YEAR,
+					currentYear: getCurrentYear(),
+					deadlines: PINNED_DEADLINES,
+				}),
+			).toBe("to_complete");
+		});
 	});
 });

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -98,6 +98,7 @@ export { hasRequiredDeclarationInfo } from "./shared/declarationPrerequisites";
 export { getDeclarationProcessStepDeadline } from "./shared/declarationProcessStep";
 // Declaration status
 export {
+	applyDeclarationClosure,
 	computeDeclarationStatus,
 	getCurrentCompliancePath,
 	hasStartedSecondDeclaration,

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -2,6 +2,7 @@
 
 // Campaign
 export {
+	getCurrentDate,
 	getCurrentYear,
 	getDeclarationDeadline,
 	getDeclarationReferencePeriod,

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -9,6 +9,24 @@ export function getCurrentYear(): number {
 	return readCampaignYearOverride() ?? new Date().getFullYear();
 }
 
+/** Returns the current date under the same clock as `getCurrentYear()`, so that a year guard and a deadline check sitting side by side cannot disagree under a pinned campaign year. Pass it to any `now` whose sibling year comes from `getCurrentYear()`. */
+export function getCurrentDate(): Date {
+	const now = new Date();
+	const override = readCampaignYearOverride();
+	if (override === null) return now;
+	// Day 0 of the next month is its predecessor's last: clamping keeps 29 February off 1 March in a non-leap pinned year.
+	const lastDayOfMonth = new Date(override, now.getMonth() + 1, 0).getDate();
+	return new Date(
+		override,
+		now.getMonth(),
+		Math.min(now.getDate(), lastDayOfMonth),
+		now.getHours(),
+		now.getMinutes(),
+		now.getSeconds(),
+		now.getMilliseconds(),
+	);
+}
+
 /** Returns the reference year for a given campaign year (N-1: a declaration reports the prior year's data). */
 export function getReferenceYearFor(campaignYear: number): number {
 	return campaignYear - 1;

--- a/packages/app/src/modules/domain/shared/declarationStatus.ts
+++ b/packages/app/src/modules/domain/shared/declarationStatus.ts
@@ -1,5 +1,10 @@
-import type { DeclarationFsmStatus, DeclarationStatus } from "../types";
+import type {
+	CampaignDeadlines,
+	DeclarationFsmStatus,
+	DeclarationStatus,
+} from "../types";
 import { isDeadlinePassed } from "./campaign";
+import { getDeclarationProcessStepDeadline } from "./declarationProcessStep";
 
 type CompliancePath = "justify" | "corrective_action" | "joint_evaluation";
 
@@ -173,4 +178,33 @@ export function computeDeclarationStatus(
 		return "done";
 	}
 	return "in_progress";
+}
+
+// Second-pass projection composed on top of computeDeclarationStatus, rather than merged into
+// it, so that function's exhaustive FSM signature stays untouched. `year < currentYear` alone is
+// unsafe in Jan/Feb: the prior campaign's deadlines (e.g. decl2CseOpinionDeadline, Feb 1st) can
+// still be open, so closing also requires that row's own-year step deadline to have passed.
+export function applyDeclarationClosure(params: {
+	status: DeclarationStatus;
+	fsmStatus: DeclarationFsmStatus | null;
+	year: number;
+	currentYear: number;
+	deadlines: CampaignDeadlines;
+	now?: Date;
+}): DeclarationStatus {
+	const { status, fsmStatus, year, currentYear, deadlines, now } = params;
+	if (year >= currentYear || status === "done") {
+		return status;
+	}
+	const stepDeadline = getDeclarationProcessStepDeadline(fsmStatus, deadlines);
+	if (stepDeadline === null || !isDeadlinePassed(stepDeadline, now)) {
+		return status;
+	}
+	if (status === "in_progress") {
+		return "closed_incomplete";
+	}
+	if (status === "to_complete") {
+		return "closed_not_done";
+	}
+	return status;
 }

--- a/packages/app/src/modules/domain/types.ts
+++ b/packages/app/src/modules/domain/types.ts
@@ -4,8 +4,13 @@ export type GapLevel = "low" | "high";
 /** Which side a set of pay gaps disfavours, or "balanced" when neither dominates. */
 export type GapDirection = "women" | "men" | "balanced";
 
-/** Lifecycle state of a declaration from the user's perspective. */
-export type DeclarationStatus = "to_complete" | "in_progress" | "done";
+/** Lifecycle state of a declaration from the user's perspective. `closed_incomplete`/`closed_not_done` are reached only via `applyDeclarationClosure` (a past-year row past its step deadline) — `computeDeclarationStatus` itself never returns them. */
+export type DeclarationStatus =
+	| "to_complete"
+	| "in_progress"
+	| "done"
+	| "closed_incomplete"
+	| "closed_not_done";
 
 /** FSM status persisted in `declarations.status`; mirrors `declarationStatusEnum` (kept in sync by `declarationFsmStatus.test.ts` — domain layer stays isomorphic, no Drizzle import). Single source for the FSM state vocabulary: the rule-engine schema (`server/rules/schema.ts`) and every UI mirror derive from this const, so adding/renaming a state surfaces as a `tsc` or Zod error, never a silent production bug. */
 export const DECLARATION_FSM_STATUSES = [

--- a/packages/app/src/modules/my-space/StatusBadge.tsx
+++ b/packages/app/src/modules/my-space/StatusBadge.tsx
@@ -20,6 +20,14 @@ const BADGE_CONFIG: Record<
 		label: "Effectué",
 		className: "fr-badge fr-badge--sm fr-badge--success fr-badge--no-icon",
 	},
+	closed_incomplete: {
+		label: "Clôturée - incomplète",
+		className: "fr-badge fr-badge--sm fr-badge--warning fr-badge--no-icon",
+	},
+	closed_not_done: {
+		label: "Clôturée - non effectuée",
+		className: "fr-badge fr-badge--sm fr-badge--error fr-badge--no-icon",
+	},
 };
 
 export function StatusBadge({ status }: Props) {

--- a/packages/app/src/modules/my-space/__tests__/StatusBadge.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/StatusBadge.test.tsx
@@ -30,4 +30,22 @@ describe("StatusBadge", () => {
 		expect(badge).toHaveClass("fr-badge--sm");
 		expect(badge).toHaveClass("fr-badge--no-icon");
 	});
+
+	it("renders a warning badge for closed_incomplete status", () => {
+		render(<StatusBadge status="closed_incomplete" />);
+		const badge = screen.getByText("Clôturée - incomplète");
+		expect(badge).toBeInTheDocument();
+		expect(badge).toHaveClass("fr-badge--warning");
+		expect(badge).toHaveClass("fr-badge--sm");
+		expect(badge).toHaveClass("fr-badge--no-icon");
+	});
+
+	it("renders an error badge for closed_not_done status, with the exact label (not the Figma typo)", () => {
+		render(<StatusBadge status="closed_not_done" />);
+		const badge = screen.getByText("Clôturée - non effectuée");
+		expect(badge).toBeInTheDocument();
+		expect(badge).toHaveClass("fr-badge--error");
+		expect(badge).toHaveClass("fr-badge--sm");
+		expect(badge).toHaveClass("fr-badge--no-icon");
+	});
 });

--- a/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { RepresentationDeclarationStatus } from "~/modules/domain";
-import { getCurrentYear, getReferenceYearFor } from "~/modules/domain";
+import type {
+	CampaignDeadlines,
+	RepresentationDeclarationStatus,
+} from "~/modules/domain";
+import {
+	getCurrentYear,
+	getDefaultCampaignDeadlines,
+	getReferenceYearFor,
+} from "~/modules/domain";
 import {
 	companies,
 	declarationStatusHistory,
@@ -10,15 +17,20 @@ import {
 	representationDeclarations,
 } from "~/server/db/schema";
 
-const { getRepresentationWorkforceHistoryMock } = vi.hoisted(() => ({
-	getRepresentationWorkforceHistoryMock: vi.fn(),
-}));
+const { getRepresentationWorkforceHistoryMock, getCampaignDeadlinesMock } =
+	vi.hoisted(() => ({
+		getRepresentationWorkforceHistoryMock: vi.fn(),
+		getCampaignDeadlinesMock: vi.fn(),
+	}));
 
 vi.mock("~/server/services/suit");
 vi.mock("~/server/auth", () => ({ auth: vi.fn() }));
 vi.mock("~/server/db", () => ({ db: {} }));
 vi.mock("~/server/db/getRepresentationWorkforceHistory", () => ({
 	getRepresentationWorkforceHistory: getRepresentationWorkforceHistoryMock,
+}));
+vi.mock("~/server/db/getCampaignDeadlines", () => ({
+	getCampaignDeadlines: getCampaignDeadlinesMock,
 }));
 
 const SIREN = "339787277";
@@ -181,6 +193,9 @@ describe("companyRouter.getWithDeclarations", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
 		getRepresentationWorkforceHistoryMock.mockResolvedValue([]);
+		getCampaignDeadlinesMock.mockImplementation((y: number) =>
+			Promise.resolve(getDefaultCampaignDeadlines(y)),
+		);
 	});
 
 	afterEach(() => {
@@ -196,6 +211,18 @@ describe("companyRouter.getWithDeclarations", () => {
 
 		expect(result.company.siren).toBe(SIREN);
 		expect(result.declarations).toBeDefined();
+	});
+
+	it("falls back to step 0 for a remuneration row with no current step", async () => {
+		const { caller } = await makeCaller({
+			declRows: [{ ...makeDeclRow(getCurrentYear()), currentStep: null }],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find((d) => d.type === "remuneration"),
+		).toMatchObject({ currentStep: 0 });
 	});
 
 	it("excludes cancelled declarations from the timeline", async () => {
@@ -522,5 +549,208 @@ describe("companyRouter.getWithDeclarations", () => {
 		expect(
 			result.declarations.find((d) => d.type === "representation"),
 		).toMatchObject({ status: "to_complete", currentStep: 0 });
+	});
+});
+
+describe("companyRouter.getWithDeclarations — past-campaign closure", () => {
+	const PAST_YEAR = getCurrentYear() - 2;
+	const OTHER_PAST_YEAR = getCurrentYear() - 3;
+	// A fixed year 2000 deadline is unambiguously elapsed no matter when the
+	// suite runs, unlike relying on `getDefaultCampaignDeadlines(PAST_YEAR)`
+	// racing the real system clock near a year boundary.
+	const ELAPSED = new Date(2000, 0, 1);
+	const NOT_YET_ELAPSED = new Date(2999, 0, 1);
+
+	function pastDeadlines(
+		year: number,
+		overrides: Partial<CampaignDeadlines>,
+	): CampaignDeadlines {
+		return { ...getDefaultCampaignDeadlines(year), ...overrides };
+	}
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		getRepresentationWorkforceHistoryMock.mockResolvedValue([]);
+		getCampaignDeadlinesMock.mockImplementation((y: number) =>
+			Promise.resolve(getDefaultCampaignDeadlines(y)),
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("S1 — closes a past-year in_progress declaration as closed_incomplete once its step deadline elapsed", async () => {
+		getCampaignDeadlinesMock.mockImplementation((y: number) =>
+			Promise.resolve(
+				y === PAST_YEAR
+					? pastDeadlines(y, { decl2ModificationDeadline: ELAPSED })
+					: getDefaultCampaignDeadlines(y),
+			),
+		);
+		const { caller } = await makeCaller({
+			declRows: [
+				{ ...makeDeclRow(PAST_YEAR), status: "corrective_actions_chosen" },
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find(
+				(d) => d.type === "remuneration" && d.year === PAST_YEAR,
+			),
+		).toMatchObject({ status: "closed_incomplete" });
+	});
+
+	it("S2 — closes a past-year to_complete declaration as closed_not_done once its step deadline elapsed", async () => {
+		getCampaignDeadlinesMock.mockImplementation((y: number) =>
+			Promise.resolve(
+				y === PAST_YEAR
+					? pastDeadlines(y, { decl1ModificationDeadline: ELAPSED })
+					: getDefaultCampaignDeadlines(y),
+			),
+		);
+		const { caller } = await makeCaller({
+			declRows: [
+				{
+					...makeDeclRow(PAST_YEAR),
+					status: "draft",
+					currentStep: 0,
+				},
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find(
+				(d) => d.type === "remuneration" && d.year === PAST_YEAR,
+			),
+		).toMatchObject({ status: "closed_not_done" });
+	});
+
+	it("S3 — keeps a past-year row open while its step deadline has not yet elapsed", async () => {
+		getCampaignDeadlinesMock.mockImplementation((y: number) =>
+			Promise.resolve(
+				y === PAST_YEAR
+					? pastDeadlines(y, { decl2CseOpinionDeadline: NOT_YET_ELAPSED })
+					: getDefaultCampaignDeadlines(y),
+			),
+		);
+		const { caller } = await makeCaller({
+			declRows: [{ ...makeDeclRow(PAST_YEAR), status: "awaiting_cse_opinion" }],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find(
+				(d) => d.type === "remuneration" && d.year === PAST_YEAR,
+			),
+		).toMatchObject({ status: "in_progress" });
+	});
+
+	it("S4 — a demarche_completed past-year row stays done, never closed", async () => {
+		getCampaignDeadlinesMock.mockImplementation((y: number) =>
+			Promise.resolve(
+				y === PAST_YEAR
+					? pastDeadlines(y, { decl2CseOpinionDeadline: ELAPSED })
+					: getDefaultCampaignDeadlines(y),
+			),
+		);
+		const { caller } = await makeCaller({
+			declRows: [{ ...makeDeclRow(PAST_YEAR), status: "demarche_completed" }],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find(
+				(d) => d.type === "remuneration" && d.year === PAST_YEAR,
+			),
+		).toMatchObject({ status: "done" });
+	});
+
+	it("S5 — the current-year row is never closed, whatever its deadline", async () => {
+		const currentYear = getCurrentYear();
+		const { caller } = await makeCaller({
+			declRows: [
+				{ ...makeDeclRow(currentYear), status: "draft", currentStep: 0 },
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find(
+				(d) => d.type === "remuneration" && d.year === currentYear,
+			),
+		).toMatchObject({ status: "to_complete" });
+		expect(getCampaignDeadlinesMock).not.toHaveBeenCalledWith(currentYear);
+	});
+
+	it("S7 — resolves each past year's deadlines independently, one call per distinct year", async () => {
+		getCampaignDeadlinesMock.mockImplementation((y: number) =>
+			Promise.resolve(
+				y === PAST_YEAR
+					? pastDeadlines(y, { decl1ModificationDeadline: ELAPSED })
+					: pastDeadlines(y, { decl2ModificationDeadline: ELAPSED }),
+			),
+		);
+		const { caller } = await makeCaller({
+			declRows: [
+				{
+					...makeDeclRow(PAST_YEAR),
+					id: "declaration-past",
+					status: "draft",
+					currentStep: 0,
+				},
+				{
+					...makeDeclRow(OTHER_PAST_YEAR),
+					id: "declaration-other-past",
+					status: "corrective_actions_chosen",
+				},
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find(
+				(d) => d.type === "remuneration" && d.year === PAST_YEAR,
+			),
+		).toMatchObject({ status: "closed_not_done" });
+		expect(
+			result.declarations.find(
+				(d) => d.type === "remuneration" && d.year === OTHER_PAST_YEAR,
+			),
+		).toMatchObject({ status: "closed_incomplete" });
+		expect(getCampaignDeadlinesMock).toHaveBeenCalledTimes(2);
+		expect(getCampaignDeadlinesMock).toHaveBeenCalledWith(PAST_YEAR);
+		expect(getCampaignDeadlinesMock).toHaveBeenCalledWith(OTHER_PAST_YEAR);
+	});
+
+	it("S6 — a past-year representation-line badge is unaffected by remuneration closure", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceBelowThreshold,
+		);
+		getCampaignDeadlinesMock.mockImplementation((y: number) =>
+			Promise.resolve(pastDeadlines(y, { decl1ModificationDeadline: ELAPSED })),
+		);
+		const { caller } = await makeCaller({
+			declRows: [
+				{ ...makeDeclRow(PAST_YEAR), status: "draft", currentStep: 0 },
+			],
+			representationDeclarationRows: [
+				makeRepresentationDeclarationRow({ status: "submitted" }),
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find((d) => d.type === "representation"),
+		).toMatchObject({ status: "done" });
 	});
 });

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -5,6 +5,7 @@ import {
 	applyDeclarationClosure,
 	computeDeclarationStatus,
 	computeRepresentationDeclarationStatus,
+	getCurrentDate,
 	getCurrentYear,
 	getObligationWorkforce,
 	getReferenceYearFor,
@@ -328,6 +329,8 @@ export const companyRouter = createTRPCRouter({
 							year: d.year,
 							currentYear: year,
 							deadlines,
+							// Same clock as `currentYear` above: left to its default the deadline check would read the wall clock and contradict the year guard.
+							now: getCurrentDate(),
 						})
 					: projectedStatus;
 				return {

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Session } from "next-auth";
 import {
+	applyDeclarationClosure,
 	computeDeclarationStatus,
 	computeRepresentationDeclarationStatus,
 	getCurrentYear,
@@ -26,6 +27,7 @@ import {
 	isImpersonatingSiren,
 } from "~/server/auth/companyAccess";
 import type { DB } from "~/server/db";
+import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
 import { getRepresentationWorkforceHistory } from "~/server/db/getRepresentationWorkforceHistory";
 import {
 	companies,
@@ -294,29 +296,57 @@ export const companyRouter = createTRPCRouter({
 					.map((r) => r.declarationId),
 			);
 
+			const pastYears = [
+				...new Set(
+					declarationRows.filter((d) => d.year < year).map((d) => d.year),
+				),
+			];
+			const pastYearDeadlines = await Promise.all(
+				pastYears.map((pastYear) => getCampaignDeadlines(pastYear)),
+			);
+			const deadlinesByYear = new Map(
+				pastYears.map((pastYear, index) => [
+					pastYear,
+					pastYearDeadlines[index],
+				]),
+			);
+
 			const representationRow = currentYearRepresentationDeclarationRows[0];
 			const representationVisible =
 				representationRow !== undefined ||
 				isPresumedSubjectToRepresentation(representationWorkforceHistory, year);
-			const mappedDeclarations: DbDeclaration[] = declarationRows.map((d) => ({
-				type: "remuneration" as const,
-				year: d.year,
-				status: computeDeclarationStatus({
+			const mappedDeclarations: DbDeclaration[] = declarationRows.map((d) => {
+				const projectedStatus = computeDeclarationStatus({
 					status: d.status,
 					currentStep: d.currentStep,
-				}),
-				fsmStatus: d.status,
-				currentStep: d.currentStep ?? 0,
-				updatedAt: d.updatedAt,
-				firstDeclarationPathChoice: d.firstDeclarationPathChoice,
-				secondDeclarationPathChoice: d.secondDeclarationPathChoice,
-				hasSubmittedSecondDeclaration: declarationIdsWithSecondDecl.has(d.id),
-				hasSubmittedCseOpinion: declarationIdsWithCseOpinion.has(d.id),
-				cseRequired: d.cseRequired,
-				hasJointEvaluationFile: yearsWithJointEval.has(d.year),
-				hasPrefillData: yearsWithPrefill.has(d.year),
-				notSubject: false,
-			}));
+				});
+				const deadlines = deadlinesByYear.get(d.year);
+				const status = deadlines
+					? applyDeclarationClosure({
+							status: projectedStatus,
+							fsmStatus: d.status,
+							year: d.year,
+							currentYear: year,
+							deadlines,
+						})
+					: projectedStatus;
+				return {
+					type: "remuneration" as const,
+					year: d.year,
+					status,
+					fsmStatus: d.status,
+					currentStep: d.currentStep ?? 0,
+					updatedAt: d.updatedAt,
+					firstDeclarationPathChoice: d.firstDeclarationPathChoice,
+					secondDeclarationPathChoice: d.secondDeclarationPathChoice,
+					hasSubmittedSecondDeclaration: declarationIdsWithSecondDecl.has(d.id),
+					hasSubmittedCseOpinion: declarationIdsWithCseOpinion.has(d.id),
+					cseRequired: d.cseRequired,
+					hasJointEvaluationFile: yearsWithJointEval.has(d.year),
+					hasPrefillData: yearsWithPrefill.has(d.year),
+					notSubject: false,
+				};
+			});
 
 			if (representationRow) {
 				const representationCurrentStep = representationRow.currentStep ?? 0;


### PR DESCRIPTION
Closes #3759

## Résumé

Le tableau « Années précédentes » de Mon espace ne distinguait pas une démarche rémunération abandonnée à l'échéance d'une démarche encore en cours. Ce ticket ajoute deux états terminaux de campagne close :

- **Clôturée - incomplète** (`fr-badge--warning`) : démarche commencée, jamais finalisée avant l'échéance de son étape.
- **Clôturée - non effectuée** (`fr-badge--error`) : rien de rempli avant l'échéance.

### Domaine

`applyDeclarationClosure` (`~/modules/domain/shared/declarationStatus.ts`) est une fonction pure de **second passage**, composée au-dessus de `computeDeclarationStatus` — qui garde sa signature et sa projection FSM inchangées (`demarcheRevisionAndStatus.test.ts` passe sans modification). Une ligne ferme quand :

1. son année est strictement antérieure à `getCurrentYear()` ;
2. l'échéance de son étape courante (`getDeclarationProcessStepDeadline`), évaluée avec les `CampaignDeadlines` **de l'année de la ligne**, est dépassée.

`done` ne ferme jamais.

### Routeur

`company.getWithDeclarations` résout les `CampaignDeadlines` de chaque année passée distincte présente dans les lignes de la déclaration (une résolution par année via `getCampaignDeadlines`, pas par ligne — base si une ligne `campaign_deadline` existe, `getDefaultCampaignDeadlines` en repli), puis applique la clôture à chaque ligne rémunération. `getUserCompanies`, `computeRepresentationDeclarationStatus`, `/mon-espace/mes-entreprises` et `CompanyInfoBanner` restent inchangés.

### UI

`StatusBadge.tsx` ajoute les deux variantes au `Record<DeclarationStatus, …>` exhaustif — mêmes classes DSFR que les trois badges existants (`fr-badge fr-badge--sm fr-badge--{warning,error} fr-badge--no-icon`), aucune couleur en dur. Libellé exact **« Clôturée - non effectuée »** (la coquille Figma « Non effectuéE » n'est pas reproduite).

## Vérification Figma

Node `8470-95143` relu via `get_design_context` : tokens `$text-default-warning` #B34000 / `$background-contrast-warning` #FFE9E6 et `$text-default-error` #CE0500 / `$background-contrast-error` #FFE9E9 — correspondent aux classes système `fr-badge--warning`/`fr-badge--error` déjà utilisées ailleurs dans l'app, sans valeur en dur. Screenshot du node comparé au rendu attendu, conforme.

## Tests

- Domaine : `applyDeclarationClosure` sur la matrice statut × échéance (dépassée/non), instant-frontière strict, no-op sur statut déjà clos, no-op sur `done`, no-op année courante/future.
- Composant : `StatusBadge` sur les deux nouveaux variants (classes + libellé exact).
- Routeur : résolution des échéances par année distincte (pas par ligne), clôture correcte par statut (S1/S2), non-clôture avant échéance (S3), `done` jamais clos (S4), année courante jamais close (S5), ligne représentation non affectée (S6), échéances base vs défaut par année (S7).

## Hors périmètre (voir analyse architecte)

Synthèse des années sans ligne en base, colonne « Échéance » des années précédentes (bug latent préexistant), divergence 5 cellules Figma vs 6 colonnes rendues.
