### PR TITLE
fix(cse): #4261 — wording de l'en-tête de colonne du tableau d'avis

### DIFF
--- a/packages/app/src/modules/cseOpinion/components/ContentTypeMatrix.tsx
+++ b/packages/app/src/modules/cseOpinion/components/ContentTypeMatrix.tsx
@@ -59,8 +59,8 @@ export function ContentTypeMatrix({
 							</caption>
 							<thead>
 								<tr>
-									<th className="fr-cell--fixed" scope="col">
-										Fichier
+									<th className="fr-cell--fixed fr-cell--multiline" scope="col">
+										Fichier(s) importé(s)/déposé(s)
 									</th>
 									{columns.map((column) => (
 										<th

--- a/packages/app/src/modules/cseOpinion/components/__tests__/ContentTypeMatrix.test.tsx
+++ b/packages/app/src/modules/cseOpinion/components/__tests__/ContentTypeMatrix.test.tsx
@@ -57,6 +57,16 @@ function renderMatrix(
 }
 
 describe("ContentTypeMatrix", () => {
+	it("names the file column header 'Fichier(s) importé(s)/déposé(s)' (wording regression guard, #4261)", () => {
+		renderMatrix();
+
+		expect(
+			screen.getByRole("columnheader", {
+				name: "Fichier(s) importé(s)/déposé(s)",
+			}),
+		).toBeInTheDocument();
+	});
+
 	it("renders one row per file with a view link pointing to the file endpoint", () => {
 		renderMatrix();
 


### PR DESCRIPTION
Closes #4261

## Résumé

L'en-tête de la 1re colonne du tableau d'association fichiers × types de contenu (étape « Importer/Déposer l'avis ou les avis du CSE ») affichait « Fichier » au singulier, alors que le parcours accepte jusqu'à 4 fichiers et que la colonne liste tous les fichiers déjà déposés.

- `ContentTypeMatrix.tsx` : le `<th scope="col">` de la 1re colonne affiche désormais **« Fichier(s) importé(s)/déposé(s) »**, et porte la classe `fr-cell--multiline` (en plus de `fr-cell--fixed` déjà présente) pour permettre au libellé de revenir à la ligne au lieu d'élargir la colonne figée au scroll horizontal mobile.
- Aucune autre occurrence de « Fichier » dans l'app n'a été modifiée (ni `FileUpload.tsx`, ni les tableaux admin/export/PDF).

## Test plan

- Nouveau test unitaire dans `ContentTypeMatrix.test.tsx` : assertion sur le nom accessible (`columnheader`) « Fichier(s) importé(s)/déposé(s) ».
- Suite `cseOpinion` complète rejouée : verte (219/219), y compris `Step2Upload.test.tsx` qui interroge un pattern voisin (`/fichiers\)/`) — pas de collision avec le nouveau libellé.
- Suite vitest complète du package : verte (6091/6091).
- `pnpm typecheck` : 0 erreur.
- `pnpm check:write` : aucun fix nécessaire.

## Gates

- validator (typecheck + test + lint + format) : PASS
- structural-auditor : PASS
- rgaa-auditor (ultra11y `review-a11y`) : PASS — changement de texte + classe layout uniquement, aucune non-conformité introduite
- security-auditor : SECURE — aucun fichier serveur touché