### PR TITLE
fix(cse-opinion): #4289 — masquer l'encart de justification des écarts en 1ère déclaration sans écart

### DIFF
--- a/packages/app/src/app/avis-cse/etape/[step]/page.tsx
+++ b/packages/app/src/app/avis-cse/etape/[step]/page.tsx
@@ -36,7 +36,7 @@ export default async function CseOpinionStepPage({ params }: StepPageProps) {
 		]);
 		const initialData = mapOpinionsFromDb(opinions);
 		const hasSecondDeclaration = declarationData.hasSubmittedSecondDeclaration;
-		const { secondDeclGapHigh } = computeGapHighFlags(
+		const { firstDeclGapHigh, secondDeclGapHigh } = computeGapHighFlags(
 			declarationData.employeeCategories,
 		);
 		const campaignDeadlines = await getCampaignDeadlines(
@@ -62,6 +62,7 @@ export default async function CseOpinionStepPage({ params }: StepPageProps) {
 					firstDeclarationPathChoice={
 						declarationData.declaration.firstDeclarationPathChoice
 					}
+					firstDeclGapHigh={firstDeclGapHigh}
 					hasSecondDeclaration={hasSecondDeclaration}
 					initialData={initialData}
 					previousHref={previousHref}

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -334,7 +334,7 @@ test.describe("[ANX-02] Path 12: compliance already completed → redirect", () 
 		// Complete declaration without gap → auto-redirect to CSE → complete CSE
 		await completeDeclaration(page, { hasGap: false });
 		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
-		await fillCseStep1(page);
+		await fillCseStep1(page, { firstDeclGapCardHidden: true });
 		await submitCseStep2(page);
 
 		// demarcheCompletedAt is now set — navigating back should redirect

--- a/packages/app/src/e2e/grille/scenarios.ts
+++ b/packages/app/src/e2e/grille/scenarios.ts
@@ -182,7 +182,7 @@ export const FICHE_SCENARIOS = {
 	"CAS-02": async ({ page }) => {
 		await completeDeclaration(page, { hasGap: false });
 		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
-		await fillCseStep1(page);
+		await fillCseStep1(page, { firstDeclGapCardHidden: true });
 		await submitCseStep2(page);
 		await finDeDemarche(page, { completed: true });
 	},
@@ -394,7 +394,7 @@ export const FICHE_SCENARIOS = {
 				});
 				await submitFromStep6Recap(page);
 				await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
-				await fillCseStep1(page);
+				await fillCseStep1(page, { firstDeclGapCardHidden: true });
 				await submitCseStep2(page);
 				await finDeDemarche(page, { completed: true });
 			},

--- a/packages/app/src/e2e/helpers/compliance-flows.ts
+++ b/packages/app/src/e2e/helpers/compliance-flows.ts
@@ -21,6 +21,8 @@ type CseStep1Options = {
 	firstDeclGapConsultationImplicit?: boolean;
 	/** The second-round justification choice already establishes consultation, so the yes/no radios are absent. */
 	secondDeclGapConsultationImplicit?: boolean;
+	/** No gap ≥ 5% on the first declaration: the whole justification card is absent. */
+	firstDeclGapCardHidden?: boolean;
 	/** No remaining gap ≥ 5% on the second declaration: the whole justification card is absent. */
 	secondDeclGapCardHidden?: boolean;
 	/** Opinion on accuracy (and on gap when consulted). Defaults to "favorable" so existing specs are unaffected. */
@@ -55,6 +57,7 @@ export async function fillCseStep1(page: Page, options: CseStep1Options = {}) {
 		secondDeclGapConsulted = false,
 		firstDeclGapConsultationImplicit = false,
 		secondDeclGapConsultationImplicit = false,
+		firstDeclGapCardHidden = false,
 		secondDeclGapCardHidden = false,
 		opinion = "favorable",
 	} = options;
@@ -63,14 +66,18 @@ export async function fillCseStep1(page: Page, options: CseStep1Options = {}) {
 		// DSFR hides native radio inputs — click on the associated label instead
 		await page.locator(`label[for="first-decl-accuracy-${opinion}"]`).click();
 		await page.locator("#first-decl-accuracy-date").fill("2025-03-15");
-		await fillGapConsultation(
-			page,
-			"first-decl-gap",
-			firstDeclGapConsulted || firstDeclGapConsultationImplicit,
-			"2025-03-15",
-			opinion,
-			firstDeclGapConsultationImplicit,
-		);
+		if (firstDeclGapCardHidden) {
+			await expect(page.locator("#first-decl-gap-legend")).toHaveCount(0);
+		} else {
+			await fillGapConsultation(
+				page,
+				"first-decl-gap",
+				firstDeclGapConsulted || firstDeclGapConsultationImplicit,
+				"2025-03-15",
+				opinion,
+				firstDeclGapConsultationImplicit,
+			);
+		}
 		if (hasSecondDeclaration) {
 			await page
 				.locator(`label[for="second-decl-accuracy-${opinion}"]`)

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -25,7 +25,22 @@ import {
 import styles from "./Step1Opinions.module.scss";
 import { saveOpinionsSchema } from "./schemas";
 import formStyles from "./shared/formActions.module.scss";
-import type { CseOpinionStep1Data } from "./types";
+import type { CseOpinionStep1Data, OpinionType } from "./types";
+
+// Looser than the form values on purpose: below the threshold the draft only ever
+// carries what the user actually entered, so the gap keys are simply absent.
+type DeclarationOpinionDraftValue = {
+	accuracyOpinion?: OpinionType;
+	accuracyDate?: string;
+	gapConsulted?: boolean;
+	gapOpinion?: OpinionType | null;
+	gapDate?: string | null;
+};
+
+type OpinionsDraftValues = {
+	firstDeclaration: DeclarationOpinionDraftValue;
+	secondDeclaration?: DeclarationOpinionDraftValue;
+};
 
 type Props = {
 	cseDeadline: Date;
@@ -33,6 +48,8 @@ type Props = {
 	year: number;
 	initialData?: CseOpinionStep1Data;
 	email?: string;
+	// Defaults to true so the card keeps rendering for callers that don't compute it.
+	firstDeclGapHigh?: boolean;
 	firstDeclarationPathChoice?: string | null;
 	hasSecondDeclaration?: boolean;
 	previousHref?: string;
@@ -46,6 +63,7 @@ export function Step1Opinions({
 	year,
 	initialData,
 	email,
+	firstDeclGapHigh = true,
 	firstDeclarationPathChoice,
 	hasSecondDeclaration = true,
 	previousHref = "/declaration-remuneration/etape/6",
@@ -53,8 +71,9 @@ export function Step1Opinions({
 	secondDeclarationPathChoice,
 }: Props) {
 	const isJointEvaluation = firstDeclarationPathChoice === "joint_evaluation";
+	const showFirstDeclarationGap = firstDeclGapHigh;
 	const isFirstDeclarationJustification =
-		firstDeclarationPathChoice === "justify";
+		showFirstDeclarationGap && firstDeclarationPathChoice === "justify";
 	const showSecondDeclarationGap = hasSecondDeclaration && secondDeclGapHigh;
 	const isSecondDeclarationJustification =
 		showSecondDeclarationGap && secondDeclarationPathChoice === "justify";
@@ -70,23 +89,26 @@ export function Step1Opinions({
 				showSecondDeclarationGap,
 				isSecondDeclarationJustification,
 				isFirstDeclarationJustification,
+				showFirstDeclarationGap,
 			),
 		[
 			hasSecondDeclaration,
 			initialData,
 			isFirstDeclarationJustification,
 			isSecondDeclarationJustification,
+			showFirstDeclarationGap,
 			showSecondDeclarationGap,
 		],
 	);
 
-	const { draft, setField, isLoadingDraft } = useDeclarationDraft({
-		siren,
-		year,
-		step: "opinions",
-		kind: "cse",
-		dbValues: initialFormValues,
-	});
+	const { draft, setField, isLoadingDraft } =
+		useDeclarationDraft<OpinionsDraftValues>({
+			siren,
+			year,
+			step: "opinions",
+			kind: "cse",
+			dbValues: initialFormValues,
+		});
 
 	const form = useZodForm(saveOpinionsSchema, {
 		defaultValues: initialFormValues,
@@ -101,12 +123,14 @@ export function Step1Opinions({
 			showSecondDeclarationGap,
 			isSecondDeclarationJustification,
 			isFirstDeclarationJustification,
+			showFirstDeclarationGap,
 		);
 	}, [
 		isLoadingDraft,
 		draft,
 		form,
 		hasSecondDeclaration,
+		showFirstDeclarationGap,
 		showSecondDeclarationGap,
 		isFirstDeclarationJustification,
 		isSecondDeclarationJustification,
@@ -115,11 +139,20 @@ export function Step1Opinions({
 	const triggerDraftSave = useCallback(() => {
 		if (isReadOnly) return;
 		const values = form.getValues();
+		// Guarding the read side alone would leave the synthesized answer in the draft,
+		// to be restored as the user's own once a gap brings the card back.
+		const firstDeclaration: DeclarationOpinionDraftValue =
+			showFirstDeclarationGap
+				? values.firstDeclaration
+				: {
+						accuracyOpinion: values.firstDeclaration.accuracyOpinion,
+						accuracyDate: values.firstDeclaration.accuracyDate,
+					};
 		setField({
-			firstDeclaration: values.firstDeclaration,
+			firstDeclaration,
 			secondDeclaration: values.secondDeclaration,
 		});
-	}, [form, isReadOnly, setField]);
+	}, [form, isReadOnly, setField, showFirstDeclarationGap]);
 
 	const mutation = api.cseOpinion.saveOpinions.useMutation({
 		onSuccess: () => router.push("/avis-cse/etape/2"),
@@ -131,8 +164,12 @@ export function Step1Opinions({
 			showSecondDeclarationGap,
 			isSecondDeclarationJustification,
 			isFirstDeclarationJustification,
+			showFirstDeclarationGap,
 		);
-		if (isGapConsultationIncomplete(submittedData.firstDeclaration)) {
+		if (
+			showFirstDeclarationGap &&
+			isGapConsultationIncomplete(submittedData.firstDeclaration)
+		) {
 			form.setError("firstDeclaration.gapOpinion", {
 				message: "Veuillez remplir tous les champs de consultation.",
 			});
@@ -240,34 +277,38 @@ export function Step1Opinions({
 						title="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
 					/>
 
-					<Controller
-						control={form.control}
-						name="firstDeclaration.gapConsulted"
-						render={({ field }) => (
-							<GapConsultationCard
-								consulted={
-									isFirstDeclarationJustification ? true : (field.value ?? null)
-								}
-								date={firstDeclGapDate ?? ""}
-								id="first-decl-gap"
-								onConsultedChange={(v) => {
-									field.onChange(v);
-									triggerDraftSave();
-								}}
-								onDateChange={(v) => {
-									form.setValue("firstDeclaration.gapDate", v);
-									triggerDraftSave();
-								}}
-								onOpinionChange={(v) => {
-									form.setValue("firstDeclaration.gapOpinion", v);
-									triggerDraftSave();
-								}}
-								opinion={firstDeclGapOpinion ?? null}
-								readOnly={isReadOnly}
-								showConsultationQuestion={!isFirstDeclarationJustification}
-							/>
-						)}
-					/>
+					{showFirstDeclarationGap && (
+						<Controller
+							control={form.control}
+							name="firstDeclaration.gapConsulted"
+							render={({ field }) => (
+								<GapConsultationCard
+									consulted={
+										isFirstDeclarationJustification
+											? true
+											: (field.value ?? null)
+									}
+									date={firstDeclGapDate ?? ""}
+									id="first-decl-gap"
+									onConsultedChange={(v) => {
+										field.onChange(v);
+										triggerDraftSave();
+									}}
+									onDateChange={(v) => {
+										form.setValue("firstDeclaration.gapDate", v);
+										triggerDraftSave();
+									}}
+									onOpinionChange={(v) => {
+										form.setValue("firstDeclaration.gapOpinion", v);
+										triggerDraftSave();
+									}}
+									opinion={firstDeclGapOpinion ?? null}
+									readOnly={isReadOnly}
+									showConsultationQuestion={!isFirstDeclarationJustification}
+								/>
+							)}
+						/>
+					)}
 				</div>
 
 				{hasSecondDeclaration && (

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -27,8 +27,7 @@ import { saveOpinionsSchema } from "./schemas";
 import formStyles from "./shared/formActions.module.scss";
 import type { CseOpinionStep1Data, OpinionType } from "./types";
 
-// Looser than the form values on purpose: below the threshold the draft only ever
-// carries what the user actually entered, so the gap keys are simply absent.
+// Looser than the form values on purpose: the draft only ever carries what the user entered.
 type DeclarationOpinionDraftValue = {
 	accuracyOpinion?: OpinionType;
 	accuracyDate?: string;
@@ -139,8 +138,7 @@ export function Step1Opinions({
 	const triggerDraftSave = useCallback(() => {
 		if (isReadOnly) return;
 		const values = form.getValues();
-		// Guarding the read side alone would leave the synthesized answer in the draft,
-		// to be restored as the user's own once a gap brings the card back.
+		// Guarding the read side alone would leave the synthesized answer in the draft.
 		const firstDeclaration: DeclarationOpinionDraftValue =
 			showFirstDeclarationGap
 				? values.firstDeclaration

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -666,6 +666,206 @@ describe("Step1Opinions", () => {
 		expect(screen.getByText("adresse@exemple.fr")).toBeInTheDocument();
 	});
 
+	describe("gap threshold gating", () => {
+		it("submits without error on a brand-new declaration (no initialData) below threshold", async () => {
+			// Normalizing inside the submit closure isn't enough: the form default must already be a boolean.
+			const user = userEvent.setup();
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					firstDeclGapHigh={false}
+					hasSecondDeclaration={false}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			await user.click(screen.getAllByLabelText("Favorable")[0] as HTMLElement);
+			await user.type(
+				screen.getByLabelText(/Date de l'avis rendu par le CSE/),
+				"2026-03-01",
+			);
+			await user.click(screen.getByRole("button", { name: /Suivant/ }));
+
+			expect(
+				screen.queryByText("Veuillez remplir tous les champs obligatoires."),
+			).not.toBeInTheDocument();
+			expect(mockMutate).toHaveBeenCalledWith({
+				firstDeclaration: {
+					accuracyOpinion: "favorable",
+					accuracyDate: "2026-03-01",
+					gapConsulted: false,
+					gapOpinion: null,
+					gapDate: null,
+				},
+				secondDeclaration: undefined,
+			});
+			expect(mockPush).toHaveBeenCalledWith("/avis-cse/etape/2");
+		});
+
+		it("clears the whole first gap answer on submit when below threshold", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					firstDeclGapHigh={false}
+					hasSecondDeclaration={false}
+					initialData={{
+						firstDeclAccuracyOpinion: "favorable",
+						firstDeclAccuracyDate: "2026-01-15",
+						firstDeclGapConsulted: true,
+						firstDeclGapOpinion: "favorable",
+						firstDeclGapDate: "2026-01-20",
+						secondDeclAccuracyOpinion: null,
+						secondDeclAccuracyDate: "",
+						secondDeclGapConsulted: null,
+						secondDeclGapOpinion: null,
+						secondDeclGapDate: null,
+					}}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			await user.click(screen.getByRole("button", { name: /Suivant/ }));
+
+			// All three fields, not just the boolean: the persisted answer would otherwise survive as `gapConsulted = false` next to `opinion = 'favorable'`.
+			expect(mockMutate).toHaveBeenCalledWith({
+				firstDeclaration: {
+					accuracyOpinion: "favorable",
+					accuracyDate: "2026-01-15",
+					gapConsulted: false,
+					gapOpinion: null,
+					gapDate: null,
+				},
+				secondDeclaration: undefined,
+			});
+			expect(mockPush).toHaveBeenCalledWith("/avis-cse/etape/2");
+		});
+
+		it("does not block submission on an incomplete first gap when below threshold", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					firstDeclGapHigh={false}
+					hasSecondDeclaration={false}
+					initialData={{
+						firstDeclAccuracyOpinion: "favorable",
+						firstDeclAccuracyDate: "2026-01-15",
+						firstDeclGapConsulted: true,
+						firstDeclGapOpinion: null,
+						firstDeclGapDate: null,
+						secondDeclAccuracyOpinion: null,
+						secondDeclAccuracyDate: "",
+						secondDeclGapConsulted: null,
+						secondDeclGapOpinion: null,
+						secondDeclGapDate: null,
+					}}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			await user.click(screen.getByRole("button", { name: /Suivant/ }));
+
+			expect(
+				screen.queryByText("Veuillez remplir tous les champs de consultation."),
+			).not.toBeInTheDocument();
+			expect(mockMutate).toHaveBeenCalled();
+			expect(mockPush).toHaveBeenCalledWith("/avis-cse/etape/2");
+		});
+
+		it("does not restore the first-declaration gap draft slice when below threshold", () => {
+			mockUseDeclarationDraft.mockReturnValue({
+				draft: {
+					firstDeclaration: {
+						accuracyOpinion: "favorable",
+						accuracyDate: "2026-01-10",
+						gapConsulted: true,
+						gapOpinion: "favorable",
+						gapDate: "2026-01-20",
+					},
+				},
+				setField: mockSetField,
+				clearDraft: mockClearDraft,
+				hasDraft: true,
+				isLoadingDraft: false,
+			});
+
+			const { container } = render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					firstDeclGapHigh={false}
+					hasSecondDeclaration={false}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			// No legend and no stray "Oui" restored from the stale draft slice.
+			expect(
+				container.querySelector("#first-decl-gap-question-legend"),
+			).toBeNull();
+			expect(container.querySelector("#first-decl-gap-yes")).toBeNull();
+		});
+
+		it("never writes the synthesized gapConsulted to the draft when below threshold, even after the gap re-appears on a later visit", async () => {
+			// The slice this save produces is what a later above-threshold visit restores as the user's own answer.
+			const user = userEvent.setup();
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					firstDeclGapHigh={false}
+					hasSecondDeclaration={false}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			await user.click(screen.getAllByLabelText("Favorable")[0] as HTMLElement);
+
+			expect(mockSetField).toHaveBeenCalled();
+			const saved = lastFirstDeclaration();
+			expect(saved?.accuracyOpinion).toBe("favorable");
+			expect(saved).not.toHaveProperty("gapConsulted");
+			expect(saved).not.toHaveProperty("gapOpinion");
+			expect(saved).not.toHaveProperty("gapDate");
+		});
+
+		it("still requires a complete gap consultation above threshold", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					firstDeclGapHigh={true}
+					hasSecondDeclaration={false}
+					initialData={{
+						firstDeclAccuracyOpinion: "favorable",
+						firstDeclAccuracyDate: "2026-01-15",
+						firstDeclGapConsulted: true,
+						firstDeclGapOpinion: null,
+						firstDeclGapDate: null,
+						secondDeclAccuracyOpinion: null,
+						secondDeclAccuracyDate: "",
+						secondDeclGapConsulted: null,
+						secondDeclGapOpinion: null,
+						secondDeclGapDate: null,
+					}}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			await user.click(screen.getByRole("button", { name: /Suivant/ }));
+
+			expect(
+				screen.getByText("Veuillez remplir tous les champs obligatoires."),
+			).toBeInTheDocument();
+			expect(mockMutate).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("gap consultation validation", () => {
 		it("blocks submission when the first-declaration gap is consulted but incomplete", async () => {
 			const user = userEvent.setup();

--- a/packages/app/src/modules/cseOpinion/__tests__/opinionsFormValues.test.ts
+++ b/packages/app/src/modules/cseOpinion/__tests__/opinionsFormValues.test.ts
@@ -75,6 +75,23 @@ describe("buildOpinionsFormValues", () => {
 		expect(values.firstDeclaration.gapOpinion).toBe("favorable");
 	});
 
+	it("clears first-declaration gap fields when no gap is ≥ 5%", () => {
+		const values = buildOpinionsFormValues(
+			initialData,
+			false,
+			false,
+			false,
+			false,
+			false,
+		);
+
+		expect(values.firstDeclaration).toMatchObject({
+			accuracyOpinion: "favorable",
+			accuracyDate: "2026-01-15",
+			...CLEARED_GAP_FIELDS,
+		});
+	});
+
 	it("omits secondDeclaration when there is no second declaration", () => {
 		const values = buildOpinionsFormValues(initialData, false, false);
 
@@ -97,6 +114,16 @@ const submitted = {
 		gapConsulted: true,
 		gapOpinion: "favorable" as const,
 		gapDate: "2026-02-02",
+	},
+};
+
+const consultedFirstDeclaration = {
+	...submitted,
+	firstDeclaration: {
+		...submitted.firstDeclaration,
+		gapConsulted: true,
+		gapOpinion: "favorable" as const,
+		gapDate: "2026-01-20",
 	},
 };
 
@@ -128,6 +155,30 @@ describe("normalizeSubmittedOpinions", () => {
 			normalizeSubmittedOpinions(submitted, true, false, true).firstDeclaration
 				.gapConsulted,
 		).toBe(true);
+	});
+
+	it("clears first-declaration gap fields when no gap is ≥ 5%", () => {
+		const result = normalizeSubmittedOpinions(
+			consultedFirstDeclaration,
+			true,
+			false,
+			false,
+			false,
+		);
+
+		expect(result.firstDeclaration).toMatchObject(CLEARED_GAP_FIELDS);
+	});
+
+	it("clears first-declaration gap fields below threshold even on the justification path", () => {
+		const result = normalizeSubmittedOpinions(
+			consultedFirstDeclaration,
+			true,
+			false,
+			true,
+			false,
+		);
+
+		expect(result.firstDeclaration).toMatchObject(CLEARED_GAP_FIELDS);
 	});
 
 	it("leaves gap fields unchanged when a remaining gap is ≥ 5% outside the justification path", () => {
@@ -192,6 +243,40 @@ describe("hydrateOpinionsForm", () => {
 		expect(setValue).toHaveBeenCalledWith(
 			"firstDeclaration.gapOpinion",
 			"favorable",
+		);
+	});
+
+	it("clears a stale first-declaration draft when no gap is ≥ 5%", () => {
+		const setValue = vi.fn() as unknown as Parameters<
+			typeof hydrateOpinionsForm
+		>[0];
+		hydrateOpinionsForm(
+			setValue,
+			{
+				firstDeclaration: {
+					accuracyOpinion: "favorable",
+					accuracyDate: "2026-01-15",
+					gapConsulted: true,
+					gapOpinion: "favorable",
+					gapDate: "2026-01-20",
+				},
+			},
+			false,
+			false,
+			false,
+			false,
+			false,
+		);
+
+		expect(setValue).toHaveBeenCalledWith(
+			"firstDeclaration.gapConsulted",
+			false,
+		);
+		expect(setValue).toHaveBeenCalledWith("firstDeclaration.gapOpinion", null);
+		expect(setValue).toHaveBeenCalledWith("firstDeclaration.gapDate", null);
+		expect(setValue).not.toHaveBeenCalledWith(
+			"firstDeclaration.gapConsulted",
+			true,
 		);
 	});
 

--- a/packages/app/src/modules/cseOpinion/opinionsFormValues.ts
+++ b/packages/app/src/modules/cseOpinion/opinionsFormValues.ts
@@ -18,16 +18,21 @@ export function buildOpinionsFormValues(
 	showSecondDeclarationGap: boolean,
 	isSecondDeclarationJustification = false,
 	isFirstDeclarationJustification = false,
+	showFirstDeclarationGap = true,
 ) {
 	return {
 		firstDeclaration: {
 			accuracyOpinion: initialData?.firstDeclAccuracyOpinion ?? undefined,
 			accuracyDate: initialData?.firstDeclAccuracyDate ?? "",
-			gapConsulted: isFirstDeclarationJustification
-				? true
-				: (initialData?.firstDeclGapConsulted ?? undefined),
-			gapOpinion: initialData?.firstDeclGapOpinion ?? null,
-			gapDate: initialData?.firstDeclGapDate ?? null,
+			...(showFirstDeclarationGap
+				? {
+						gapConsulted: isFirstDeclarationJustification
+							? true
+							: (initialData?.firstDeclGapConsulted ?? undefined),
+						gapOpinion: initialData?.firstDeclGapOpinion ?? null,
+						gapDate: initialData?.firstDeclGapDate ?? null,
+					}
+				: CLEARED_GAP_FIELDS),
 		},
 		secondDeclaration: hasSecondDeclaration
 			? {
@@ -52,13 +57,20 @@ export function normalizeSubmittedOpinions(
 	showSecondDeclarationGap: boolean,
 	isSecondDeclarationJustification: boolean,
 	isFirstDeclarationJustification = false,
+	showFirstDeclarationGap = true,
 ): OpinionsInput {
-	const normalized = isFirstDeclarationJustification
+	// Dropped together: a persisted opinion beside a false gapConsulted reaches the PDF and the open data as a self-contradictory row.
+	const normalized = !showFirstDeclarationGap
 		? {
 				...data,
-				firstDeclaration: { ...data.firstDeclaration, gapConsulted: true },
+				firstDeclaration: { ...data.firstDeclaration, ...CLEARED_GAP_FIELDS },
 			}
-		: data;
+		: isFirstDeclarationJustification
+			? {
+					...data,
+					firstDeclaration: { ...data.firstDeclaration, gapConsulted: true },
+				}
+			: data;
 	if (!normalized.secondDeclaration) return normalized;
 	if (!showSecondDeclarationGap) {
 		return {
@@ -130,8 +142,13 @@ export function hydrateOpinionsForm(
 	showSecondDeclarationGap: boolean,
 	isSecondDeclarationJustification: boolean,
 	isFirstDeclarationJustification = false,
+	showFirstDeclarationGap = true,
 ) {
-	if (isFirstDeclarationJustification) {
+	if (!showFirstDeclarationGap) {
+		setValue("firstDeclaration.gapConsulted", CLEARED_GAP_FIELDS.gapConsulted);
+		setValue("firstDeclaration.gapOpinion", CLEARED_GAP_FIELDS.gapOpinion);
+		setValue("firstDeclaration.gapDate", CLEARED_GAP_FIELDS.gapDate);
+	} else if (isFirstDeclarationJustification) {
 		setValue("firstDeclaration.gapConsulted", true);
 	}
 	if (draft.firstDeclaration) {
@@ -140,8 +157,9 @@ export function hydrateOpinionsForm(
 			"firstDeclaration",
 			draft.firstDeclaration,
 			{
-				applyGapConsulted: !isFirstDeclarationJustification,
-				applyGapDetails: true,
+				applyGapConsulted:
+					showFirstDeclarationGap && !isFirstDeclarationJustification,
+				applyGapDetails: showFirstDeclarationGap,
 			},
 		);
 	}


### PR DESCRIPTION
Closes #4289

## Résumé

À l'étape 1 de la saisie des avis CSE, l'encart « Justification des écarts ≥ 5 % » de la **première déclaration** était toujours affiché, même quand aucune catégorie d'emploi n'atteint ce seuil (CAS-02, CAS-02-6IND). L'étape 2 gate déjà sa colonne « Justification » sur le même prédicat — l'étape 1 en était l'exception.

La branche a été **rebasée sur alpha** après #4444 et #4441, qui ont extrait la logique du formulaire dans `src/modules/cseOpinion/opinionsFormValues.ts` et introduit `computeGapHighFlags` côté domaine. Le correctif suit désormais cette structure, en miroir exact du traitement déjà en place pour la 2ᵉ déclaration (`showSecondDeclarationGap`).

- `src/app/avis-cse/etape/[step]/page.tsx` : récupère `firstDeclGapHigh` de `computeGapHighFlags` (déjà appelé pour la 2ᵉ déclaration) et le passe à `Step1Opinions`. Aucun filtre de catégories local — le seuil reste dans le domaine.
- `src/modules/cseOpinion/opinionsFormValues.ts` : les trois fonctions du module (`buildOpinionsFormValues`, `normalizeSubmittedOpinions`, `hydrateOpinionsForm`) prennent `showFirstDeclarationGap` et appliquent `CLEARED_GAP_FIELDS` sous le seuil — les trois champs sont nullés **ensemble**, sinon la ligne `cseOpinions` reste contradictoire (`gapConsulted = false` à côté d'un `opinion` non nul) et atteint le PDF de récapitulatif et l'open data.
- `src/modules/cseOpinion/Step1Opinions.tsx` : nouvelle prop `firstDeclGapHigh` (défaut `true`, rétro-compatible), rendu conditionnel de l'encart, et **garde côté écriture du brouillon** — sous le seuil, la tranche remise à `setField` ne porte aucun champ d'écart.

Hors périmètre : l'incohérence symétrique sur la 2ᵉ déclaration, traitée par #4441.

## La garde du brouillon

Deux commentaires de revue ont montré que gater la seule *lecture* du brouillon ne suffit pas. `initialFormValues` sert à la fois de `defaultValues` et de `dbValues`, et `computeDraftDiff` compare au niveau racine : dès la moindre saisie, la tranche `firstDeclaration` entière partait dans le brouillon, `gapConsulted: false` synthétisé compris. Un retour à l'étape 6 introduisant un écart ≥ 5 % faisait alors réapparaître l'encart **pré-répondu « Non »** — une réponse à portée réglementaire jamais donnée, et qui passait la validation puisque `isGapConsultationIncomplete` ne se déclenche que sur `gapConsulted === true`.

`triggerDraftSave` reconstruit donc la tranche avec les seuls champs d'exactitude sous le seuil : le brouillon ne peut plus contenir de champ d'écart, et la réhydratation n'a plus rien à restaurer.

## Tests E2E

L'encart disparaissant du DOM, `fillCseStep1` prend une option `firstDeclGapCardHidden` (défaut `false`, tous les appels existants inchangés) — nommée et construite comme le `secondDeclGapCardHidden` déjà présent. À `true`, le helper **assert l'absence de l'encart** au lieu de le remplir, de sorte qu'un encart disparaissant à tort pour un CAS qui en a besoin resterait détecté. Les trois scénarios dont la 1ʳᵉ déclaration n'a aucun écart la passent explicitement : CAS-02, CAS-02-6IND, ANX-02.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 475 fichiers, 6136 tests
- [x] `pnpm check` (biome lint + format)
- [x] Rouge/vert vérifié sur l'état rebasé : avec `Step1Opinions.tsx` et `opinionsFormValues.ts` revertés sur alpha, les 5 tests sous-seuil du composant et les 4 tests du module échouent ; la contre-épreuve au-dessus du seuil passe des deux côtés.
- [x] `structural-auditor` — MINOR, constats de commentaires corrigés
- [x] `rgaa-auditor`
- [ ] `security-auditor` — sans objet, aucun fichier sous `server/` ou `routers/` modifié
