### PR TITLE
refactor(api): #3763 — mutualise le contrôle de verrou REST dans un garde nommé

### DIFF
--- a/packages/app/src/app/api/upload/__tests__/route.test.ts
+++ b/packages/app/src/app/api/upload/__tests__/route.test.ts
@@ -650,10 +650,13 @@ describe("POST /api/upload", () => {
 
 		expect(response.status).toBe(200);
 		expect(mocks.runUploadPipeline).toHaveBeenCalled();
-		expect(mocks.assertDeclarationUnlockedForWrite).toHaveBeenCalledWith(
-			{},
-			"123456789",
-			"user-1",
+		// The guard must vet the very (siren, year) the pipeline then writes to.
+		const [, guardSiren, guardYear, guardUserId] =
+			mocks.assertDeclarationUnlockedForWrite.mock.calls[0] ?? [];
+		expect(guardSiren).toBe("123456789");
+		expect(guardUserId).toBe("user-1");
+		expect(mocks.runUploadPipeline).toHaveBeenCalledWith(
+			expect.objectContaining({ siren: guardSiren, year: guardYear }),
 		);
 	});
 });

--- a/packages/app/src/app/api/upload/__tests__/route.test.ts
+++ b/packages/app/src/app/api/upload/__tests__/route.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-	auth: vi.fn(),
-	runUploadPipeline: vi.fn(),
-	logAction: vi.fn().mockResolvedValue(undefined),
-	getActiveLock: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+	class DeclarationLockedByOtherUserError extends Error {}
+	return {
+		auth: vi.fn(),
+		runUploadPipeline: vi.fn(),
+		logAction: vi.fn().mockResolvedValue(undefined),
+		assertDeclarationUnlockedForWrite: vi.fn(),
+		DeclarationLockedByOtherUserError,
+	};
+});
 
 vi.mock("~/server/auth", () => ({
 	auth: mocks.auth,
@@ -19,28 +23,13 @@ vi.mock("~/server/audit/log", () => ({
 	logAction: mocks.logAction,
 }));
 
-// The route resolves the current-year declaration before streaming the body so
-// it can refuse a target locked by another co-declarant (epic #3556). Mock the
-// db lookup to return one declaration and the lock service to a configurable
-// holder.
-vi.mock("~/server/db", () => ({
-	db: {
-		select: () => ({
-			from: () => ({
-				where: () => ({
-					limit: async () => [{ id: "decl-1" }],
-				}),
-			}),
-		}),
-	},
-}));
-
-vi.mock("~/server/db/schema", () => ({
-	declarations: { id: "id", siren: "siren", year: "year" },
-}));
+// Only the guard verdict is mocked here: its three semantics live in
+// `declarationLockService.test.ts`, which owns the declaration lookup.
+vi.mock("~/server/db", () => ({ db: {} }));
 
 vi.mock("~/server/services/declarationLockService", () => ({
-	getActiveLock: mocks.getActiveLock,
+	assertDeclarationUnlockedForWrite: mocks.assertDeclarationUnlockedForWrite,
+	DeclarationLockedByOtherUserError: mocks.DeclarationLockedByOtherUserError,
 }));
 
 function validSession() {
@@ -99,7 +88,7 @@ describe("POST /api/upload", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		// Default: declaration free of any active lock, so the upload proceeds.
-		mocks.getActiveLock.mockResolvedValue(null);
+		mocks.assertDeclarationUnlockedForWrite.mockResolvedValue(undefined);
 	});
 
 	it("returns 400 when X-Flow-Type is missing", async () => {
@@ -595,13 +584,9 @@ describe("POST /api/upload", () => {
 
 	it("returns 409 and audits a failure row when another co-declarant holds the lock", async () => {
 		validSession();
-		mocks.getActiveLock.mockResolvedValue({
-			userId: "user-2",
-			email: "other@example.com",
-			firstName: "Bob",
-			lastName: "Durand",
-			expiresAt: new Date(Date.now() + 30 * 60_000),
-		});
+		mocks.assertDeclarationUnlockedForWrite.mockRejectedValue(
+			new mocks.DeclarationLockedByOtherUserError(),
+		);
 
 		const { POST } = await import("../route");
 		const response = await POST(
@@ -625,15 +610,28 @@ describe("POST /api/upload", () => {
 		);
 	});
 
-	it("proceeds when the session user holds the lock", async () => {
+	it("propagates an unexpected guard failure instead of reporting a conflict", async () => {
 		validSession();
-		mocks.getActiveLock.mockResolvedValue({
-			userId: "user-1",
-			email: "user@example.com",
-			firstName: "Alice",
-			lastName: "Martin",
-			expiresAt: new Date(Date.now() + 30 * 60_000),
-		});
+		mocks.assertDeclarationUnlockedForWrite.mockRejectedValue(
+			new Error("database unreachable"),
+		);
+
+		const { POST } = await import("../route");
+
+		await expect(
+			POST(
+				buildRequest({
+					"Content-Type": "application/pdf",
+					"X-Filename": "avis-cse.pdf",
+					"X-Flow-Type": "cse_opinion",
+				}),
+			),
+		).rejects.toThrow("database unreachable");
+		expect(mocks.runUploadPipeline).not.toHaveBeenCalled();
+	});
+
+	it("proceeds when the guard raises no conflict", async () => {
+		validSession();
 		mocks.runUploadPipeline.mockResolvedValue({
 			ok: true,
 			fileId: "file-uuid",
@@ -652,5 +650,10 @@ describe("POST /api/upload", () => {
 
 		expect(response.status).toBe(200);
 		expect(mocks.runUploadPipeline).toHaveBeenCalled();
+		expect(mocks.assertDeclarationUnlockedForWrite).toHaveBeenCalledWith(
+			{},
+			"123456789",
+			"user-1",
+		);
 	});
 });

--- a/packages/app/src/app/api/upload/route.ts
+++ b/packages/app/src/app/api/upload/route.ts
@@ -221,7 +221,7 @@ export async function POST(request: Request): Promise<Response> {
 
 	// Before the body is streamed: no bandwidth wasted on a locked target.
 	try {
-		await assertDeclarationUnlockedForWrite(db, siren, session.user.id);
+		await assertDeclarationUnlockedForWrite(db, siren, year, session.user.id);
 	} catch (error) {
 		if (!(error instanceof DeclarationLockedByOtherUserError)) {
 			throw error;

--- a/packages/app/src/app/api/upload/route.ts
+++ b/packages/app/src/app/api/upload/route.ts
@@ -1,4 +1,3 @@
-import { and, eq } from "drizzle-orm";
 import { AUDIT_ACTIONS, type AuditActionKey } from "~/modules/audit";
 import {
 	DECLARATION_LOCK_CONFLICT_MESSAGE,
@@ -14,8 +13,10 @@ import { logAction } from "~/server/audit/log";
 import { buildRequestContext } from "~/server/audit/requestContext";
 import { auth } from "~/server/auth";
 import { db } from "~/server/db";
-import { declarations } from "~/server/db/schema";
-import { getActiveLock } from "~/server/services/declarationLockService";
+import {
+	assertDeclarationUnlockedForWrite,
+	DeclarationLockedByOtherUserError,
+} from "~/server/services/declarationLockService";
 import {
 	runUploadPipeline,
 	type UploadPipelineResult,
@@ -218,38 +219,29 @@ export async function POST(request: Request): Promise<Response> {
 	const safeFileName = fileName.trim();
 	const year = getCurrentYear();
 
-	// Collaborative edit lock. This route is not tRPC, so the lock
-	// is enforced inline against the service rather than via the
-	// `declarationLockedWriteProcedure` middleware. The upload is refused when
-	// another co-declarant holds an active lock on the same declaration; a free
-	// lock (or one held by this user) lets the upload proceed. The check runs
-	// before the body is streamed so no bandwidth is wasted on a locked target.
-	const declarationRows = await db
-		.select({ id: declarations.id })
-		.from(declarations)
-		.where(and(eq(declarations.siren, siren), eq(declarations.year, year)))
-		.limit(1);
-	const lockedDeclarationId = declarationRows[0]?.id;
-	if (lockedDeclarationId) {
-		const lock = await getActiveLock(db, lockedDeclarationId);
-		if (lock && lock.userId !== userId) {
-			writeFailure({
-				action,
-				flowType,
-				fileName,
-				fileId: null,
-				errorMessage: "HTTP 409 locked_by_other",
-				userId,
-				userEmail,
-				siren,
-				requestContext,
-				startedAt,
-			});
-			return Response.json(
-				{ error: DECLARATION_LOCK_CONFLICT_MESSAGE },
-				{ status: 409 },
-			);
+	// Before the body is streamed: no bandwidth wasted on a locked target.
+	try {
+		await assertDeclarationUnlockedForWrite(db, siren, session.user.id);
+	} catch (error) {
+		if (!(error instanceof DeclarationLockedByOtherUserError)) {
+			throw error;
 		}
+		writeFailure({
+			action,
+			flowType,
+			fileName,
+			fileId: null,
+			errorMessage: "HTTP 409 locked_by_other",
+			userId,
+			userEmail,
+			siren,
+			requestContext,
+			startedAt,
+		});
+		return Response.json(
+			{ error: DECLARATION_LOCK_CONFLICT_MESSAGE },
+			{ status: 409 },
+		);
 	}
 
 	let result: UploadPipelineResult;

--- a/packages/app/src/server/api/routers/declarationHelpers.ts
+++ b/packages/app/src/server/api/routers/declarationHelpers.ts
@@ -22,6 +22,16 @@ export function activeDeclarationFilter(siren: string, year: number) {
 	);
 }
 
+/**
+ * Contrairement à `activeDeclarationFilter`, n'exclut **pas** les déclarations
+ * annulées : c'est la ligne que le pipeline d'upload écrit réellement. Le garde
+ * de verrou doit résoudre exactement celle-là, sinon il verrouille une
+ * déclaration pendant que l'écriture en touche une autre.
+ */
+export function currentDeclarationFilter(siren: string, year: number) {
+	return and(eq(declarations.siren, siren), eq(declarations.year, year));
+}
+
 /** Minimal structural contract for `select().from(table)…limit(n)` on a single table. */
 type SelectTx<Table, Row> = {
 	select: () => {

--- a/packages/app/src/server/api/routers/declarationHelpers.ts
+++ b/packages/app/src/server/api/routers/declarationHelpers.ts
@@ -22,16 +22,6 @@ export function activeDeclarationFilter(siren: string, year: number) {
 	);
 }
 
-/**
- * Contrairement à `activeDeclarationFilter`, n'exclut **pas** les déclarations
- * annulées : c'est la ligne que le pipeline d'upload écrit réellement. Le garde
- * de verrou doit résoudre exactement celle-là, sinon il verrouille une
- * déclaration pendant que l'écriture en touche une autre.
- */
-export function currentDeclarationFilter(siren: string, year: number) {
-	return and(eq(declarations.siren, siren), eq(declarations.year, year));
-}
-
 /** Minimal structural contract for `select().from(table)…limit(n)` on a single table. */
 type SelectTx<Table, Row> = {
 	select: () => {

--- a/packages/app/src/server/db/__tests__/declarationConditions.test.ts
+++ b/packages/app/src/server/db/__tests__/declarationConditions.test.ts
@@ -1,8 +1,10 @@
+import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 
 import {
 	notCancelledCondition,
+	resolveCurrentDeclarationId,
 	submittedDeclarationCondition,
 } from "../declarationConditions";
 
@@ -28,5 +30,67 @@ describe("notCancelledCondition", () => {
 		expect(sql).toContain("cancelled_at");
 		expect(sql.toLowerCase()).toContain("is null");
 		expect(params).toEqual([]);
+	});
+});
+
+describe("resolveCurrentDeclarationId", () => {
+	function stubDb(rows: { id: string }[]) {
+		const captured: { where?: SQL; orderBy?: SQL[] } = {};
+		const chain = {
+			from: () => chain,
+			where: (clause: SQL) => {
+				captured.where = clause;
+				return chain;
+			},
+			orderBy: (...clauses: SQL[]) => {
+				captured.orderBy = clauses;
+				return chain;
+			},
+			limit: () => Promise.resolve(rows),
+		};
+		return { db: { select: () => chain }, captured };
+	}
+
+	// This ordering is the correctness argument of the lock guard: the guard and
+	// `uploadPipeline` each run their own query, and the unique index on
+	// (siren, year) is partial, so several cancelled rows may share the pair.
+	// Without a deterministic order the two lookups can land on different rows.
+	it("orders the active declaration first, then the most recent", async () => {
+		const { db, captured } = stubDb([{ id: "decl-1" }]);
+
+		await resolveCurrentDeclarationId(db as never, "123456789", 2026);
+
+		const rendered = (captured.orderBy ?? []).map((clause) =>
+			dialect.sqlToQuery(clause).sql.toLowerCase(),
+		);
+		expect(rendered).toHaveLength(2);
+		expect(rendered[0]).toContain("cancelled_at");
+		expect(rendered[0]).toContain("is null desc");
+		expect(rendered[1]).toContain("created_at");
+		expect(rendered[1]).toContain("desc");
+	});
+
+	it("scopes on siren and year without excluding cancelled declarations", async () => {
+		const { db, captured } = stubDb([]);
+
+		await resolveCurrentDeclarationId(db as never, "123456789", 2026);
+
+		const { sql, params } = dialect.sqlToQuery(captured.where as SQL);
+		expect(sql).toContain("siren");
+		expect(sql).toContain("year");
+		expect(sql.toLowerCase()).not.toContain("cancelled_at");
+		expect(params).toEqual(["123456789", 2026]);
+	});
+
+	it("returns the resolved id, or null when the pair has no declaration", async () => {
+		const found = stubDb([{ id: "decl-1" }]);
+		const empty = stubDb([]);
+
+		await expect(
+			resolveCurrentDeclarationId(found.db as never, "123456789", 2026),
+		).resolves.toBe("decl-1");
+		await expect(
+			resolveCurrentDeclarationId(empty.db as never, "123456789", 2026),
+		).resolves.toBeNull();
 	});
 });

--- a/packages/app/src/server/db/__tests__/declarationConditions.test.ts
+++ b/packages/app/src/server/db/__tests__/declarationConditions.test.ts
@@ -54,8 +54,9 @@ describe("resolveCurrentDeclarationId", () => {
 	// This ordering is the correctness argument of the lock guard: the guard and
 	// `uploadPipeline` each run their own query, and the unique index on
 	// (siren, year) is partial, so several cancelled rows may share the pair.
-	// Without a deterministic order the two lookups can land on different rows.
-	it("orders the active declaration first, then the most recent", async () => {
+	// The order has to be total — a tie would hand the two lookups different
+	// rows, which is the divergence the guard exists to prevent.
+	it("orders by active, then most recent, then id to break every tie", async () => {
 		const { db, captured } = stubDb([{ id: "decl-1" }]);
 
 		await resolveCurrentDeclarationId(db as never, "123456789", 2026);
@@ -63,11 +64,16 @@ describe("resolveCurrentDeclarationId", () => {
 		const rendered = (captured.orderBy ?? []).map((clause) =>
 			dialect.sqlToQuery(clause).sql.toLowerCase(),
 		);
-		expect(rendered).toHaveLength(2);
+		expect(rendered).toHaveLength(3);
 		expect(rendered[0]).toContain("cancelled_at");
 		expect(rendered[0]).toContain("is null desc");
 		expect(rendered[1]).toContain("created_at");
 		expect(rendered[1]).toContain("desc");
+		// `createdAt` is nullable and DESC puts NULLs first: an undated row would
+		// otherwise outrank every dated one.
+		expect(rendered[1]).toContain("nulls last");
+		expect(rendered[2]).toContain("id");
+		expect(rendered[2]).toContain("desc");
 	});
 
 	it("scopes on siren and year without excluding cancelled declarations", async () => {

--- a/packages/app/src/server/db/declarationConditions.ts
+++ b/packages/app/src/server/db/declarationConditions.ts
@@ -1,6 +1,10 @@
-import { isNull, ne } from "drizzle-orm";
+import { and, desc, eq, isNull, ne, sql } from "drizzle-orm";
 
+import type { DB } from "./index";
 import { declarations } from "./schema";
+
+type Tx = Parameters<Parameters<DB["transaction"]>[0]>[0];
+type DbOrTx = DB | Tx;
 
 /**
  * SQL mirrors of the domain declaration predicates. Drizzle builds SQL and
@@ -19,4 +23,41 @@ export function submittedDeclarationCondition() {
 /** Drizzle condition mirroring `isCancelled` (negated): the declaration is not cancelled. */
 export function notCancelledCondition() {
 	return isNull(declarations.cancelledAt);
+}
+
+/**
+ * Le couple (siren, année), **sans** exclure les déclarations annulées —
+ * l'exact opposé délibéré d'`activeDeclarationFilter`. C'est ce que le pipeline
+ * d'upload écrit, donc ce que son garde de verrou doit inspecter.
+ */
+export function currentDeclarationFilter(siren: string, year: number) {
+	return and(eq(declarations.siren, siren), eq(declarations.year, year));
+}
+
+/**
+ * La ligne que `/api/upload` écrit réellement, résolue de façon déterministe.
+ *
+ * L'index unique sur (siren, année) est **partiel** — `WHERE cancelled_at IS
+ * NULL` —, donc plusieurs déclarations annulées peuvent partager le couple, et
+ * un `LIMIT 1` sans ordre rendrait une ligne arbitraire. Deux requêtes non
+ * ordonnées portant le même filtre peuvent rendre deux lignes différentes : le
+ * garde de verrou et l'écriture qu'il protège doivent partager ce résolveur,
+ * pas seulement leur filtre. L'ordre fait gagner la déclaration active, puis la
+ * plus récente.
+ */
+export async function resolveCurrentDeclarationId(
+	db: DbOrTx,
+	siren: string,
+	year: number,
+): Promise<string | null> {
+	const rows = await db
+		.select({ id: declarations.id })
+		.from(declarations)
+		.where(currentDeclarationFilter(siren, year))
+		.orderBy(
+			sql`${declarations.cancelledAt} is null desc`,
+			desc(declarations.createdAt),
+		)
+		.limit(1);
+	return rows[0]?.id ?? null;
 }

--- a/packages/app/src/server/db/declarationConditions.ts
+++ b/packages/app/src/server/db/declarationConditions.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { and, desc, eq, isNull, ne, sql } from "drizzle-orm";
 
 import type { DB } from "./index";
@@ -43,8 +45,14 @@ function currentDeclarationFilter(siren: string, year: number) {
  * un `LIMIT 1` sans ordre rendrait une ligne arbitraire. Deux requêtes non
  * ordonnées portant le même filtre peuvent rendre deux lignes différentes : le
  * garde de verrou et l'écriture qu'il protège doivent partager ce résolveur,
- * pas seulement leur filtre. L'ordre fait gagner la déclaration active, puis la
- * plus récente.
+ * pas seulement leur filtre.
+ *
+ * L'ordre doit être **total**, sinon il ne décide rien dans les cas où il est
+ * justement sollicité : la déclaration active gagne, puis la plus récente, puis
+ * l'`id` — clé finale unique, sans laquelle deux lignes annulées de même
+ * `createdAt` laisseraient le choix à Postgres. `createdAt` est nullable, et un
+ * `DESC` place les NULL en tête : `nulls last` renvoie les lignes sans date au
+ * fond, là où « la plus récente » les attend.
  */
 export async function resolveCurrentDeclarationId(
 	db: DbOrTx,
@@ -57,7 +65,8 @@ export async function resolveCurrentDeclarationId(
 		.where(currentDeclarationFilter(siren, year))
 		.orderBy(
 			sql`${declarations.cancelledAt} is null desc`,
-			desc(declarations.createdAt),
+			sql`${declarations.createdAt} desc nulls last`,
+			desc(declarations.id),
 		)
 		.limit(1);
 	return rows[0]?.id ?? null;

--- a/packages/app/src/server/db/declarationConditions.ts
+++ b/packages/app/src/server/db/declarationConditions.ts
@@ -27,10 +27,11 @@ export function notCancelledCondition() {
 
 /**
  * Le couple (siren, année), **sans** exclure les déclarations annulées —
- * l'exact opposé délibéré d'`activeDeclarationFilter`. C'est ce que le pipeline
- * d'upload écrit, donc ce que son garde de verrou doit inspecter.
+ * l'exact opposé délibéré d'`activeDeclarationFilter`. Volontairement privé :
+ * la propriété de sûreté repose sur le résolveur ci-dessous, pas sur le filtre,
+ * et un second appelant du filtre seul rouvrirait la divergence.
  */
-export function currentDeclarationFilter(siren: string, year: number) {
+function currentDeclarationFilter(siren: string, year: number) {
 	return and(eq(declarations.siren, siren), eq(declarations.year, year));
 }
 

--- a/packages/app/src/server/services/__tests__/declarationLockService.test.ts
+++ b/packages/app/src/server/services/__tests__/declarationLockService.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCurrentYear } from "~/modules/domain";
 
 vi.mock("~/server/db", () => ({ db: {} }));
 
@@ -17,9 +18,17 @@ vi.mock("~/server/db/schema", () => ({
 		firstName: "firstName",
 		lastName: "lastName",
 	},
+	declarations: { id: "id" },
+}));
+
+const CURRENT_DECLARATION_FILTER = Symbol("currentDeclarationFilter");
+
+vi.mock("~/server/api/routers/declarationHelpers", () => ({
+	currentDeclarationFilter: vi.fn(() => CURRENT_DECLARATION_FILTER),
 }));
 
 const DECLARATION_ID = "decl-1";
+const SIREN = "123456789";
 const USER_ID = "user-1";
 const TIMEOUT_MINUTES = 30;
 const NOW = new Date("2025-06-23T10:00:00.000Z");
@@ -96,6 +105,95 @@ describe("getActiveLock", () => {
 		const { getActiveLock } = await service();
 
 		expect(await getActiveLock(select as never, DECLARATION_ID)).toBeNull();
+	});
+});
+
+describe("assertDeclarationUnlockedForWrite", () => {
+	function guardDb(declarationRows: unknown[], lockRows: unknown[]) {
+		const declarationWhere = vi
+			.fn()
+			.mockReturnValue({ limit: vi.fn().mockResolvedValue(declarationRows) });
+		const innerJoin = vi.fn().mockReturnValue({
+			where: vi
+				.fn()
+				.mockReturnValue({ limit: vi.fn().mockResolvedValue(lockRows) }),
+		});
+		const from = vi
+			.fn()
+			.mockReturnValueOnce({ where: declarationWhere })
+			.mockReturnValue({ innerJoin });
+		return {
+			db: { select: vi.fn().mockReturnValue({ from }) },
+			declarationWhere,
+		};
+	}
+
+	it("rejects when another co-declarant holds an active lock", async () => {
+		const { db } = guardDb(
+			[{ id: DECLARATION_ID }],
+			[{ ...HOLDER, userId: "user-2" }],
+		);
+		const {
+			assertDeclarationUnlockedForWrite,
+			DeclarationLockedByOtherUserError,
+		} = await service();
+
+		await expect(
+			assertDeclarationUnlockedForWrite(db as never, SIREN, USER_ID),
+		).rejects.toBeInstanceOf(DeclarationLockedByOtherUserError);
+	});
+
+	it("resolves when no active lock is held", async () => {
+		const { db } = guardDb([{ id: DECLARATION_ID }], []);
+		const { assertDeclarationUnlockedForWrite } = await service();
+
+		await expect(
+			assertDeclarationUnlockedForWrite(db as never, SIREN, USER_ID),
+		).resolves.toBeUndefined();
+	});
+
+	it("resolves when the caller already holds the lock", async () => {
+		const { db } = guardDb([{ id: DECLARATION_ID }], [HOLDER]);
+		const { assertDeclarationUnlockedForWrite } = await service();
+
+		await expect(
+			assertDeclarationUnlockedForWrite(db as never, SIREN, USER_ID),
+		).resolves.toBeUndefined();
+	});
+
+	it("resolves through the same filter the upload pipeline writes through", async () => {
+		const { db, declarationWhere } = guardDb([], []);
+		const { currentDeclarationFilter } = await import(
+			"~/server/api/routers/declarationHelpers"
+		);
+		const { assertDeclarationUnlockedForWrite } = await service();
+
+		await expect(
+			assertDeclarationUnlockedForWrite(db as never, SIREN, USER_ID),
+		).resolves.toBeUndefined();
+		expect(currentDeclarationFilter).toHaveBeenCalledWith(
+			SIREN,
+			getCurrentYear(),
+		);
+		expect(declarationWhere).toHaveBeenCalledWith(CURRENT_DECLARATION_FILTER);
+		expect(db.select).toHaveBeenCalledTimes(1);
+	});
+
+	// Scoping this lookup to active declarations only would make the guard blind
+	// to a cancelled row that `uploadPipeline` still resolves and writes to.
+	it("still rejects when a cancelled declaration is locked by another user", async () => {
+		const { db } = guardDb(
+			[{ id: DECLARATION_ID }],
+			[{ ...HOLDER, userId: "user-2" }],
+		);
+		const {
+			assertDeclarationUnlockedForWrite,
+			DeclarationLockedByOtherUserError,
+		} = await service();
+
+		await expect(
+			assertDeclarationUnlockedForWrite(db as never, SIREN, USER_ID),
+		).rejects.toBeInstanceOf(DeclarationLockedByOtherUserError);
 	});
 });
 

--- a/packages/app/src/server/services/__tests__/declarationLockService.test.ts
+++ b/packages/app/src/server/services/__tests__/declarationLockService.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getCurrentYear } from "~/modules/domain";
 
 vi.mock("~/server/db", () => ({ db: {} }));
 
@@ -18,13 +17,10 @@ vi.mock("~/server/db/schema", () => ({
 		firstName: "firstName",
 		lastName: "lastName",
 	},
-	declarations: { id: "id" },
 }));
 
-const CURRENT_DECLARATION_FILTER = Symbol("currentDeclarationFilter");
-
-vi.mock("~/server/api/routers/declarationHelpers", () => ({
-	currentDeclarationFilter: vi.fn(() => CURRENT_DECLARATION_FILTER),
+vi.mock("~/server/db/declarationConditions", () => ({
+	resolveCurrentDeclarationId: vi.fn(),
 }));
 
 const DECLARATION_ID = "decl-1";
@@ -109,91 +105,95 @@ describe("getActiveLock", () => {
 });
 
 describe("assertDeclarationUnlockedForWrite", () => {
-	function guardDb(declarationRows: unknown[], lockRows: unknown[]) {
-		const declarationWhere = vi
-			.fn()
-			.mockReturnValue({ limit: vi.fn().mockResolvedValue(declarationRows) });
-		const innerJoin = vi.fn().mockReturnValue({
-			where: vi
-				.fn()
-				.mockReturnValue({ limit: vi.fn().mockResolvedValue(lockRows) }),
-		});
-		const from = vi
-			.fn()
-			.mockReturnValueOnce({ where: declarationWhere })
-			.mockReturnValue({ innerJoin });
+	const YEAR = 2026;
+
+	async function helpers() {
+		return await import("~/server/db/declarationConditions");
+	}
+
+	function lockDb(lockRows: unknown[]) {
 		return {
-			db: { select: vi.fn().mockReturnValue({ from }) },
-			declarationWhere,
+			select: vi.fn().mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					innerJoin: vi.fn().mockReturnValue({
+						where: vi
+							.fn()
+							.mockReturnValue({ limit: vi.fn().mockResolvedValue(lockRows) }),
+					}),
+				}),
+			}),
 		};
 	}
 
 	it("rejects when another co-declarant holds an active lock", async () => {
-		const { db } = guardDb(
-			[{ id: DECLARATION_ID }],
-			[{ ...HOLDER, userId: "user-2" }],
-		);
+		const { resolveCurrentDeclarationId } = await helpers();
+		vi.mocked(resolveCurrentDeclarationId).mockResolvedValue(DECLARATION_ID);
+		const db = lockDb([{ ...HOLDER, userId: "user-2" }]);
 		const {
 			assertDeclarationUnlockedForWrite,
 			DeclarationLockedByOtherUserError,
 		} = await service();
 
 		await expect(
-			assertDeclarationUnlockedForWrite(db as never, SIREN, USER_ID),
+			assertDeclarationUnlockedForWrite(db as never, SIREN, YEAR, USER_ID),
 		).rejects.toBeInstanceOf(DeclarationLockedByOtherUserError);
 	});
 
 	it("resolves when no active lock is held", async () => {
-		const { db } = guardDb([{ id: DECLARATION_ID }], []);
+		const { resolveCurrentDeclarationId } = await helpers();
+		vi.mocked(resolveCurrentDeclarationId).mockResolvedValue(DECLARATION_ID);
 		const { assertDeclarationUnlockedForWrite } = await service();
 
 		await expect(
-			assertDeclarationUnlockedForWrite(db as never, SIREN, USER_ID),
+			assertDeclarationUnlockedForWrite(
+				lockDb([]) as never,
+				SIREN,
+				YEAR,
+				USER_ID,
+			),
 		).resolves.toBeUndefined();
 	});
 
 	it("resolves when the caller already holds the lock", async () => {
-		const { db } = guardDb([{ id: DECLARATION_ID }], [HOLDER]);
+		const { resolveCurrentDeclarationId } = await helpers();
+		vi.mocked(resolveCurrentDeclarationId).mockResolvedValue(DECLARATION_ID);
 		const { assertDeclarationUnlockedForWrite } = await service();
 
 		await expect(
-			assertDeclarationUnlockedForWrite(db as never, SIREN, USER_ID),
+			assertDeclarationUnlockedForWrite(
+				lockDb([HOLDER]) as never,
+				SIREN,
+				YEAR,
+				USER_ID,
+			),
 		).resolves.toBeUndefined();
 	});
 
-	it("resolves through the same filter the upload pipeline writes through", async () => {
-		const { db, declarationWhere } = guardDb([], []);
-		const { currentDeclarationFilter } = await import(
-			"~/server/api/routers/declarationHelpers"
-		);
+	// The guard must land on the row `uploadPipeline` writes to. Sharing the
+	// filter is not enough — the unique index on (siren, year) is partial, so an
+	// unordered lookup can return a different row on each call.
+	it("delegates row resolution to the resolver the write path uses", async () => {
+		const { resolveCurrentDeclarationId } = await helpers();
+		vi.mocked(resolveCurrentDeclarationId).mockResolvedValue(null);
+		const db = lockDb([]);
 		const { assertDeclarationUnlockedForWrite } = await service();
 
 		await expect(
-			assertDeclarationUnlockedForWrite(db as never, SIREN, USER_ID),
+			assertDeclarationUnlockedForWrite(db as never, SIREN, YEAR, USER_ID),
 		).resolves.toBeUndefined();
-		expect(currentDeclarationFilter).toHaveBeenCalledWith(
-			SIREN,
-			getCurrentYear(),
-		);
-		expect(declarationWhere).toHaveBeenCalledWith(CURRENT_DECLARATION_FILTER);
-		expect(db.select).toHaveBeenCalledTimes(1);
+		expect(resolveCurrentDeclarationId).toHaveBeenCalledWith(db, SIREN, YEAR);
+		expect(db.select).not.toHaveBeenCalled();
 	});
 
-	// Scoping this lookup to active declarations only would make the guard blind
-	// to a cancelled row that `uploadPipeline` still resolves and writes to.
-	it("still rejects when a cancelled declaration is locked by another user", async () => {
-		const { db } = guardDb(
-			[{ id: DECLARATION_ID }],
-			[{ ...HOLDER, userId: "user-2" }],
-		);
-		const {
-			assertDeclarationUnlockedForWrite,
-			DeclarationLockedByOtherUserError,
-		} = await service();
+	it("guards the year it is given rather than re-deriving one", async () => {
+		const { resolveCurrentDeclarationId } = await helpers();
+		vi.mocked(resolveCurrentDeclarationId).mockResolvedValue(DECLARATION_ID);
+		const db = lockDb([]);
+		const { assertDeclarationUnlockedForWrite } = await service();
 
-		await expect(
-			assertDeclarationUnlockedForWrite(db as never, SIREN, USER_ID),
-		).rejects.toBeInstanceOf(DeclarationLockedByOtherUserError);
+		await assertDeclarationUnlockedForWrite(db as never, SIREN, 2024, USER_ID);
+
+		expect(resolveCurrentDeclarationId).toHaveBeenCalledWith(db, SIREN, 2024);
 	});
 });
 

--- a/packages/app/src/server/services/__tests__/uploadPipeline.test.ts
+++ b/packages/app/src/server/services/__tests__/uploadPipeline.test.ts
@@ -46,6 +46,10 @@ vi.mock("drizzle-orm", () => ({
 	and: (...args: unknown[]) => ({ op: "and", args }),
 	eq: (...args: unknown[]) => ({ op: "eq", args }),
 	count: () => ({ op: "count" }),
+	desc: (column: unknown) => ({ op: "desc", column }),
+	isNull: (column: unknown) => ({ op: "isNull", column }),
+	ne: (...args: unknown[]) => ({ op: "ne", args }),
+	sql: (...args: unknown[]) => ({ op: "sql", args }),
 }));
 
 function createStream(): ReadableStream<Uint8Array> {
@@ -77,15 +81,13 @@ function primeDbSelect(steps: Step[]) {
 					if (step?.kind === "count") {
 						return Promise.resolve([{ value: step.value }]);
 					}
-					// Declaration lookup path chains `.limit(1)` before await.
-					return {
-						limit: () =>
-							Promise.resolve(
-								step?.kind === "declaration" && step.id !== undefined
-									? [{ id: step.id }]
-									: [],
-							),
-					};
+					// Declaration lookup path chains `.orderBy().limit(1)` before await.
+					const rows =
+						step?.kind === "declaration" && step.id !== undefined
+							? [{ id: step.id }]
+							: [];
+					const limit = { limit: () => Promise.resolve(rows) };
+					return { ...limit, orderBy: () => limit };
 				},
 			}),
 		};

--- a/packages/app/src/server/services/__tests__/uploadPipeline.test.ts
+++ b/packages/app/src/server/services/__tests__/uploadPipeline.test.ts
@@ -81,13 +81,17 @@ function primeDbSelect(steps: Step[]) {
 					if (step?.kind === "count") {
 						return Promise.resolve([{ value: step.value }]);
 					}
-					// Declaration lookup path chains `.orderBy().limit(1)` before await.
+					// Declaration lookup path chains `.orderBy().limit(1)` before
+					// await. `.limit()` is deliberately unreachable without
+					// `.orderBy()`: an unordered lookup here would resolve a
+					// different row than the lock guard, and must break loudly.
 					const rows =
 						step?.kind === "declaration" && step.id !== undefined
 							? [{ id: step.id }]
 							: [];
-					const limit = { limit: () => Promise.resolve(rows) };
-					return { ...limit, orderBy: () => limit };
+					return {
+						orderBy: () => ({ limit: () => Promise.resolve(rows) }),
+					};
 				},
 			}),
 		};

--- a/packages/app/src/server/services/declarationLockService.ts
+++ b/packages/app/src/server/services/declarationLockService.ts
@@ -2,13 +2,10 @@ import "server-only";
 
 import { and, eq, gt, lte, or } from "drizzle-orm";
 
-import {
-	DECLARATION_LOCK_CONFLICT_MESSAGE,
-	getCurrentYear,
-} from "~/modules/domain";
-import { currentDeclarationFilter } from "~/server/api/routers/declarationHelpers";
+import { DECLARATION_LOCK_CONFLICT_MESSAGE } from "~/modules/domain";
 import type { DB } from "~/server/db";
-import { declarationLocks, declarations, users } from "~/server/db/schema";
+import { resolveCurrentDeclarationId } from "~/server/db/declarationConditions";
+import { declarationLocks, users } from "~/server/db/schema";
 
 type Tx = Parameters<Parameters<DB["transaction"]>[0]>[0];
 
@@ -103,25 +100,23 @@ export class DeclarationLockedByOtherUserError extends Error {
  * — or a declaration that does not exist yet — lets the write through. Merging
  * the two intentions into one function would break `/api/upload`.
  *
- * Resolves through `currentDeclarationFilter`, the same filter `uploadPipeline`
- * uses, cancelled rows included. Scoping the guard to active declarations only
- * would let a write onto a cancelled-but-locked declaration slip past.
+ * Resolves through `resolveCurrentDeclarationId`, the same resolver
+ * `uploadPipeline` writes through — sharing only a filter would not do: the
+ * unique index on (siren, year) is partial, so an unordered `LIMIT 1` can hand
+ * the guard a different row than the one the write lands on. `year` is a
+ * parameter for the same reason: deriving it here would let a caller guard one
+ * year while writing to another.
  */
 export async function assertDeclarationUnlockedForWrite(
 	db: DbClient,
 	siren: string,
+	year: number,
 	userId: string,
 ): Promise<void> {
-	const rows = await db
-		.select({ id: declarations.id })
-		.from(declarations)
-		.where(currentDeclarationFilter(siren, getCurrentYear()))
-		.limit(1);
+	const declarationId = await resolveCurrentDeclarationId(db, siren, year);
+	if (!declarationId) return;
 
-	const declaration = rows[0];
-	if (!declaration) return;
-
-	const lock = await getActiveLock(db, declaration.id);
+	const lock = await getActiveLock(db, declarationId);
 	if (lock && lock.userId !== userId) {
 		throw new DeclarationLockedByOtherUserError();
 	}

--- a/packages/app/src/server/services/declarationLockService.ts
+++ b/packages/app/src/server/services/declarationLockService.ts
@@ -2,8 +2,13 @@ import "server-only";
 
 import { and, eq, gt, lte, or } from "drizzle-orm";
 
+import {
+	DECLARATION_LOCK_CONFLICT_MESSAGE,
+	getCurrentYear,
+} from "~/modules/domain";
+import { currentDeclarationFilter } from "~/server/api/routers/declarationHelpers";
 import type { DB } from "~/server/db";
-import { declarationLocks, users } from "~/server/db/schema";
+import { declarationLocks, declarations, users } from "~/server/db/schema";
 
 type Tx = Parameters<Parameters<DB["transaction"]>[0]>[0];
 
@@ -83,6 +88,43 @@ export async function getLockReadState(
 			email: activeLock.email,
 		},
 	};
+}
+
+export class DeclarationLockedByOtherUserError extends Error {
+	constructor() {
+		super(DECLARATION_LOCK_CONFLICT_MESSAGE);
+		this.name = "DeclarationLockedByOtherUserError";
+	}
+}
+
+/**
+ * Deliberately looser than `declarationLockedWriteProcedure`, which demands a
+ * lock **owned by the caller**: REST clients never acquire one, so a free lock
+ * — or a declaration that does not exist yet — lets the write through. Merging
+ * the two intentions into one function would break `/api/upload`.
+ *
+ * Resolves through `currentDeclarationFilter`, the same filter `uploadPipeline`
+ * uses, cancelled rows included. Scoping the guard to active declarations only
+ * would let a write onto a cancelled-but-locked declaration slip past.
+ */
+export async function assertDeclarationUnlockedForWrite(
+	db: DbClient,
+	siren: string,
+	userId: string,
+): Promise<void> {
+	const rows = await db
+		.select({ id: declarations.id })
+		.from(declarations)
+		.where(currentDeclarationFilter(siren, getCurrentYear()))
+		.limit(1);
+
+	const declaration = rows[0];
+	if (!declaration) return;
+
+	const lock = await getActiveLock(db, declaration.id);
+	if (lock && lock.userId !== userId) {
+		throw new DeclarationLockedByOtherUserError();
+	}
 }
 
 /**

--- a/packages/app/src/server/services/uploadPipeline.ts
+++ b/packages/app/src/server/services/uploadPipeline.ts
@@ -8,8 +8,8 @@ import {
 	type FlowType,
 	UPLOAD_REQUEST_TIMEOUT_MS,
 } from "~/modules/shared/uploadConfig";
-import { currentDeclarationFilter } from "~/server/api/routers/declarationHelpers";
 import { db } from "~/server/db";
+import { resolveCurrentDeclarationId } from "~/server/db/declarationConditions";
 import { declarations, files } from "~/server/db/schema";
 
 import { getRequiredContentTypes } from "./cseRequiredContentTypes";
@@ -208,12 +208,8 @@ async function findCurrentDeclaration(
 	siren: string,
 	year: number,
 ): Promise<{ id: string } | null> {
-	const rows = await db
-		.select({ id: declarations.id })
-		.from(declarations)
-		.where(currentDeclarationFilter(siren, year))
-		.limit(1);
-	return rows[0] ?? null;
+	const id = await resolveCurrentDeclarationId(db, siren, year);
+	return id === null ? null : { id };
 }
 
 async function countFilesByType(

--- a/packages/app/src/server/services/uploadPipeline.ts
+++ b/packages/app/src/server/services/uploadPipeline.ts
@@ -8,6 +8,7 @@ import {
 	type FlowType,
 	UPLOAD_REQUEST_TIMEOUT_MS,
 } from "~/modules/shared/uploadConfig";
+import { currentDeclarationFilter } from "~/server/api/routers/declarationHelpers";
 import { db } from "~/server/db";
 import { declarations, files } from "~/server/db/schema";
 
@@ -210,7 +211,7 @@ async function findCurrentDeclaration(
 	const rows = await db
 		.select({ id: declarations.id })
 		.from(declarations)
-		.where(and(eq(declarations.siren, siren), eq(declarations.year, year)))
+		.where(currentDeclarationFilter(siren, year))
 		.limit(1);
 	return rows[0] ?? null;
 }


### PR DESCRIPTION
Closes #3763

Le contrôle de verrou collaboratif de `POST /api/upload` était écrit inline dans la route (`upload/route.ts:217-253`), en doublon conceptuel du middleware tRPC `declarationLockedWriteProcedure`. Il est extrait dans un garde nommé, `assertDeclarationUnlockedForWrite`, à côté des autres primitives de verrou.

## Deux intentions, deux fonctions — la fusion aurait cassé l'upload

Le check REST et le middleware tRPC ne disent pas la même chose. Les factoriser en une seule fonction était le piège de ce ticket :

| | tRPC `declarationLockedWriteProcedure` | `/api/upload` |
|---|---|---|
| Verrou absent | rejette (`CONFLICT`) | laisse passer |
| Déclaration absente | `NOT_FOUND` | laisse passer |

Les clients REST n'acquièrent jamais de verrou : exiger « un verrou tenu par l'appelant » aurait refusé tous les uploads. Le garde porte donc explicitement la sémantique REST — « refuse si un *autre* co-déclarant tient un verrou actif » — et le middleware tRPC garde la sienne, plus stricte.

## Contrat client : trois sémantiques préservées, une cible d'écriture précisée

Les trois sémantiques REST sont préservées à l'identique : verrou absent → passe, déclaration absente → passe, déclaration annulée → toujours gardée.

**Un comportement change, et il faut le dire.** Quand un couple (siren, année) porte à la fois une déclaration active et une ou plusieurs annulées, `uploadPipeline` prenait jusqu'ici une ligne **arbitraire** — `LIMIT 1` sans `ORDER BY`. Il prend désormais l'active. Ce n'est pas un effet de bord du refactor mais sa condition : sans cible déterministe, aucun garde ne peut promettre de vérifier le verrou de la ligne qui sera écrite. L'ancien comportement n'était pas un contrat, c'était l'absence de contrat.

## Le garde et l'écriture résolvent la même ligne

Le garde vérifie un verrou sur une déclaration ; `uploadPipeline` en écrit une. Si les deux ne résolvent pas la même ligne, le contrôle de concurrence garde l'une pendant que l'écriture touche l'autre.

Les deux passent désormais par un **résolveur** partagé, `resolveCurrentDeclarationId` — pas seulement un filtre partagé. La nuance décide de tout : l'index unique sur (siren, année) est **partiel** (`WHERE cancelled_at IS NULL`), donc plusieurs lignes annulées peuvent partager le couple, et deux `LIMIT 1` non ordonnés portant le même filtre peuvent rendre deux lignes différentes.

L'ordre du résolveur est **total** — sans quoi il ne déciderait rien précisément dans le cas où on le sollicite : déclaration active d'abord, puis `created_at desc nulls last` (la colonne est nullable, et un `DESC` placerait sinon les lignes sans date en tête), puis `id desc` comme clé finale unique.

Scoper le garde aux seules déclarations *actives* — via `activeDeclarationFilter`, ce qui ressemblait à un durcissement — aurait ouvert un trou : une déclaration annulée mais encore verrouillée (l'annulation admin ne purge pas `declarationLocks`) devient invisible au garde, alors que `uploadPipeline` la résout et écrit dedans.

`declarationConditions` passe sous `server-only` : le module ne portait que des fragments SQL, il exécute désormais une requête.

## Tests

`declarationConditions.test.ts` exécute le **vrai** résolveur et vérifie le SQL émis via `PgDialect`, comme les gardes de parité voisins du même fichier — l'ordre est tout l'argument de correction, il devait être testé pour de bon. `declarationLockService.test.ts` couvre les trois sémantiques du garde et sa délégation au résolveur partagé. `upload/__tests__/route.test.ts` couvre le comportement HTTP observable : 409 + ligne d'audit d'échec, 200 au passage, et propagation d'une erreur inattendue au lieu d'un 409 trompeur.

Les mocks de `route.test.ts` changent — `vi.mock` remplace le module entier, donc la factory doit exposer les exports que la route importe réellement. Le chemin de module mocké, lui, est inchangé : la couverture des trois sémantiques est déplacée vers le test du service, pas supprimée.

## Reliquat

`src/server/api/routers/declarationDraft.ts:110-118` porte la même sémantique en version tRPC — prochain appelant naturel du garde, hors périmètre ici.
