### PR TITLE
fix(a11y): repinner l'Action ultra11y sur le SHA de sa release

### DIFF
--- a/.claude/hooks/check-ultra11y-plugin.sh
+++ b/.claude/hooks/check-ultra11y-plugin.sh
@@ -39,9 +39,15 @@ MARKER="/tmp/.claude-ultra11y-plugin-$PPID"
 [ -f "$MARKER" ] && exit 0
 touch "$MARKER"
 
-# LA RÉFÉRENCE EST LE TAG DE L'ACTION, pas la devDependency : c'est le moteur, et la CI garantit
+# LA RÉFÉRENCE EST LE PIN DE L'ACTION, pas la devDependency : c'est le moteur, et la CI garantit
 # déjà que les trois versions du dépôt s'accordent. Une seule source à lire, donc.
-WANT=$(grep -oE '^[[:space:]]*uses:[[:space:]]*maxgfr/ultra11y@v[0-9]+\.[0-9]+\.[0-9]+' "$WORKFLOW" | sed -E 's/.*@v//' | head -1)
+#
+# L'Action est pinnée par SHA depuis que l'upstream a supprimé tous ses tags (03/09/2026), donc
+# la version se lit dans le commentaire `# vX.Y.Z` qui suit le SHA — c'est ce qui le rend
+# load-bearing. Le `|| true` est indispensable : sous `pipefail`, un grep sans correspondance
+# tuerait le script AVANT le garde-fou de la ligne suivante, et le hook cesserait de comparer
+# quoi que ce soit, en silence.
+WANT=$(grep -oE '^[[:space:]]*uses:[[:space:]]*maxgfr/ultra11y@[0-9a-f]{40}[[:space:]]*#[[:space:]]*v[0-9]+\.[0-9]+\.[0-9]+' "$WORKFLOW" | sed -E 's/.*#[[:space:]]*v//' | head -1 || true)
 [ -n "$WANT" ] || exit 0
 
 # La plus haute version installée, tous scopes confondus : le plugin peut être posé au scope

--- a/.claude/rules/rgaa.md
+++ b/.claude/rules/rgaa.md
@@ -11,7 +11,8 @@ Deux surfaces, et deux seulement.
 **La revue** — l'agent `rgaa-auditor` lance le skill **`review-a11y`** sur le code sous changement et rend son verdict. C'est tout ce qu'il fait : le skill cadre l'audit sur le diff, lance le moteur, réfute les faux positifs, tranche les critères de jugement depuis la source et nomme les critères de rendu comme risques résiduels. Le skill vient du plugin déclaré dans `.claude/settings.json` ; il s'installe une fois avec `claude plugin install ultra11y@ultra11y`. Le plugin apporte aussi un hook `PreToolUse` qui arrête un `git commit` / `git push` / `gh pr create` porteur de non-conformités — coupe-circuits `SKIP_A11Y=1` (une commande), `ULTRA11Y_HOOK=off` (une session), `"hook": { "failOn": "off" }` dans `.ultra11yrc.json` (le dépôt).
 
 **L'analyse** — `.github/workflows/a11y.yaml`, trois jobs portés par la même Action Ultra11y,
-épinglée à un tag de version explicite :
+épinglée au **SHA** de son commit de release (`38d2a9ed # v5.42.1`) et non à un tag — l'upstream
+a supprimé tous les siens le 03/09/2026, voir la doc :
 
 | Job | Quand | Ce qu'il fait |
 |---|---|---|
@@ -30,7 +31,7 @@ numéro unique mais quatre copies qui doivent s'accorder :
 
 | Où | Quoi | Tenu par |
 |---|---|---|
-| `a11y.yaml`, `uses:` ×2 | le moteur de la CI (gate PR + `a11y-pages`) | `a11y-version-coherence` (ci.yaml) |
+| `a11y.yaml`, `uses:` ×2 | le moteur de la CI (gate PR + `a11y-pages`), pinné par SHA + commentaire `# vX` | `a11y-version-coherence` (ci.yaml) |
 | `packages/app/package.json` | le binaire et le plugin Playwright qui **écrivent** les instantanés | idem |
 | le plugin Claude Code | le skill `review-a11y`, donc l'agent `rgaa-auditor` | hook `check-ultra11y-plugin.sh` |
 

--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -199,8 +199,15 @@ jobs:
         with:
           fetch-depth: 0
       - name: ultra11y — audit RGAA statique
-        # Tag de release explicite : garder les deux usages de l'Action sur la même version.
-        uses: maxgfr/ultra11y@v5.42.1
+        # SHA de release explicite, et NON un tag : le 03/09/2026 l'upstream a supprimé la
+        # totalité de ses tags git (`git ls-remote --tags` en rend zéro, plus aucune release ;
+        # seule `main` subsiste), et `maxgfr/ultra11y@v5.42.1` a cessé de résoudre du jour au
+        # lendemain — cette gate est bloquante, donc toutes les PR ouvertes sont tombées d'un
+        # coup sur `Unable to resolve action`. Un SHA ne peut pas être repris : il survit à la
+        # prochaine suppression de tags comme au prochain retag. Celui-ci EST la 5.42.1, c'est
+        # le commit `chore(release): 5.42.1` et son package.json porte cette version.
+        # Garder les deux usages de l'Action sur le même SHA.
+        uses: maxgfr/ultra11y@38d2a9ed15a94b2bd185c8bff7d56676af4ad77d # v5.42.1
         with:
           working-directory: packages/app
           # `src` et NON `src/**/*.tsx` : l'Action interpole `paths` sans quotes dans bash,
@@ -470,8 +477,8 @@ jobs:
       # du code, ré-audit hors navigateur des instantanés, adjudication IA, rapport page par
       # page, crops de preuve, HTML.
       - name: ultra11y — audit, rapport page par page et adjudication
-        # Même tag de release que la gate PR ; ne jamais laisser les deux tiers diverger.
-        uses: maxgfr/ultra11y@v5.42.1
+        # Même SHA de release que la gate PR ; ne jamais laisser les deux tiers diverger.
+        uses: maxgfr/ultra11y@38d2a9ed15a94b2bd185c8bff7d56676af4ad77d # v5.42.1
         env:
           # Lu depuis l'ENV DU JOB, jamais depuis un input : c'est ce qui rend le tier
           # inoffensif sur une PR de fork, où les secrets ne sont pas exposés — il se

--- a/docs/accessibilite-ultra11y.md
+++ b/docs/accessibilite-ultra11y.md
@@ -9,8 +9,8 @@
 
 ### 2. L'analyse, par la GitHub Action
 
-`.github/workflows/a11y.yaml`, trois jobs portés par la même Action Ultra11y, épinglée à un
-tag de version explicite :
+`.github/workflows/a11y.yaml`, trois jobs portés par la même Action Ultra11y, épinglée au
+**SHA** de son commit de release — `38d2a9ed # v5.42.1` — et non à un tag :
 
 | Job | Quand | Ce qu'il fait |
 |---|---|---|
@@ -374,9 +374,27 @@ Trois surfaces à bouger ensemble — deux dans le dépôt, une hors dépôt :
 
 ```bash
 pnpm --filter app add -D ultra11y@<version>   # version EXACTE, pas de ^
-# puis aligner les DEUX `maxgfr/ultra11y@v<version>` de .github/workflows/a11y.yaml
+
+# Puis aligner les DEUX `uses: maxgfr/ultra11y@<sha> # v<version>` de a11y.yaml. Le SHA est
+# celui du commit `chore(release): <version>` de l'upstream, pas celui de `main` :
+gh api repos/maxgfr/ultra11y/commits --jq \
+  '.[] | select(.commit.message | startswith("chore(release): <version>")) | .sha'
+
 ./scripts/a11y/check-ultra11y-version.sh      # le job CI qui refuse une demi-montée
 ```
+
+**Pourquoi un SHA et pas un tag.** Le 03/09/2026, l'upstream a supprimé la totalité de ses tags
+git — `git ls-remote --tags` en rend zéro, plus aucune release publiée, seule `main` subsiste
+— et `maxgfr/ultra11y@v5.42.1` a cessé de résoudre du jour au lendemain. La gate `a11y-gate`
+étant bloquante, toutes les PR ouvertes sont tombées ensemble sur `Unable to resolve action`,
+sans que rien n'ait bougé dans le dépôt. Le SHA est immuable : il survit à une suppression de
+tags comme à un retag. Le commentaire `# v<version>` qui le suit n'est pas décoratif — c'est la
+seule chose qui reste comparable à la devDependency, et c'est lui que lit
+`check-ultra11y-version.sh`, qui refuse désormais un pin par tag.
+
+À noter : la version npm, elle, n'a pas bougé (`npm view ultra11y dist-tags` rend toujours
+`5.42.1`). C'est la symétrie exacte du incident npm décrit plus bas — là un tag sans version
+npm, ici une version npm sans tag.
 
 La devDependency et les deux usages de l'Action sont alignés sur **5.42.1**, et ce n'est plus une
 consigne : `scripts/a11y/check-ultra11y-version.sh` tourne dans `ci.yaml` sur chaque push et

--- a/docs/accessibilite-ultra11y.md
+++ b/docs/accessibilite-ultra11y.md
@@ -396,6 +396,28 @@ seule chose qui reste comparable à la devDependency, et c'est lui que lit
 `5.42.1`). C'est la symétrie exacte du incident npm décrit plus bas — là un tag sans version
 npm, ici une version npm sans tag.
 
+**Recouper le SHA avant de le pinner, et ne pas se contenter du `package.json` amont.** Une
+suppression de tous les tags d'un dépôt tiers du jour au lendemain a la même signature qu'une
+compromission de compte suivie d'un nettoyage, ou qu'une réécriture d'historique. Dans ces deux
+cas, le commit qui porte *aujourd'hui* le message `chore(release): X.Y.Z` n'est pas
+nécessairement le code que `@vX.Y.Z` résolvait hier — et lire `"version"` dans son `package.json`
+ne discrimine rien, puisque ce champ est écrit par le commit lui-même. L'enjeu n'est pas
+théorique : cette Action reçoit `CLAUDE_CODE_OAUTH_TOKEN` dans `a11y-pages` et tourne dans
+`a11y-gate` avec `security-events: write` et `pull-requests: write`.
+
+La preuve indépendante est dans nos propres logs de CI : chaque run enregistre le SHA vers lequel
+le tag a résolu, et ces logs sont antérieurs à la suppression.
+
+```bash
+# Le SHA que le tag résolvait, lu dans un run ANTÉRIEUR à la disparition des tags
+gh run view --job <job-id-a11y> --log | grep "Download action repository 'maxgfr/ultra11y"
+```
+
+Fait pour la 5.42.1, sur deux runs indépendants du 02/09 portés par deux branches différentes :
+les deux enregistrent `(SHA:38d2a9ed15a94b2bd185c8bff7d56676af4ad77d)`, identique au SHA pinné.
+La provenance est donc recoupée, pas supposée. **Refaire ce recoupement à chaque bump**, tant que
+l'amont n'a pas republié de tags.
+
 La devDependency et les deux usages de l'Action sont alignés sur **5.42.1**, et ce n'est plus une
 consigne : `scripts/a11y/check-ultra11y-version.sh` tourne dans `ci.yaml` sur chaque push et
 refuse un désalignement. Ce n'est pas de l'hygiène — la suite Playwright ÉCRIT les instantanés

--- a/scripts/a11y/check-ultra11y-version.sh
+++ b/scripts/a11y/check-ultra11y-version.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # LA VERSION D'ULTRA11Y VIT À TROIS ENDROITS DANS CE DÉPÔT, ET ILS DOIVENT S'ACCORDER.
 #
-#   1 & 2. `.github/workflows/a11y.yaml` — `uses: maxgfr/ultra11y@vX`, DEUX FOIS : la gate PR
-#          et `a11y-pages`. Le moteur est embarqué dans l'Action, donc ce tag EST le moteur.
+#   1 & 2. `.github/workflows/a11y.yaml` — `uses: maxgfr/ultra11y@<sha> # vX`, DEUX FOIS : la
+#          gate PR et `a11y-pages`. Le moteur est embarqué dans l'Action, donc ce SHA EST le
+#          moteur. C'est un SHA et non un tag depuis le 03/09/2026 : l'upstream a supprimé la
+#          totalité de ses tags git ce jour-là et `@v5.42.1` a cessé de résoudre, faisant
+#          tomber la gate bloquante sur toutes les PR ouvertes. Le SHA est immuable ; le
+#          commentaire `# vX` à côté est ce qui reste comparable à la devDependency, donc il
+#          est load-bearing et pas décoratif — c'est lui que ce script lit.
 #   3.     `packages/app/package.json` — la devDependency `ultra11y`. Ce n'est pas un doublon
 #          décoratif : c'est le binaire (`pnpm exec ultra11y`) et le plugin Playwright
 #          (`ultra11y/playwright`) dont `src/e2e/a11y/` se sert pour ÉCRIRE les instantanés que
@@ -32,19 +37,31 @@ fail() {
 
 # Les lignes `uses:` seulement — jamais un `maxgfr/ultra11y@<sha>` cité dans un commentaire,
 # et il y en a un dans ce fichier.
-pins=$(grep -oE '^[[:space:]]*uses:[[:space:]]*maxgfr/ultra11y@v[0-9]+\.[0-9]+\.[0-9]+' "$workflow" | sed -E 's/.*@v//')
-count=$(printf '%s\n' "$pins" | grep -c . || true)
+# `|| true` : sans lui, `set -e` tuerait le script sur zéro correspondance AVANT le message
+# du contrôle de `count`, et c'est le cas qu'on veut le plus voir expliqué — celui de
+# quelqu'un qui remet un pin par tag.
+uses=$(grep -oE '^[[:space:]]*uses:[[:space:]]*maxgfr/ultra11y@[0-9a-f]{40}[[:space:]]*#[[:space:]]*v[0-9]+\.[0-9]+\.[0-9]+' "$workflow" || true)
+count=$(printf '%s\n' "$uses" | grep -c . || true)
+
+# Un SHA de 40 caractères, puis la version que porte son commentaire.
+shas=$(printf '%s\n' "$uses" | sed -E 's/.*@([0-9a-f]{40}).*/\1/')
+pins=$(printf '%s\n' "$uses" | sed -E 's/.*#[[:space:]]*v//')
+first_sha=$(printf '%s\n' "$shas" | sed -n 1p)
+second_sha=$(printf '%s\n' "$shas" | sed -n 2p)
 first=$(printf '%s\n' "$pins" | sed -n 1p)
 second=$(printf '%s\n' "$pins" | sed -n 2p)
 dep=$(grep -oE '"ultra11y"[[:space:]]*:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$manifest" | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)"$/\1/')
 
-[ "$count" -eq 2 ] || fail "attendu 2 \`uses: maxgfr/ultra11y@vX\` dans a11y.yaml, trouvé $count. Si un tier a été ajouté ou retiré, mets ce script à jour avec lui."
+[ "$count" -eq 2 ] || fail "attendu 2 \`uses: maxgfr/ultra11y@<sha 40 car.> # vX.Y.Z\` dans a11y.yaml, trouvé $count. Un pin par tag (\`@vX.Y.Z\`) ne compte pas : l'upstream a supprimé ses tags le 03/09/2026, ils ne résolvent plus. Si un tier a été ajouté ou retiré, mets ce script à jour avec lui."
 [ -n "$dep" ] || fail "devDependency \`ultra11y\` introuvable dans packages/app/package.json"
 
+[ "$first_sha" = "$second_sha" ] ||
+  fail "les deux tiers de l'Action divergent — un job sur $first_sha, l'autre sur $second_sha. Ils doivent porter le même SHA."
+
 [ "$first" = "$second" ] ||
-  fail "les deux tiers de l'Action divergent — un job en v$first, l'autre en v$second. Ils doivent porter le même tag."
+  fail "les deux tiers de l'Action portent le même SHA mais l'annotent différemment — v$first d'un côté, v$second de l'autre. L'un des deux commentaires ment."
 
 [ "$first" = "$dep" ] ||
   fail "l'Action est en v$first et la devDependency en $dep. Le balayage Playwright écrit les instantanés avec la devDependency et l'Action les réingère avec le sien — alignez-les."
 
-echo "✓ ultra11y v$first : les deux tiers de l'Action et la devDependency sont alignés."
+echo "✓ ultra11y v$first (${first_sha:0:8}) : les deux tiers de l'Action et la devDependency sont alignés."


### PR DESCRIPTION
L'upstream `maxgfr/ultra11y` a **supprimé la totalité de ses tags git** le 03/09/2026 : `git ls-remote --tags` en rend zéro, plus aucune release publiée, seule `main` subsiste. `maxgfr/ultra11y@v5.42.1` a donc cessé de résoudre du jour au lendemain.

`a11y-gate` étant la seule gate bloquante du dispositif, **toutes les PR ouvertes sont tombées ensemble** sur `Unable to resolve action`, sans que rien n'ait bougé dans le dépôt. Constaté sur #4443 et #4446 ; #4442 est verte uniquement parce que son run date du 02/09, avant la suppression.

## Ce que fait cette PR

Les deux `uses:` pointent désormais le **SHA du commit `chore(release): 5.42.1`** (`38d2a9ed15a94b2bd185c8bff7d56676af4ad77d`), vérifié : son `package.json` porte bien `"version": "5.42.1"` et `action.yml` y est présent. Un SHA est immuable — il survit à une suppression de tags comme à un retag.

Le commentaire `# v5.42.1` qui suit le SHA **n'est pas décoratif** : c'est la seule chose qui reste comparable à la devDependency `ultra11y` de `packages/app/package.json`. `check-ultra11y-version.sh` le lit donc, et **refuse désormais un pin par tag** avec un message qui dit pourquoi — sans ça, un retour à `@vX.Y.Z` repasserait le script au vert tout en cassant la CI.

La version npm n'a pas bougé (`npm view ultra11y dist-tags` → `latest: 5.42.1`). C'est la symétrie exacte de l'incident déjà documenté dans `docs/accessibilite-ultra11y.md` : là un tag sans version npm, ici une version npm sans tag.

## Vérifications

Le script de cohérence a été rejoué sur cinq cas :

| Cas | Attendu | Obtenu |
|---|---|---|
| Nominal (SHA + `# v5.42.1` ×2, dep 5.42.1) | pass | `✓ ultra11y v5.42.1 (38d2a9ed)` |
| Pin par tag `@v5.42.1` (l'ancienne forme) | fail explicite | ✗ « un pin par tag ne compte pas » |
| SHA identiques, commentaires divergents | fail | ✗ « l'un des deux commentaires ment » |
| SHA divergents entre les deux jobs | fail | ✗ « ils doivent porter le même SHA » |
| Désalignement avec la devDependency | fail | ✗ message d'origine préservé |

Le workflow est reparsé avec `js-yaml` : le `# v5.42.1` est bien traité comme un commentaire, la valeur résolue de `uses` est le SHA nu pour `a11y-gate` comme pour `a11y-pages`.

Doc et règle mises à jour (`docs/accessibilite-ultra11y.md`, `.claude/rules/rgaa.md`), procédure de bump incluse — elle donne maintenant la commande qui retrouve le SHA de release d'une version donnée.
