### PR TITLE
chore(a11y): migrer les liens ultra11y vers SocialGouv

### DIFF
--- a/.claude/hooks/check-ultra11y-plugin.sh
+++ b/.claude/hooks/check-ultra11y-plugin.sh
@@ -41,7 +41,7 @@ touch "$MARKER"
 
 # LA RÉFÉRENCE EST LE TAG DE L'ACTION, pas la devDependency : c'est le moteur, et la CI garantit
 # déjà que les trois versions du dépôt s'accordent. Une seule source à lire, donc.
-WANT=$(grep -E '^[[:space:]]*uses:[[:space:]]*maxgfr/ultra11y@' "$WORKFLOW" | sed -E '
+WANT=$(grep -E '^[[:space:]]*uses:[[:space:]]*SocialGouv/ultra11y@' "$WORKFLOW" | sed -E '
 	s/.*@v([0-9]+\.[0-9]+\.[0-9]+).*/\1/
 	t
 	s/.*#[[:space:]]*v([0-9]+\.[0-9]+\.[0-9]+).*/\1/

--- a/.claude/rules/rgaa.md
+++ b/.claude/rules/rgaa.md
@@ -4,15 +4,14 @@
 
 ## Un seul dispositif : ultra11y
 
-L'outil est **ultra11y** (`github.com/maxgfr/ultra11y`, MIT). Il n'y a **pas** de second système d'accessibilité dans ce dépôt, et c'est délibéré : deux jeux de règles sur un même sujet divergent, et celui qui n'a pas de moteur derrière lui est celui qui invente des non-conformités.
+L'outil est **ultra11y** (`github.com/SocialGouv/ultra11y`, MIT). Il n'y a **pas** de second système d'accessibilité dans ce dépôt, et c'est délibéré : deux jeux de règles sur un même sujet divergent, et celui qui n'a pas de moteur derrière lui est celui qui invente des non-conformités.
 
 Deux surfaces, et deux seulement.
 
 **La revue** — l'agent `rgaa-auditor` lance le skill **`review-a11y`** sur le code sous changement et rend son verdict. C'est tout ce qu'il fait : le skill cadre l'audit sur le diff, lance le moteur, réfute les faux positifs, tranche les critères de jugement depuis la source et nomme les critères de rendu comme risques résiduels. Le skill vient du plugin déclaré dans `.claude/settings.json` ; il s'installe une fois avec `claude plugin install ultra11y@ultra11y`. Le plugin apporte aussi un hook `PreToolUse` qui arrête un `git commit` / `git push` / `gh pr create` porteur de non-conformités — coupe-circuits `SKIP_A11Y=1` (une commande), `ULTRA11Y_HOOK=off` (une session), `"hook": { "failOn": "off" }` dans `.ultra11yrc.json` (le dépôt).
 
 **L'analyse** — `.github/workflows/a11y.yaml`, trois jobs portés par la même Action Ultra11y,
-épinglée au SHA du commit de release (`uses: maxgfr/ultra11y@<sha> # vX.Y.Z` ; upstream n'a
-actuellement aucun tag) :
+épinglée au SHA du commit de release (`uses: SocialGouv/ultra11y@<sha> # vX.Y.Z`) :
 
 | Job | Quand | Ce qu'il fait |
 |---|---|---|

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
     "ultra11y": {
       "source": {
         "source": "github",
-        "repo": "maxgfr/ultra11y"
+        "repo": "SocialGouv/ultra11y"
       }
     }
   },

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     # MÊME CADENCE ET MÊME BRANCHE QUE L'ÉCOSYSTÈME NPM CI-DESSOUS, ET C'EST LOAD-BEARING.
     #
-    # `maxgfr/ultra11y` existe des deux côtés : comme Action épinglée dans a11y.yaml et comme
+    # `SocialGouv/ultra11y` existe des deux côtés : comme Action épinglée dans a11y.yaml et comme
     # devDependency dans packages/app. Les deux doivent porter la même version — le balayage
     # Playwright écrit les instantanés avec la devDependency, l'Action les réingère avec son
     # moteur embarqué. Dependabot ne peut pas grouper à travers deux écosystèmes, donc le mieux
@@ -26,7 +26,7 @@ updates:
       # Une seule PR pour les deux `uses:` d'ultra11y, jamais deux qui se marchent dessus.
       ultra11y:
         patterns:
-          - "maxgfr/ultra11y"
+          - "SocialGouv/ultra11y"
   - package-ecosystem: "npm"
     labels:
       - bot

--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -199,8 +199,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: ultra11y — audit RGAA statique
-        # Pin the 5.42.1 release commit: the v5.42.1 tag is missing upstream.
-        uses: maxgfr/ultra11y@38d2a9ed15a94b2bd185c8bff7d56676af4ad77d # v5.42.1
+        # Pin the 5.42.1 release commit; keep the version comment for the consistency check.
+        uses: SocialGouv/ultra11y@38d2a9ed15a94b2bd185c8bff7d56676af4ad77d # v5.42.1
         with:
           working-directory: packages/app
           # `src` et NON `src/**/*.tsx` : l'Action interpole `paths` sans quotes dans bash,
@@ -413,7 +413,7 @@ jobs:
           #     `DPkg::Lock::Timeout` ne couvre pas. Le processus 2077 le tenait depuis plus de
           #     dix minutes : un `apt-get update` de fond bloqué sur le miroir Azure.
           #
-          # C'est le même diagnostic que maxgfr/ultra11y@7090f62 (« apt on the Azure mirror is
+          # C'est le même diagnostic que SocialGouv/ultra11y@7090f62 (« apt on the Azure mirror is
           # what hangs »), et la même conclusion : on ne fait pas dépendre un livrable d'apt.
           #
           # Deux lignes de défense. D'abord on libère le verrou pour de bon — c'est une VM
@@ -471,7 +471,7 @@ jobs:
       # page, crops de preuve, HTML.
       - name: ultra11y — audit, rapport page par page et adjudication
         # Same 5.42.1 release commit as the PR gate; never let the two tiers drift.
-        uses: maxgfr/ultra11y@38d2a9ed15a94b2bd185c8bff7d56676af4ad77d # v5.42.1
+        uses: SocialGouv/ultra11y@38d2a9ed15a94b2bd185c8bff7d56676af4ad77d # v5.42.1
         env:
           # Lu depuis l'ENV DU JOB, jamais depuis un input : c'est ce qui rend le tier
           # inoffensif sur une PR de fork, où les secrets ne sont pas exposés — il se

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -135,7 +135,7 @@ jobs:
           #     `DPkg::Lock::Timeout` ne couvre pas. Le processus 2077 le tenait depuis plus de
           #     dix minutes : un `apt-get update` de fond bloqué sur le miroir Azure.
           #
-          # C'est le même diagnostic que maxgfr/ultra11y@7090f62 (« apt on the Azure mirror is
+          # C'est le même diagnostic que SocialGouv/ultra11y@7090f62 (« apt on the Azure mirror is
           # what hangs »), et la même conclusion : on ne fait pas dépendre un livrable d'apt.
           #
           # Deux lignes de défense. D'abord on libère le verrou pour de bon — c'est une VM

--- a/docs/accessibilite-ultra11y.md
+++ b/docs/accessibilite-ultra11y.md
@@ -10,7 +10,7 @@
 ### 2. L'analyse, par la GitHub Action
 
 `.github/workflows/a11y.yaml`, trois jobs portés par la même Action Ultra11y, épinglée au
-SHA du commit de release avec un commentaire `# vX.Y.Z` (upstream n'a actuellement aucun tag) :
+SHA du commit de release avec un commentaire `# vX.Y.Z` :
 
 | Job | Quand | Ce qu'il fait |
 |---|---|---|
@@ -137,7 +137,7 @@ là-dessus** — `Critère 12.5 déclaré indécidable, mais il porte désormais
 la liste`. C'est le comportement recherché : une dispense ne survit pas à ce qu'elle excusait, et
 la porte l'exige elle-même plutôt que d'attendre qu'on y pense.
 
-En amont, `maxgfr/ultra11y#36` traite la cause, et c'est livré en **5.34.1** : le refus nomme
+En amont, `SocialGouv/ultra11y#36` traite la cause, et c'est livré en **5.34.1** : le refus nomme
 désormais la moisson du critère au lieu de ne montrer que le symptôme, et `ABSENCE_RULE` dit de
 citer la région inspectée.
 
@@ -375,9 +375,8 @@ Trois surfaces à bouger ensemble — deux dans le dépôt, une hors dépôt :
 ```bash
 pnpm --filter app add -D ultra11y@<version>   # version EXACTE, pas de ^
 # puis aligner les DEUX `uses:` de .github/workflows/a11y.yaml sur le SHA de release :
-#   uses: maxgfr/ultra11y@<sha> # v<version>
-# Upstream n'a actuellement aucun tag (`git ls-remote --tags https://github.com/maxgfr/ultra11y.git`
-# est vide) : `@vX.Y.Z` ne résout pas. Le SHA est le commit `chore(release): X.Y.Z`.
+#   uses: SocialGouv/ultra11y@<sha> # v<version>
+# Le SHA doit correspondre au commit de la release `v<version>`.
 ./scripts/a11y/check-ultra11y-version.sh      # refuse une demi-montée, y compris SHA ≠ version npm
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -723,7 +723,7 @@ Activé via `data-fr-scheme="system"` sur `<html>`. Cookie `fr-theme` lu par un 
 
 ### 11.5 RGAA 4.1.2 / WCAG 2.2 AA
 
-Toute l'accessibilité passe par **ultra11y**, en deux surfaces : l'agent `rgaa-auditor`, qui lance le skill `review-a11y` sur le code sous changement, et le workflow `.github/workflows/a11y.yaml` (Action `maxgfr/ultra11y`) — gate statique bloquante sur chaque PR, plus — au cron hebdomadaire ou en manuel — un balayage Playwright des pages qui décide les critères au rendu et fait adjuger les critères de jugement par le runner CLI du moteur. Lighthouse rapporte un score d'accessibilité en avertissement, ce n'est pas une gate. Aucun système a11y parallèle. Règle canonique : `.claude/rules/rgaa.md`.
+Toute l'accessibilité passe par **ultra11y**, en deux surfaces : l'agent `rgaa-auditor`, qui lance le skill `review-a11y` sur le code sous changement, et le workflow `.github/workflows/a11y.yaml` (Action `SocialGouv/ultra11y`) — gate statique bloquante sur chaque PR, plus — au cron hebdomadaire ou en manuel — un balayage Playwright des pages qui décide les critères au rendu et fait adjuger les critères de jugement par le runner CLI du moteur. Lighthouse rapporte un score d'accessibilité en avertissement, ce n'est pas une gate. Aucun système a11y parallèle. Règle canonique : `.claude/rules/rgaa.md`.
 
 ---
 

--- a/scripts/a11y/check-ultra11y-version.sh
+++ b/scripts/a11y/check-ultra11y-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # LA VERSION D'ULTRA11Y VIT À TROIS ENDROITS DANS CE DÉPÔT, ET ILS DOIVENT S'ACCORDER.
 #
-#   1 & 2. `.github/workflows/a11y.yaml` — `uses: maxgfr/ultra11y@…`, DEUX FOIS : la gate PR
+#   1 & 2. `.github/workflows/a11y.yaml` — `uses: SocialGouv/ultra11y@…`, DEUX FOIS : la gate PR
 #          et `a11y-pages`. Le moteur est embarqué dans l'Action. La version se lit soit
 #          sur `@vX.Y.Z`, soit sur un `# vX.Y.Z` quand le ref est un SHA de release
 #          (les tags peuvent disparaître en amont alors que le commit reste).
@@ -34,7 +34,7 @@ fail() {
 [ -f "$manifest" ] || fail "fichier introuvable : $manifest"
 
 # Lignes `uses:` seulement — un SHA cité dans un commentaire du workflow ne compte pas.
-uses_lines=$(grep -E '^[[:space:]]*uses:[[:space:]]*maxgfr/ultra11y@' "$workflow" || true)
+uses_lines=$(grep -E '^[[:space:]]*uses:[[:space:]]*SocialGouv/ultra11y@' "$workflow" || true)
 count=$(printf '%s\n' "$uses_lines" | grep -c . || true)
 
 pin_version() {
@@ -48,14 +48,14 @@ pin_version() {
 }
 
 pin_ref() {
-	printf '%s\n' "$1" | sed -E 's|^[[:space:]]*uses:[[:space:]]*maxgfr/ultra11y@([^[:space:]#]+).*|\1|'
+	printf '%s\n' "$1" | sed -E 's|^[[:space:]]*uses:[[:space:]]*SocialGouv/ultra11y@([^[:space:]#]+).*|\1|'
 }
 
 resolve_engine_version() {
 	local ref="$1"
 	command -v curl >/dev/null 2>&1 || return 1
 	local json
-	json=$(curl -sfL --max-time 10 "https://raw.githubusercontent.com/maxgfr/ultra11y/${ref}/package.json") || return 1
+	json=$(curl -sfL --max-time 10 "https://raw.githubusercontent.com/SocialGouv/ultra11y/${ref}/package.json") || return 1
 	printf '%s\n' "$json" | sed -nE 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' | sed -n 1p
 }
 
@@ -67,7 +67,7 @@ first_ref=$(pin_ref "$first_line")
 second_ref=$(pin_ref "$second_line")
 dep=$(grep -oE '"ultra11y"[[:space:]]*:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$manifest" | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)"$/\1/')
 
-[ "$count" -eq 2 ] || fail "attendu 2 \`uses: maxgfr/ultra11y@…\` dans a11y.yaml, trouvé $count. Si un tier a été ajouté ou retiré, mets ce script à jour avec lui."
+[ "$count" -eq 2 ] || fail "attendu 2 \`uses: SocialGouv/ultra11y@…\` dans a11y.yaml, trouvé $count. Si un tier a été ajouté ou retiré, mets ce script à jour avec lui."
 [ -n "$first" ] && [ -n "$second" ] ||
 	fail "chaque \`uses:\` doit porter \`@vX.Y.Z\` ou un \`# vX.Y.Z\` (pin SHA de release)."
 [ -n "$dep" ] || fail "devDependency \`ultra11y\` introuvable dans packages/app/package.json"


### PR DESCRIPTION
## Contexte

Le dépôt Ultra11y a été transféré de `maxgfr/ultra11y` vers `SocialGouv/ultra11y`.

## Changements

- mise à jour des deux références à la GitHub Action ;
- mise à jour de Dependabot et du contrôle de cohérence des versions ;
- mise à jour de la configuration Claude et de sa vérification ;
- mise à jour des liens et exemples dans la documentation.

## Vérifications

- le tag `SocialGouv/ultra11y@v5.42.1` existe et expose toujours `action.yml` ;
- `./scripts/a11y/check-ultra11y-version.sh` passe ;
- aucune référence à `maxgfr/ultra11y` ne subsiste.