### PR TITLE
fix(declaration): #4141 — la marge de FormActions s'additionne au gap flex

### DIFF
--- a/packages/app/src/e2e/second-declaration-info-styling.e2e.ts
+++ b/packages/app/src/e2e/second-declaration-info-styling.e2e.ts
@@ -5,9 +5,12 @@ import {
 	selectCompliancePath,
 } from "./helpers/compliance-flows";
 import {
+	ensureCurrentYearDeclaration,
 	resetDeclarationToDraft,
+	resetGipWorkforce,
 	setCompanyHasCse,
 	setCompanyWorkforce,
+	setDeclarationComplianceState,
 } from "./helpers/db";
 import { completeDeclaration } from "./helpers/declaration-flows";
 
@@ -95,4 +98,75 @@ test.describe("second declaration step 1 — DSFR overrides", () => {
 			await expect(callout).toHaveCSS("padding", EXPECTED_DESKTOP_PADDING);
 		});
 	});
+});
+
+// #4141 — FormActions owns the 32px above the buttons as `margin-top: 2rem`, which is right
+// under a block-flow parent and wrong under these `gap: 2rem` flex columns, where it adds to
+// the gap instead of collapsing into it: 64px on étape 3 until `fr-mt-0` cancelled it.
+// `CompliancePathChoice` reached the same 32px through a positional `> :last-child` rule
+// until #4141 swapped it for that shared idiom — a substitution no unit test can observe,
+// since jsdom resolves neither the flex gap nor DSFR's `!important` reset, and the vitest
+// tests assert the class string rather than what it renders to.
+const FLEX_HOSTS = [
+	{ name: "choix du parcours", path: COMPLIANCE_PATH },
+	{ name: "seconde déclaration — étape 3", path: `${COMPLIANCE_PATH}/etape/3` },
+];
+
+// The rendered gap, not the computed margin: 32px is what the maquette asks for and what
+// regressed to 64px, whereas asserting `margin-top: 0` only restates the class name.
+const EXPECTED_ACTIONS_GAP = 32;
+
+test.describe("form actions — 32px under a flex-gap parent", () => {
+	// Both screens gate on the corrective branch and redirect out without it. Seeding the
+	// choice reaches them by URL, where replaying the funnel lands on étape 1 only and leaves
+	// étape 3 — the screen the bug was on — unreachable. Same recipe as stepper-spacing.
+	test.beforeAll(async () => {
+		await ensureCurrentYearDeclaration();
+		await resetDeclarationToDraft();
+		await resetGipWorkforce();
+		await setCompanyHasCse(true);
+		await setDeclarationComplianceState({
+			firstDeclarationPathChoice: "corrective_action",
+		});
+	});
+
+	test.afterAll(async () => {
+		await resetDeclarationToDraft();
+	});
+
+	for (const host of FLEX_HOSTS) {
+		test(`${host.name} — 32px between the last block and the form actions`, async ({
+			page,
+		}) => {
+			await page.goto(host.path);
+			// A redirected page still has a "Précédent" link to measure, so pin the URL:
+			// without it a green run proves nothing about the screen named here.
+			await page.waitForURL(`**${host.path}`, { timeout: 15_000 });
+
+			const actions = page
+				.getByRole("link", { name: "Précédent" })
+				.locator("..");
+			await expect(actions).toBeVisible();
+
+			const gap = await actions.evaluate((element) => {
+				// Étape 3 keeps its submit modal in the DOM while closed, immediately before
+				// the actions. It is `position: fixed` and fills the viewport, so its border
+				// box says nothing about the flow the 32px belongs to: walk back to the
+				// nearest sibling actually laid out in that flow.
+				let previous = element.previousElementSibling;
+				while (previous && getComputedStyle(previous).position === "fixed") {
+					previous = previous.previousElementSibling;
+				}
+				if (!previous) {
+					throw new Error("the form actions must follow a content block");
+				}
+				return Math.round(
+					element.getBoundingClientRect().top -
+						previous.getBoundingClientRect().bottom,
+				);
+			});
+
+			expect(gap).toBe(EXPECTED_ACTIONS_GAP);
+		});
+	}
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/FormActions.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/FormActions.module.scss
@@ -2,6 +2,8 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	// relies on block margin-collapse (fieldset): stays 2rem with or without a callout above
+	// Spaces .actions from the previous block under a block-flow parent (e.g. a
+	// DSFR fieldset). Under a flex parent with `gap`, this adds to the gap
+	// instead of collapsing into it — the call site must pass `fr-mt-0`.
 	margin-top: 2rem;
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.module.scss
@@ -12,12 +12,6 @@
 	display: flex;
 	flex-direction: column;
 	gap: 2rem;
-
-	// FormActions carries its own `margin-top: 2rem` for block-flow parents; the
-	// flex gap already provides that spacing here and the margin would double it.
-	> :last-child {
-		margin-top: 0;
-	}
 }
 
 // DSFR's fieldset gutters (negative row margin + per-element side padding) exist

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -270,6 +270,7 @@ export function CompliancePathChoice({
 				<FormErrors mutationError={mutation.error?.message} />
 
 				<FormActions
+					className="fr-mt-0"
 					isSubmitting={mutation.isPending}
 					mimoquageNextHref={
 						initialPath

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -341,6 +341,13 @@ describe("CompliancePathChoice", () => {
 		);
 	});
 
+	it("neutralises the top margin of the form actions (issue #4141)", () => {
+		render(compliancePathChoice());
+		expect(
+			screen.getByRole("link", { name: /précédent/i }).parentElement,
+		).toHaveClass("fr-mt-0");
+	});
+
 	it("renders previous link pointing to the second-declaration recap in round 2", () => {
 		render(compliancePathChoice({ isSecondRound: true }));
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -174,6 +174,7 @@ export function SecondDeclarationStep3Review({
 			<FormErrors mutationError={mutation.error?.message} />
 
 			<FormActions
+				className="fr-mt-0"
 				nextHref={nextHref}
 				nextLabel={nextLabel}
 				previousHref={`${BASE_PATH}/etape/2`}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -434,6 +434,15 @@ describe("SecondDeclarationStep3Review", () => {
 		});
 	});
 
+	it("neutralises the top margin of the form actions (issue #4141)", () => {
+		renderStep3();
+
+		expect(
+			screen.getByRole("button", { name: /soumettre/i }).parentElement
+				?.parentElement,
+		).toHaveClass("fr-mt-0");
+	});
+
 	it("closes the modal without submitting when Annuler is clicked", async () => {
 		const user = userEvent.setup();
 		renderStep3();


### PR DESCRIPTION
Closes #4141

## Résumé

Sur `SecondDeclarationStep3Review`, `.actions` (FormActions) est enfant direct d'un `<form>` en flux flex (`gap: 2rem`) et ne portait aucune neutralisation : le `margin-top: 2rem` propre à `FormActions` s'additionnait au gap flex → 64px au lieu des 32px attendus par la maquette. Correction : `className="fr-mt-0"` sur ce point d'appel — l'idiome déjà utilisé sur `SecondDeclarationStep1Info` et `CategoryForm`.

Par cohérence, `CompliancePathChoice` (qui neutralisait la même marge via un sélecteur positionnel `> :last-child { margin-top: 0 }`, fragile dès qu'un `<dialog>` suit `.actions`) est aligné sur le même idiome `fr-mt-0`. Le commentaire trompeur de `FormActions.module.scss` (qui invoquait à tort la fusion des marges block-flow) est corrigé.

Le ticket original annonçait 5 écrans affectés ; 4 avaient déjà été neutralisés entre-temps (notamment #3577). Voir le commentaire `## Analyse du bug` de l'issue pour le détail complet de l'investigation.

## Vérification

**One-shot (dev server, DOM mesuré)** :

| Écran | Avant | Après |
|---|---|---|
| `/declaration-remuneration/parcours-conformite/etape/3` (SecondDeclarationStep3Review — le bug) | 64px, `margin-top: 32px` | **32px, `margin-top: 0px`** |
| `/declaration-remuneration/parcours-conformite/etape/1` (déjà corrigé par #3577) | — | 32px, `margin-top: 0px` (non-régression) |
| `/declaration-remuneration/etape/1` (écran en flux bloc, fieldset) | — | 32px, `margin-top: 32px` (non-régression — la marge fait le travail ici) |

Mesure : `getBoundingClientRect()` entre `.actions` et le bloc visible précédent (en ignorant le `<dialog>` de mise à jour CSE, toujours présent dans le DOM avec `visibility: hidden` et une position `fixed` plein viewport — artefact DSFR indépendant du fix) + `getComputedStyle(...).marginTop`.

**Revert-verify (TU)** : le diff source seul reverté → les deux nouveaux tests (`SecondDeclarationStep3Review.test.tsx`, `CompliancePathChoice.test.tsx`) passent en RED (`Received: actions` au lieu de `fr-mt-0`) ; ré-appliqué → GREEN.

## Tests

- `SecondDeclarationStep3Review.test.tsx` : nouvelle assertion `fr-mt-0` sur le conteneur des actions
- `CompliancePathChoice.test.tsx` : assertion symétrique (même fix, même point d'appel)
- Suite complète : 76 tests verts sur les 3 fichiers concernés, typecheck clean, `pnpm check:write` clean

## Hors périmètre

`cseOpinion/shared/formActions.module.scss` et `declaration-representation/StepPageClient.module.scss` sont des barres d'actions parallèles quasi-dupliquées, signalées dans l'analyse mais non touchées ici — mutualisation à part entière, hors ticket.