### PR TITLE
fix(declaration): #4034 — direction de l'encart de synthèse alignée sur le seuil réglementaire

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/GapInterpretationCallout.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/GapInterpretationCallout.tsx
@@ -3,13 +3,22 @@ import type { GapDirection } from "~/modules/domain";
 import {
 	formatGapCompact,
 	formatVariablePayProportion,
-	gapDirection,
+	GAP_ALERT_THRESHOLD,
 	gapLevel,
 	gapMagnitude,
 	resolveGap,
+	significantGapDirection,
 } from "~/modules/domain";
 import type { PayGapRow } from "../types";
 import styles from "./InterpretationCallout.module.scss";
+import { PAY_GAP_LABELS } from "./indicatorRowMapping";
+
+const [
+	ANNUAL_MEAN_LABEL,
+	HOURLY_MEAN_LABEL,
+	ANNUAL_MEDIAN_LABEL,
+	HOURLY_MEDIAN_LABEL,
+] = PAY_GAP_LABELS;
 
 /** Gap shown for one row: the GIP value while untouched, else recomputed from the declared operands. */
 function rowGap(row: PayGapRow): number | null {
@@ -32,28 +41,33 @@ type GapAnalysis = {
 
 function analyzeGaps(rows: PayGapRow[]): GapAnalysis {
 	const findRow = (label: string) => rows.find((r) => r.label === label);
-	const annualMean = findRow("Annuelle brute moyenne");
-	const annualMedian = findRow("Annuelle brute médiane");
-	const hourlyMean = findRow("Horaire brute moyenne");
-	const hourlyMedian = findRow("Horaire brute médiane");
+	const annualMean = findRow(ANNUAL_MEAN_LABEL);
+	const annualMedian = findRow(ANNUAL_MEDIAN_LABEL);
+	const hourlyMean = findRow(HOURLY_MEAN_LABEL);
+	const hourlyMedian = findRow(HOURLY_MEDIAN_LABEL);
 
-	const annualMeanGap = annualMean ? gapMagnitude(rowGap(annualMean)) : null;
-	const annualMedianGap = annualMedian
-		? gapMagnitude(rowGap(annualMedian))
-		: null;
-	const hourlyMeanGap = hourlyMean ? gapMagnitude(rowGap(hourlyMean)) : null;
-	const hourlyMedianGap = hourlyMedian
-		? gapMagnitude(rowGap(hourlyMedian))
-		: null;
+	const annualMeanSignedGap = annualMean ? rowGap(annualMean) : null;
+	const annualMedianSignedGap = annualMedian ? rowGap(annualMedian) : null;
+	const hourlyMeanSignedGap = hourlyMean ? rowGap(hourlyMean) : null;
+	const hourlyMedianSignedGap = hourlyMedian ? rowGap(hourlyMedian) : null;
 
-	const gaps = [annualMeanGap, annualMedianGap, hourlyMeanGap, hourlyMedianGap];
-	const hasHighGap = gaps.some((g) => gapLevel(g) === "high");
+	const annualMeanGap = gapMagnitude(annualMeanSignedGap);
+	const annualMedianGap = gapMagnitude(annualMedianSignedGap);
+	const hourlyMeanGap = gapMagnitude(hourlyMeanSignedGap);
+	const hourlyMedianGap = gapMagnitude(hourlyMedianSignedGap);
 
-	// When no gap reaches the regulatory threshold, treat the situation as
-	// balanced — sub-threshold deltas are not interpreted as disfavor.
-	const direction: GapDirection = hasHighGap
-		? gapDirection(rows.map((r) => ({ women: r.womenValue, men: r.menValue })))
-		: "balanced";
+	const signedGaps = [
+		annualMeanSignedGap,
+		annualMedianSignedGap,
+		hourlyMeanSignedGap,
+		hourlyMedianSignedGap,
+	];
+	const hasHighGap = signedGaps.some((g) => gapLevel(g) === "high");
+
+	// Direction is derived only from rows crossing the threshold, weighted by magnitude —
+	// `significantGapDirection` returns "balanced" by itself when none does, so the two
+	// never disagree the way an unfiltered majority vote could.
+	const direction: GapDirection = significantGapDirection(signedGaps);
 
 	return {
 		direction,
@@ -120,7 +134,7 @@ function buildPayGapBody(analysis: GapAnalysis): {
 
 	return {
 		title: "Écart entre hommes et femmes",
-		body: "Les rémunérations annuelles et médianes sont très proches, avec des écarts inférieurs à 5 %. Les différences horaires sont également limitées.",
+		body: `Les rémunérations annuelles et médianes sont très proches, avec des écarts inférieurs à ${GAP_ALERT_THRESHOLD} %. Les différences horaires sont également limitées.`,
 		interpretation:
 			"Les écarts sont faibles et ne révèlent pas d'inégalité significative.",
 	};

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/GapInterpretationCallout.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/GapInterpretationCallout.test.tsx
@@ -132,6 +132,31 @@ describe("GapInterpretationCallout", () => {
 		expect(container.textContent).toMatch(/16,66\s*%/);
 	});
 
+	it("renders '-' for gaps whose rows are missing from the input (defensive fallback)", () => {
+		const rows = makeRows({
+			annualMeanW: "25000",
+			annualMeanM: "30000",
+			hourlyMedianW: "11",
+			hourlyMedianM: "14",
+		}).filter(
+			(r) =>
+				r.label !== "Annuelle brute médiane" &&
+				r.label !== "Horaire brute moyenne",
+		);
+
+		const { container } = render(
+			<GapInterpretationCallout rows={rows} variant="payGap" />,
+		);
+
+		expect(
+			screen.getByText(/Écart en défaveur des femmes/),
+		).toBeInTheDocument();
+		expect(container.textContent).toMatch(
+			/rémunération médiane inférieure de -\./,
+		);
+		expect(container.textContent).toMatch(/autour de -\./);
+	});
+
 	it("renders balanced title for payGap variant when gaps are below 5%", () => {
 		// 2 rows women-lower, 2 rows men-lower => balanced direction, all gaps < 5%
 		const rows = makeRows({
@@ -153,6 +178,67 @@ describe("GapInterpretationCallout", () => {
 		expect(
 			screen.getByText(/Les rémunérations annuelles et médianes/),
 		).toBeInTheDocument();
+	});
+
+	it("announces men-disfavored direction, not balanced, when a significant gap is outvoted 2-2 by sub-threshold rows (#4034 defect A)", () => {
+		// Annual mean crosses the threshold at -20% (men disfavored). The three other rows sit
+		// well under 0.5% and split 2 women-lower / 1 men-lower — a raw majority vote over all
+		// four rows ties 2-2 and used to fall back to "balanced" despite the orange accent.
+		const rows = makeRows({
+			annualMeanW: "30000",
+			annualMeanM: "25000",
+			annualMedianW: "29995",
+			annualMedianM: "30000",
+			hourlyMeanW: "14.995",
+			hourlyMeanM: "15",
+			hourlyMedianW: "15",
+			hourlyMedianM: "14.995",
+		});
+
+		const { container } = render(
+			<GapInterpretationCallout rows={rows} variant="payGap" />,
+		);
+
+		expect(container.querySelector(".fr-callout")).toHaveClass(
+			"fr-callout--orange-terre-battue",
+		);
+		expect(
+			screen.getByText(/Écart en défaveur des hommes/),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/Écart entre hommes et femmes/),
+		).not.toBeInTheDocument();
+	});
+
+	it("announces men-disfavored direction, not the opposite, when outvoted 3-1 by sub-threshold rows (#4034 defect B)", () => {
+		// Same significant -20% row (men disfavored), but all three sub-threshold rows point
+		// the other way. A raw majority vote (1 vs 3) used to flip the announced direction to
+		// "women" while still displaying the 20% magnitude of the men-disfavoring row as evidence.
+		const rows = makeRows({
+			annualMeanW: "30000",
+			annualMeanM: "25000",
+			annualMedianW: "29995",
+			annualMedianM: "30000",
+			hourlyMeanW: "14.995",
+			hourlyMeanM: "15",
+			hourlyMedianW: "14.996",
+			hourlyMedianM: "15",
+		});
+
+		const { container } = render(
+			<GapInterpretationCallout rows={rows} variant="payGap" />,
+		);
+
+		expect(container.querySelector(".fr-callout")).toHaveClass(
+			"fr-callout--orange-terre-battue",
+		);
+		expect(
+			screen.getByText(/Écart en défaveur des hommes/),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/Écart en défaveur des femmes/),
+		).not.toBeInTheDocument();
+		expect(container.textContent).toMatch(/20,00\s*%/);
 	});
 
 	it("renders women disfavored title for variablePay variant", () => {

--- a/packages/app/src/modules/declaration-remuneration/shared/indicatorRowMapping.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/indicatorRowMapping.ts
@@ -2,7 +2,7 @@ import type { GipGapReference } from "~/modules/domain";
 import type { PayGapRow, Step2Data, Step3Data } from "../types";
 import type { GipPrefillData } from "./gipMdsMapping";
 
-const PAY_GAP_LABELS = [
+export const PAY_GAP_LABELS = [
 	"Annuelle brute moyenne",
 	"Horaire brute moyenne",
 	"Annuelle brute médiane",

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -279,6 +279,24 @@ describe("SecondDeclarationStep3Review", () => {
 		);
 	});
 
+	it("navigates to compliance path when gaps persist after submit, on a negative gap (#4034)", async () => {
+		// Same routing as the +50% case above, but with women earning more than men (-6%):
+		// the threshold is symmetric, so a negative gap must persist the compliance path too.
+		renderStep3({
+			cseOpinionRequired: true,
+			secondDeclarationCategories: [
+				makeCategory({ annualBaseWomen: "1060", annualBaseMen: "1000" }),
+			],
+		});
+
+		await submitDeclaration();
+
+		expect(mockMutate).toHaveBeenCalledTimes(1);
+		expect(mockPush).toHaveBeenCalledWith(
+			"/declaration-remuneration/parcours-conformite",
+		);
+	});
+
 	it("navigates to avis-cse when no gaps remain and a CSE opinion is due", async () => {
 		renderStep3({
 			cseOpinionRequired: true,

--- a/packages/app/src/modules/domain/__tests__/gap.test.ts
+++ b/packages/app/src/modules/domain/__tests__/gap.test.ts
@@ -8,7 +8,6 @@ import {
 	computeGapBetween,
 	computeGapRatio,
 	computeTotal,
-	gapDirection,
 	gapLevel,
 	gapMagnitude,
 	gapRatioToPercent,
@@ -16,6 +15,7 @@ import {
 	hasHighGap,
 	resolveGap,
 	resolveGapRatio,
+	significantGapDirection,
 } from "../shared/gap";
 
 describe("regulatory constants", () => {
@@ -349,46 +349,52 @@ describe("hasHighGap", () => {
 	});
 });
 
-describe("gapDirection", () => {
-	it("returns women when women are lower-paid in more rows", () => {
-		expect(
-			gapDirection([
-				{ women: "90", men: "100" },
-				{ women: "80", men: "100" },
-				{ women: "100", men: "95" },
-			]),
-		).toBe("women");
+describe("significantGapDirection", () => {
+	it("returns women when the only significant gap favors women, even split 2/2 by sub-threshold rows (#4034 defect A)", () => {
+		// One significant gap (20, men earn more => women disfavored) plus three sub-threshold
+		// gaps split evenly the other way — an unfiltered majority vote would tie to "balanced".
+		expect(significantGapDirection([20, 0.1, 0.1, -0.2])).toBe("women");
 	});
 
-	it("returns men when men are lower-paid in more rows", () => {
-		expect(
-			gapDirection([
-				{ women: "100", men: "90" },
-				{ women: "100", men: "80" },
-			]),
-		).toBe("men");
+	it("returns men when the only significant gap favors men, even outvoted 3-1 by sub-threshold rows (#4034 defect B)", () => {
+		// One significant gap (-20, women earn more => men disfavored) plus three sub-threshold
+		// gaps all pointing the other way — an unfiltered majority vote would flip this to "women".
+		expect(significantGapDirection([-20, 0.1, 0.2, 0.15])).toBe("men");
 	});
 
-	it("returns balanced on a tie", () => {
-		expect(
-			gapDirection([
-				{ women: "90", men: "100" },
-				{ women: "100", men: "90" },
-			]),
-		).toBe("balanced");
+	it("weighs cumulated magnitude rather than counting rows", () => {
+		// A single large women-disfavoring gap (30) outweighs two smaller men-disfavoring
+		// gaps (-6, -6) even though they are more numerous: 30 - 6 - 6 = 18 > 0.
+		expect(significantGapDirection([30, -6, -6])).toBe("women");
 	});
 
-	it("returns balanced for no data", () => {
-		expect(gapDirection([])).toBe("balanced");
+	it("returns balanced when no gap reaches the threshold", () => {
+		expect(significantGapDirection([1, -2, 3, -0.5])).toBe("balanced");
 	});
 
-	it("ignores rows with non-numeric values", () => {
-		expect(
-			gapDirection([
-				{ women: "abc", men: "100" },
-				{ women: "90", men: "100" },
-			]),
-		).toBe("women");
+	it("returns balanced for an empty list", () => {
+		expect(significantGapDirection([])).toBe("balanced");
+	});
+
+	it("ignores null gaps", () => {
+		expect(significantGapDirection([null, null, 20])).toBe("women");
+	});
+
+	it("never returns balanced when at least one gap is significant, even on an exact tie", () => {
+		expect(significantGapDirection([20, -20])).not.toBe("balanced");
+	});
+
+	it("breaks an exact tie on the largest-magnitude side, favoring men when it is negative", () => {
+		// Four significant gaps summing to exactly 0 (5 - 5 - 10 + 10), with the largest-magnitude
+		// value (-10) landing mid-array — exercises both the "new element wins" and "keeps the
+		// current largest" paths of the tie-break, and the "men" branch of its final sign check
+		// (the sibling test above only ever resolves to "women").
+		expect(significantGapDirection([5, -5, -10, 10])).toBe("men");
+	});
+
+	it("respects a custom threshold", () => {
+		expect(significantGapDirection([8], 10)).toBe("balanced");
+		expect(significantGapDirection([8], 5)).toBe("women");
 	});
 });
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -184,7 +184,6 @@ export {
 	computeGapHighFlags,
 	computeGapRatio,
 	computeTotal,
-	gapDirection,
 	gapLevel,
 	gapMagnitude,
 	gapRatioToPercent,
@@ -192,6 +191,7 @@ export {
 	hasHighGap,
 	resolveGap,
 	resolveGapRatio,
+	significantGapDirection,
 } from "./shared/gap";
 // GIP annual average workforce — canonical headcount for obligations & display
 export {

--- a/packages/app/src/modules/domain/shared/gap.ts
+++ b/packages/app/src/modules/domain/shared/gap.ts
@@ -123,23 +123,31 @@ export function hasHighGap(gaps: ReadonlyArray<number | null>): boolean {
 	return gaps.some((gap) => gapLevel(gap) === "high");
 }
 
-/** Determines which side is more often the lower-paid one across a set of women/men value pairs.
- *  "women" when women are lower in more rows, "men" for the opposite, "balanced" on a tie or no data. */
-export function gapDirection(
-	pairs: ReadonlyArray<{ women: string; men: string }>,
+/** Direction of pay disparity, derived only from gaps that cross the regulatory threshold and weighted by
+ *  their signed magnitude (cumulated per side) — unlike a plain majority vote, which would let several
+ *  sub-threshold rows outvote a single significant one. Positive gaps favor "women" (men earn more),
+ *  negative gaps favor "men" (women earn more), matching `computeGap`'s sign convention.
+ *
+ *  Total: whenever at least one gap is significant, the result always carries a sign — it can never be
+ *  "balanced" while a threshold-crossing row exists. */
+export function significantGapDirection(
+	gaps: ReadonlyArray<number | null>,
+	threshold: number = GAP_ALERT_THRESHOLD,
 ): GapDirection {
-	let womenLowerCount = 0;
-	let menLowerCount = 0;
-	for (const { women, men } of pairs) {
-		const w = Number.parseFloat(women);
-		const m = Number.parseFloat(men);
-		if (Number.isNaN(w) || Number.isNaN(m)) continue;
-		if (w < m) womenLowerCount++;
-		if (m < w) menLowerCount++;
-	}
-	if (womenLowerCount > menLowerCount) return "women";
-	if (menLowerCount > womenLowerCount) return "men";
-	return "balanced";
+	const significant = gaps.filter(
+		(gap): gap is number => gap !== null && Math.abs(gap) >= threshold,
+	);
+	if (significant.length === 0) return "balanced";
+
+	const cumulated = significant.reduce((sum, gap) => sum + gap, 0);
+	if (cumulated > 0) return "women";
+	if (cumulated < 0) return "men";
+
+	// Exact tie between opposing significant gaps: break on the largest magnitude side.
+	const largestMagnitude = significant.reduce((largest, gap) =>
+		Math.abs(gap) > Math.abs(largest) ? gap : largest,
+	);
+	return largestMagnitude > 0 ? "women" : "men";
 }
 
 /** Converts a stored gap ratio (e.g. `"0.0523"`) to a signed percentage (`5.23`).


### PR DESCRIPTION
Closes #4034

## Contexte

Suite de l'analyse révisée sur #4034 : le point 1 (convergence badge web/PDF) et le point 3 (routage post-seconde-déclaration) étaient déjà livrés par #3963/#4040. Ce ticket corrige le seul défaut restant : l'encart de synthèse (`GapInterpretationCallout`) pouvait afficher un texte incohérent, voire contradictoire, avec son propre accent visuel.

## Root cause

L'accent couleur de l'encart venait de `hasHighGap` (magnitude, filtrée par le seuil réglementaire de 5 %), mais la direction du texte venait de `gapDirection`, un vote majoritaire sur **toutes** les lignes, non filtré par le seuil et non pondéré par la magnitude. Un écart significatif à −20 % pouvait donc être mis en minorité par trois écarts sous 0,5 %, produisant :

- soit un texte « balanced » (« pas de différence significative ») sous un accent orange (défaut A) ;
- soit — plus grave — l'annonce de la direction **opposée**, tout en affichant la magnitude de 20 % de l'écart significatif comme preuve à l'appui de cette affirmation inverse (défaut B).

## Correctif

- Nouvelle fonction de domaine pure `significantGapDirection` (`~/modules/domain/shared/gap.ts`) : dérive la direction uniquement des écarts qui franchissent `GAP_ALERT_THRESHOLD`, pondérés par leur magnitude signée cumulée. Dès qu'une ligne est significative, le résultat ne peut plus jamais valoir `"balanced"`.
- `analyzeGaps` (`GapInterpretationCallout.tsx`) indexe désormais les lignes via `PAY_GAP_LABELS` (nouvellement exportée depuis `indicatorRowMapping.ts`) au lieu de libellés français en dur.
- Le texte « balanced » dérive le seuil affiché (« 5 % ») de `GAP_ALERT_THRESHOLD` au lieu de le coder en dur.
- L'ancienne fonction de vote `gapDirection` (non pondérée, non filtrée par seuil) est retirée : plus aucun appelant après ce changement (vérifié — un `gapDirection` homonyme mais sans rapport reste dans `consultation/formatters.ts`, non touché).
- Hors périmètre, tranché par arbitrage produit : l'encart continue d'afficher des **magnitudes** (pas de signe) dans la prose — la direction est déjà portée par le titre et la phrase elle-même.

## Vérification

Cas rouges avant le fix (`pnpm test GapInterpretationCallout`, revert du diff source) : 2 échecs sur les scénarios A et B — le cas B affichait notamment « Écart en défaveur des femmes » avec la magnitude 20,00 % pour un écart en réalité en défaveur des hommes. Verts après réapplication du fix (20/20 sur ce fichier, 6098/6098 sur la suite complète).

Point 3 (routage post-seconde-déclaration) : comportement déjà correct côté code, désormais couvert par un test à écart négatif (−6 %) en plus du cas existant à +50 %.

## Test plan

- [x] `pnpm test` (6098/6098)
- [x] `pnpm typecheck`
- [x] `pnpm check:write`
- [x] Cas A et B rouges avant fix, verts après (revert-verify)
- [x] `gapDirection` retiré : aucun appelant restant (hors homonyme non lié dans `consultation/formatters.ts`)
