### PR TITLE
feat(admin): #4462 — garde des pages /admin/** et écran de reprise de la double authentification

### DIFF
--- a/packages/app/src/__tests__/middleware.test.ts
+++ b/packages/app/src/__tests__/middleware.test.ts
@@ -16,15 +16,13 @@ vi.mock("~/env", () => ({
 	},
 }));
 
-import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
-
 import { middleware } from "~/middleware";
+import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
 
 function nowSeconds(): number {
 	return Math.floor(Date.now() / 1000);
 }
 
-/** Admin token whose two-factor authentication is `elapsed` seconds old. */
 function adminToken(elapsed: number) {
 	return { id: "u1", isAdmin: true, adminMfaAt: nowSeconds() - elapsed };
 }

--- a/packages/app/src/__tests__/middleware.test.ts
+++ b/packages/app/src/__tests__/middleware.test.ts
@@ -16,7 +16,18 @@ vi.mock("~/env", () => ({
 	},
 }));
 
+import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
+
 import { middleware } from "~/middleware";
+
+function nowSeconds(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+/** Admin token whose two-factor authentication is `elapsed` seconds old. */
+function adminToken(elapsed: number) {
+	return { id: "u1", isAdmin: true, adminMfaAt: nowSeconds() - elapsed };
+}
 
 function makeRequest(
 	pathnameAndSearch = "/admin",
@@ -75,11 +86,75 @@ describe("admin middleware", () => {
 		expect(res.headers.get("location")).toBe("http://localhost/mon-espace");
 	});
 
-	it("lets admin users through", async () => {
-		mockGetToken.mockResolvedValue({ id: "u1", isAdmin: true });
+	it("lets an admin with a two-factor authentication inside the window through", async () => {
+		mockGetToken.mockResolvedValue(adminToken(0));
 		const res = await middleware(makeRequest("/admin"));
 		// NextResponse.next() does not set a redirect location
 		expect(res.headers.get("location")).toBeNull();
+	});
+
+	it("marks the backoffice response no-store", async () => {
+		// A browser back after an expiry must not restore a backoffice page
+		// from the cache.
+		mockGetToken.mockResolvedValue(adminToken(0));
+		const res = await middleware(makeRequest("/admin/declarations"));
+		expect(res.headers.get("cache-control")).toBe("no-store");
+	});
+
+	it("sends an admin whose authentication expired to the resume screen", async () => {
+		mockGetToken.mockResolvedValue(adminToken(ADMIN_MFA_WINDOW_SECONDS + 1));
+		const res = await middleware(makeRequest("/admin/declarations"));
+		expect(res.headers.get("location")).toBe(
+			"http://localhost/acces-backoffice?retour=%2Fadmin%2Fdeclarations",
+		);
+	});
+
+	it("sends an admin with no two-factor authentication to the resume screen", async () => {
+		mockGetToken.mockResolvedValue({ id: "u1", isAdmin: true });
+		const res = await middleware(makeRequest("/admin"));
+		expect(res.headers.get("location")).toBe(
+			"http://localhost/acces-backoffice?retour=%2Fadmin",
+		);
+	});
+
+	it("carries the deep link, query string included, into the resume screen", async () => {
+		// The resume action aims back at the page the agent asked for.
+		mockGetToken.mockResolvedValue({ id: "u1", isAdmin: true });
+		const res = await middleware(
+			makeRequest("/admin/declarations/abc?onglet=historique"),
+		);
+		expect(res.headers.get("location")).toBe(
+			"http://localhost/acces-backoffice?retour=%2Fadmin%2Fdeclarations%2Fabc%3Fonglet%3Dhistorique",
+		);
+	});
+
+	it("never redirects an admin to an external site, whatever the state", async () => {
+		// The product rules out reopening ProConnect in the middle of a
+		// navigation: every refusal stays on an Egapro URL.
+		for (const token of [
+			null,
+			{ id: "u1" },
+			{ id: "u1", isAdmin: false },
+			{ id: "u1", isAdmin: true },
+			adminToken(ADMIN_MFA_WINDOW_SECONDS + 1),
+		]) {
+			mockGetToken.mockResolvedValue(token);
+			const res = await middleware(makeRequest("/admin"));
+			const location = res.headers.get("location");
+			if (location) expect(new URL(location).origin).toBe("http://localhost");
+		}
+	});
+
+	it("still turns a non-admin away silently when the second factor is fresh", async () => {
+		// Passing the second factor grants nothing on its own: without the
+		// grant, the backoffice is never even mentioned.
+		mockGetToken.mockResolvedValue({
+			id: "u1",
+			isAdmin: false,
+			adminMfaAt: nowSeconds(),
+		});
+		const res = await middleware(makeRequest("/admin"));
+		expect(res.headers.get("location")).toBe("http://localhost/mon-espace");
 	});
 });
 

--- a/packages/app/src/app/acces-backoffice/page.tsx
+++ b/packages/app/src/app/acces-backoffice/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
-import { AdminAccessPage, sanitizeAdminReturnPath } from "~/modules/admin/access";
+import {
+	AdminAccessPage,
+	sanitizeAdminReturnPath,
+} from "~/modules/admin/access";
 import { resolveAdminAccess } from "~/modules/domain";
 import { auth } from "~/server/auth";
 
@@ -11,16 +14,10 @@ type PageProps = {
 	searchParams: Promise<{ retour?: string }>;
 };
 
-/**
- * Resume screen of the backoffice two-factor authentication. It lives outside
- * `/admin` on purpose: served by a route the backoffice guard covers, it would
- * bounce against that very guard.
- *
- * It runs the same decision table as the guard, so an agent without the admin
- * grant is turned away towards `/mon-espace` exactly as they would be on
- * `/admin` — an exception here would turn the screen into the disclosure the
- * guard refuses to make.
- */
+// Outside `/admin` on purpose: under the backoffice guard, this screen would
+// bounce against that very guard. It runs the same decision table, so a user
+// without the grant is turned away exactly as on `/admin` — an exception here
+// would make this screen the disclosure the guard refuses to make.
 export default async function Page({ searchParams }: PageProps) {
 	const { retour } = await searchParams;
 	const returnPath = sanitizeAdminReturnPath(retour);

--- a/packages/app/src/app/acces-backoffice/page.tsx
+++ b/packages/app/src/app/acces-backoffice/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { AdminAccessPage, sanitizeAdminReturnPath } from "~/modules/admin/access";
+import { resolveAdminAccess } from "~/modules/domain";
+import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Accès à l'administration" };
+
+type PageProps = {
+	searchParams: Promise<{ retour?: string }>;
+};
+
+/**
+ * Resume screen of the backoffice two-factor authentication. It lives outside
+ * `/admin` on purpose: served by a route the backoffice guard covers, it would
+ * bounce against that very guard.
+ *
+ * It runs the same decision table as the guard, so an agent without the admin
+ * grant is turned away towards `/mon-espace` exactly as they would be on
+ * `/admin` — an exception here would turn the screen into the disclosure the
+ * guard refuses to make.
+ */
+export default async function Page({ searchParams }: PageProps) {
+	const { retour } = await searchParams;
+	const returnPath = sanitizeAdminReturnPath(retour);
+
+	const session = await auth();
+	const decision = resolveAdminAccess(session?.user, new Date());
+
+	if (decision.type === "login") {
+		redirect(`/login?callbackUrl=${encodeURIComponent(returnPath)}`);
+	}
+	if (decision.type === "monEspace") redirect("/mon-espace");
+	// Already authenticated at the required level: nothing to resume, the agent
+	// goes straight where they were headed.
+	if (decision.type === "allow") redirect(returnPath);
+
+	return <AdminAccessPage reason={decision.reason} returnPath={returnPath} />;
+}

--- a/packages/app/src/app/acces-backoffice/page.tsx
+++ b/packages/app/src/app/acces-backoffice/page.tsx
@@ -14,10 +14,7 @@ type PageProps = {
 	searchParams: Promise<{ retour?: string }>;
 };
 
-// Outside `/admin` on purpose: under the backoffice guard, this screen would
-// bounce against that very guard. It runs the same decision table, so a user
-// without the grant is turned away exactly as on `/admin` — an exception here
-// would make this screen the disclosure the guard refuses to make.
+// Outside `/admin` on purpose: under the backoffice guard this screen would bounce against that very guard.
 export default async function Page({ searchParams }: PageProps) {
 	const { retour } = await searchParams;
 	const returnPath = sanitizeAdminReturnPath(retour);
@@ -29,8 +26,7 @@ export default async function Page({ searchParams }: PageProps) {
 		redirect(`/login?callbackUrl=${encodeURIComponent(returnPath)}`);
 	}
 	if (decision.type === "monEspace") redirect("/mon-espace");
-	// Already authenticated at the required level: nothing to resume, the agent
-	// goes straight where they were headed.
+	// Nothing left to resume: the agent goes straight where they were headed.
 	if (decision.type === "allow") redirect(returnPath);
 
 	return <AdminAccessPage reason={decision.reason} returnPath={returnPath} />;

--- a/packages/app/src/app/admin/layout.tsx
+++ b/packages/app/src/app/admin/layout.tsx
@@ -2,17 +2,28 @@ import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 
 import { AdminShell } from "~/modules/admin";
+import { resolveAdminAccess } from "~/modules/domain";
 import { auth } from "~/server/auth";
 
+/**
+ * Node-runtime guard of the backoffice, running the same decision table as the
+ * Edge middleware — defense in depth, never the only barrier.
+ *
+ * It does not know which path was requested (a layout receives no pathname), so
+ * the resume screen falls back to `/admin` here. The middleware, which does
+ * know, is what preserves the deep link in the normal path.
+ */
 export default async function AdminLayout({
 	children,
 }: {
 	children: ReactNode;
 }) {
 	const session = await auth();
+	const decision = resolveAdminAccess(session?.user, new Date());
 
-	if (!session?.user) redirect("/login");
-	if (!session.user.isAdmin) redirect("/mon-espace");
+	if (decision.type === "login") redirect("/login");
+	if (decision.type === "monEspace") redirect("/mon-espace");
+	if (decision.type === "resume") redirect("/acces-backoffice");
 
 	return <AdminShell>{children}</AdminShell>;
 }

--- a/packages/app/src/app/admin/layout.tsx
+++ b/packages/app/src/app/admin/layout.tsx
@@ -5,14 +5,9 @@ import { AdminShell } from "~/modules/admin";
 import { resolveAdminAccess } from "~/modules/domain";
 import { auth } from "~/server/auth";
 
-/**
- * Node-runtime guard of the backoffice, running the same decision table as the
- * Edge middleware — defense in depth, never the only barrier.
- *
- * It does not know which path was requested (a layout receives no pathname), so
- * the resume screen falls back to `/admin` here. The middleware, which does
- * know, is what preserves the deep link in the normal path.
- */
+// Defense in depth behind the Edge middleware, on the same decision table.
+// A layout receives no pathname, so the resume screen falls back to `/admin`
+// here; the middleware, which knows it, preserves the deep link.
 export default async function AdminLayout({
 	children,
 }: {

--- a/packages/app/src/app/admin/layout.tsx
+++ b/packages/app/src/app/admin/layout.tsx
@@ -5,9 +5,7 @@ import { AdminShell } from "~/modules/admin";
 import { resolveAdminAccess } from "~/modules/domain";
 import { auth } from "~/server/auth";
 
-// Defense in depth behind the Edge middleware, on the same decision table.
-// A layout receives no pathname, so the resume screen falls back to `/admin`
-// here; the middleware, which knows it, preserves the deep link.
+// Defense in depth behind the Edge middleware; a layout receives no pathname, hence the `/admin` fallback on resume.
 export default async function AdminLayout({
 	children,
 }: {

--- a/packages/app/src/middleware.ts
+++ b/packages/app/src/middleware.ts
@@ -68,23 +68,17 @@ function redirectToLogin(request: NextRequest) {
 async function adminMiddleware(request: NextRequest) {
 	const token = await getToken({ req: request, secret: env.AUTH_SECRET });
 
-	// The Edge runtime is allowed to settle freshness: the token is already
-	// decoded here to read the admin grant, and the rule is a comparison of two
-	// numbers — no database, no Node API.
+	// The Edge runtime can settle freshness itself: the token is already decoded here, and the rule compares two numbers.
 	const decision = resolveAdminAccess(token, new Date());
 
 	switch (decision.type) {
-		// No token, or a token predating the `isAdmin` field (users signed in
-		// before that field existed). The DB sync runs in the `jwt` callback on
-		// sign-in, so a fresh token is the only way to get the correct flag.
+		// The DB sync runs in the `jwt` callback, so a fresh sign-in is the only way to obtain the grant flag.
 		case "login":
 			return redirectToLogin(request);
-		// Silent refusal: a user without the grant is not told the backoffice
-		// exists.
+		// Silent refusal: a user without the grant is never told the backoffice exists.
 		case "monEspace":
 			return NextResponse.redirect(new URL("/mon-espace", request.url));
-		// Explicit refusal, on an Egapro screen: the product rules out reopening
-		// ProConnect in the middle of a navigation the agent did not ask for.
+		// Explicit refusal on an Egapro screen: reopening ProConnect mid-navigation is ruled out by the product.
 		case "resume": {
 			const resumeUrl = new URL("/acces-backoffice", request.url);
 			resumeUrl.searchParams.set(
@@ -98,9 +92,7 @@ async function adminMiddleware(request: NextRequest) {
 	}
 }
 
-// A browser back after an expiry must not restore a backoffice page from the
-// cache. The back/forward cache stays a client behaviour we do not command;
-// the header is the part that is ours, and the verifiable one.
+// A browser back after an expiry must not restore a backoffice page from the cache.
 function noStore(response: NextResponse) {
 	response.headers.set("Cache-Control", "no-store");
 	return response;

--- a/packages/app/src/middleware.ts
+++ b/packages/app/src/middleware.ts
@@ -2,13 +2,15 @@ import { type NextRequest, NextResponse } from "next/server";
 import { getToken } from "next-auth/jwt";
 
 import { env } from "~/env";
+import { resolveAdminAccess } from "~/modules/domain";
 
 /**
  * Next.js Edge middleware handling three concerns:
  *
- * 1. `/admin/*` — backoffice guard. Decodes the NextAuth JWT and enforces
- *    `isAdmin`. Defense in depth: `src/app/admin/layout.tsx` re-checks the
- *    session on the Node runtime in case the token is missing the flag.
+ * 1. `/admin/*` — backoffice guard. Decodes the NextAuth JWT and applies the
+ *    shared decision table of `resolveAdminAccess` — admin grant *and* a
+ *    two-factor authentication inside the window. Defense in depth:
+ *    `src/app/admin/layout.tsx` runs the same table on the Node runtime.
  *
  * 2. `/mon-espace/*`, `/declaration-remuneration/*`, `/avis-cse/*` — session
  *    gating only (no `isAdmin` check). Captures the requested URL into
@@ -66,19 +68,45 @@ function redirectToLogin(request: NextRequest) {
 async function adminMiddleware(request: NextRequest) {
 	const token = await getToken({ req: request, secret: env.AUTH_SECRET });
 
-	// Force re-login when there is no token OR when the token predates the
-	// `isAdmin` field (users signed in before this PR). The DB sync runs in
-	// the `jwt` callback on sign-in, so a fresh token is the only way to get
-	// the correct flag.
-	if (!token || token.isAdmin === undefined) {
-		return redirectToLogin(request);
-	}
+	// The Edge runtime is allowed to settle freshness: the token is already
+	// decoded here to read the admin grant, and the rule is a comparison of two
+	// numbers — no database, no Node API.
+	const decision = resolveAdminAccess(token, new Date());
 
-	if (!token.isAdmin) {
-		return NextResponse.redirect(new URL("/mon-espace", request.url));
+	switch (decision.type) {
+		// No token, or a token predating the `isAdmin` field (users signed in
+		// before that field existed). The DB sync runs in the `jwt` callback on
+		// sign-in, so a fresh token is the only way to get the correct flag.
+		case "login":
+			return redirectToLogin(request);
+		// Silent refusal: a user without the grant is not told the backoffice
+		// exists.
+		case "monEspace":
+			return NextResponse.redirect(new URL("/mon-espace", request.url));
+		// Explicit refusal, on an Egapro screen: the product rules out reopening
+		// ProConnect in the middle of a navigation the agent did not ask for.
+		case "resume": {
+			const resumeUrl = new URL("/acces-backoffice", request.url);
+			resumeUrl.searchParams.set(
+				"retour",
+				`${request.nextUrl.pathname}${request.nextUrl.search}`,
+			);
+			return NextResponse.redirect(resumeUrl);
+		}
+		default:
+			return noStore(NextResponse.next());
 	}
+}
 
-	return NextResponse.next();
+/**
+ * Marks a backoffice response uncacheable, so that a browser back after an
+ * expiry does not restore a page of the backoffice from its cache. The
+ * back/forward cache remains a client behaviour we do not command; the header
+ * is the part that is ours, and the part that is verifiable.
+ */
+function noStore(response: NextResponse) {
+	response.headers.set("Cache-Control", "no-store");
+	return response;
 }
 
 async function sessionMiddleware(request: NextRequest) {

--- a/packages/app/src/middleware.ts
+++ b/packages/app/src/middleware.ts
@@ -98,12 +98,9 @@ async function adminMiddleware(request: NextRequest) {
 	}
 }
 
-/**
- * Marks a backoffice response uncacheable, so that a browser back after an
- * expiry does not restore a page of the backoffice from its cache. The
- * back/forward cache remains a client behaviour we do not command; the header
- * is the part that is ours, and the part that is verifiable.
- */
+// A browser back after an expiry must not restore a backoffice page from the
+// cache. The back/forward cache stays a client behaviour we do not command;
+// the header is the part that is ours, and the verifiable one.
 function noStore(response: NextResponse) {
 	response.headers.set("Cache-Control", "no-store");
 	return response;

--- a/packages/app/src/modules/admin/__tests__/AdminLayout.test.tsx
+++ b/packages/app/src/modules/admin/__tests__/AdminLayout.test.tsx
@@ -21,7 +21,13 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("~/server/auth", () => ({ auth: mockAuth }));
 
+import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
+
 import AdminLayout from "~/app/admin/layout";
+
+function nowSeconds(): number {
+	return Math.floor(Date.now() / 1000);
+}
 
 describe("AdminLayout", () => {
 	beforeEach(() => {
@@ -45,8 +51,32 @@ describe("AdminLayout", () => {
 		expect(mockRedirect).toHaveBeenCalledWith("/mon-espace");
 	});
 
-	it("renders children for an admin user", async () => {
+	it("sends an admin whose two-factor authentication is missing to the resume screen", async () => {
 		mockAuth.mockResolvedValue({ user: { id: "u1", isAdmin: true } });
+		await expect(
+			AdminLayout({ children: "child" as unknown as React.ReactNode }),
+		).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith("/acces-backoffice");
+	});
+
+	it("sends an admin whose two-factor authentication expired to the resume screen", async () => {
+		mockAuth.mockResolvedValue({
+			user: {
+				id: "u1",
+				isAdmin: true,
+				adminMfaAt: nowSeconds() - ADMIN_MFA_WINDOW_SECONDS - 1,
+			},
+		});
+		await expect(
+			AdminLayout({ children: "child" as unknown as React.ReactNode }),
+		).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith("/acces-backoffice");
+	});
+
+	it("renders children for an admin authenticated inside the window", async () => {
+		mockAuth.mockResolvedValue({
+			user: { id: "u1", isAdmin: true, adminMfaAt: nowSeconds() },
+		});
 		const result = await AdminLayout({
 			children: "admin-child" as unknown as React.ReactNode,
 		});

--- a/packages/app/src/modules/admin/__tests__/AdminLayout.test.tsx
+++ b/packages/app/src/modules/admin/__tests__/AdminLayout.test.tsx
@@ -21,9 +21,8 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("~/server/auth", () => ({ auth: mockAuth }));
 
-import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
-
 import AdminLayout from "~/app/admin/layout";
+import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
 
 function nowSeconds(): number {
 	return Math.floor(Date.now() / 1000);

--- a/packages/app/src/modules/admin/access/AdminAccessPage.tsx
+++ b/packages/app/src/modules/admin/access/AdminAccessPage.tsx
@@ -20,15 +20,8 @@ const CONTENT: Record<AdminMfaFailure, { title: string; body: string }> = {
 	},
 };
 
-/**
- * Landing screen of an eligible agent whose two-factor authentication is
- * missing or out of the window. An Egapro screen rather than a silent redirect:
- * the agent is told what is being asked of them, and decides when to go through
- * ProConnect again.
- *
- * Both states are derived from the session on the server — a reason carried in
- * the URL would be displayable at will.
- */
+// An Egapro screen rather than a silent redirect: the agent is told what is
+// asked of them and decides when to go through ProConnect again.
 export function AdminAccessPage({ reason, returnPath }: Props) {
 	const { title, body } = CONTENT[reason];
 

--- a/packages/app/src/modules/admin/access/AdminAccessPage.tsx
+++ b/packages/app/src/modules/admin/access/AdminAccessPage.tsx
@@ -20,8 +20,7 @@ const CONTENT: Record<AdminMfaFailure, { title: string; body: string }> = {
 	},
 };
 
-// An Egapro screen rather than a silent redirect: the agent is told what is
-// asked of them and decides when to go through ProConnect again.
+// An Egapro screen rather than a silent redirect: the agent decides when to go through ProConnect again.
 export function AdminAccessPage({ reason, returnPath }: Props) {
 	const { title, body } = CONTENT[reason];
 

--- a/packages/app/src/modules/admin/access/AdminAccessPage.tsx
+++ b/packages/app/src/modules/admin/access/AdminAccessPage.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+
+import type { AdminMfaFailure } from "~/modules/domain";
+
+import { AdminAccessResumeButton } from "./AdminAccessResumeButton";
+
+type Props = {
+	reason: AdminMfaFailure;
+	returnPath: string;
+};
+
+const CONTENT: Record<AdminMfaFailure, { title: string; body: string }> = {
+	expired: {
+		title: "Votre accès au backoffice a expiré",
+		body: "Pour des raisons de sécurité, l'accès à l'espace d'administration demande une double authentification récente. La vôtre est arrivée à échéance.",
+	},
+	missing: {
+		title: "La double authentification n'a pas abouti",
+		body: "L'accès à l'espace d'administration demande une double authentification ProConnect. Votre session n'en porte pas.",
+	},
+};
+
+/**
+ * Landing screen of an eligible agent whose two-factor authentication is
+ * missing or out of the window. An Egapro screen rather than a silent redirect:
+ * the agent is told what is being asked of them, and decides when to go through
+ * ProConnect again.
+ *
+ * Both states are derived from the session on the server — a reason carried in
+ * the URL would be displayable at will.
+ */
+export function AdminAccessPage({ reason, returnPath }: Props) {
+	const { title, body } = CONTENT[reason];
+
+	return (
+		<main className="fr-container fr-py-6w" id="content" tabIndex={-1}>
+			<div className="fr-grid-row fr-grid-row--center">
+				<div className="fr-col-12 fr-col-md-8">
+					<h1>{title}</h1>
+					<p className="fr-mb-3w">{body}</p>
+					<p className="fr-mb-5w">
+						Votre espace déclarant reste accessible : seule l&apos;entrée dans
+						l&apos;espace d&apos;administration demande ce second facteur.
+					</p>
+					<ul className="fr-btns-group fr-btns-group--inline-md">
+						<li>
+							<AdminAccessResumeButton returnPath={returnPath} />
+						</li>
+						<li>
+							<Link className="fr-btn fr-btn--secondary" href="/mon-espace">
+								Retourner à Mon espace
+							</Link>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</main>
+	);
+}

--- a/packages/app/src/modules/admin/access/AdminAccessResumeButton.tsx
+++ b/packages/app/src/modules/admin/access/AdminAccessResumeButton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+
+type Props = {
+	returnPath: string;
+};
+
+/**
+ * Relaunches the ProConnect two-factor step-up, aiming back at the deep link
+ * the agent originally requested.
+ *
+ * The passage is triggered by a click, never by the page itself: an automatic
+ * redirect would send the agent bouncing between Egapro and ProConnect were the
+ * issuer to replay an authentication too old for our freshness window.
+ */
+export function AdminAccessResumeButton({ returnPath }: Props) {
+	return (
+		<button
+			className="fr-btn"
+			onClick={() => {
+				void signIn("proconnect", { callbackUrl: returnPath });
+			}}
+			type="button"
+		>
+			Refaire la double authentification
+		</button>
+	);
+}

--- a/packages/app/src/modules/admin/access/AdminAccessResumeButton.tsx
+++ b/packages/app/src/modules/admin/access/AdminAccessResumeButton.tsx
@@ -6,9 +6,7 @@ type Props = {
 	returnPath: string;
 };
 
-// Triggered by a click, never by the page itself: an automatic redirect would
-// bounce the agent between Egapro and ProConnect were the issuer to replay an
-// authentication too old for our window.
+// Click-triggered, never automatic: an issuer replaying an authentication too old for our window would loop the agent.
 export function AdminAccessResumeButton({ returnPath }: Props) {
 	return (
 		<button

--- a/packages/app/src/modules/admin/access/AdminAccessResumeButton.tsx
+++ b/packages/app/src/modules/admin/access/AdminAccessResumeButton.tsx
@@ -6,14 +6,9 @@ type Props = {
 	returnPath: string;
 };
 
-/**
- * Relaunches the ProConnect two-factor step-up, aiming back at the deep link
- * the agent originally requested.
- *
- * The passage is triggered by a click, never by the page itself: an automatic
- * redirect would send the agent bouncing between Egapro and ProConnect were the
- * issuer to replay an authentication too old for our freshness window.
- */
+// Triggered by a click, never by the page itself: an automatic redirect would
+// bounce the agent between Egapro and ProConnect were the issuer to replay an
+// authentication too old for our window.
 export function AdminAccessResumeButton({ returnPath }: Props) {
 	return (
 		<button

--- a/packages/app/src/modules/admin/access/__tests__/AccesBackofficePage.test.tsx
+++ b/packages/app/src/modules/admin/access/__tests__/AccesBackofficePage.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRedirect, mockAuth } = vi.hoisted(() => ({
+	mockRedirect: vi.fn<(url: string) => never>().mockImplementation(() => {
+		throw new Error("NEXT_REDIRECT");
+	}),
+	mockAuth: vi.fn(),
+}));
+
+vi.mock("next/navigation", async (importOriginal) => ({
+	...(await importOriginal<Record<string, unknown>>()),
+	redirect: mockRedirect,
+}));
+
+vi.mock("~/server/auth", () => ({ auth: mockAuth }));
+
+import Page from "~/app/acces-backoffice/page";
+import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
+
+function nowSeconds(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+function renderPage(retour?: string) {
+	return Page({ searchParams: Promise.resolve({ retour }) });
+}
+
+describe("acces-backoffice page", () => {
+	beforeEach(() => {
+		mockRedirect.mockClear();
+		mockAuth.mockReset();
+	});
+
+	it("sends a visitor without a session to the sign-in page, deep link kept", async () => {
+		mockAuth.mockResolvedValue(null);
+
+		await expect(renderPage("/admin/declarations")).rejects.toThrow(
+			"NEXT_REDIRECT",
+		);
+		expect(mockRedirect).toHaveBeenCalledWith(
+			"/login?callbackUrl=%2Fadmin%2Fdeclarations",
+		);
+	});
+
+	it("turns a user without the admin grant away towards Mon espace", async () => {
+		// The screen refuses exactly what the guard refuses: an exception here
+		// would make it the admission the guard declines to make.
+		mockAuth.mockResolvedValue({ user: { id: "u1", isAdmin: false } });
+
+		await expect(renderPage("/admin")).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith("/mon-espace");
+	});
+
+	it("sends an agent already authenticated inside the window straight in", async () => {
+		mockAuth.mockResolvedValue({
+			user: { id: "u1", isAdmin: true, adminMfaAt: nowSeconds() },
+		});
+
+		await expect(renderPage("/admin/declarations")).rejects.toThrow(
+			"NEXT_REDIRECT",
+		);
+		expect(mockRedirect).toHaveBeenCalledWith("/admin/declarations");
+	});
+
+	it("announces an expiry from the session, not from the URL", async () => {
+		mockAuth.mockResolvedValue({
+			user: {
+				id: "u1",
+				isAdmin: true,
+				adminMfaAt: nowSeconds() - ADMIN_MFA_WINDOW_SECONDS - 1,
+			},
+		});
+
+		render(await renderPage("/admin"));
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: "Votre accès au backoffice a expiré",
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("announces a failed authentication when the session carries no date", async () => {
+		mockAuth.mockResolvedValue({ user: { id: "u1", isAdmin: true } });
+
+		render(await renderPage("/admin"));
+
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: "La double authentification n'a pas abouti",
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("ignores a return path pointing outside the backoffice", async () => {
+		// `retour` is attacker-controlled: the screen must never become a
+		// redirector towards an arbitrary destination.
+		mockAuth.mockResolvedValue({
+			user: { id: "u1", isAdmin: true, adminMfaAt: nowSeconds() },
+		});
+
+		await expect(renderPage("https://evil.example")).rejects.toThrow(
+			"NEXT_REDIRECT",
+		);
+		expect(mockRedirect).toHaveBeenCalledWith("/admin");
+	});
+});

--- a/packages/app/src/modules/admin/access/__tests__/AdminAccessPage.test.tsx
+++ b/packages/app/src/modules/admin/access/__tests__/AdminAccessPage.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { signIn } from "next-auth/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AdminAccessPage } from "../AdminAccessPage";
+
+const mockSignIn = vi.mocked(signIn);
+
+describe("AdminAccessPage", () => {
+	beforeEach(() => {
+		mockSignIn.mockClear();
+	});
+
+	it("renders the main landmark with the skip-link target", () => {
+		render(<AdminAccessPage reason="expired" returnPath="/admin" />);
+
+		const main = screen.getByRole("main");
+		expect(main).toHaveAttribute("id", "content");
+		expect(main).toHaveAttribute("tabIndex", "-1");
+	});
+
+	it("announces an expiry when the authentication is out of the window", () => {
+		render(<AdminAccessPage reason="expired" returnPath="/admin" />);
+
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: "Votre accès au backoffice a expiré",
+			}),
+		).toBeInTheDocument();
+		expect(screen.getByText(/arrivée à échéance/)).toBeInTheDocument();
+	});
+
+	it("announces a failed authentication when the session carries no date", () => {
+		render(<AdminAccessPage reason="missing" returnPath="/admin" />);
+
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: "La double authentification n'a pas abouti",
+			}),
+		).toBeInTheDocument();
+		expect(screen.getByText(/Votre session n'en porte pas/)).toBeInTheDocument();
+	});
+
+	it("keeps Mon espace reachable while the backoffice is refused", () => {
+		render(<AdminAccessPage reason="expired" returnPath="/admin" />);
+
+		expect(
+			screen.getByRole("link", { name: "Retourner à Mon espace" }),
+		).toHaveAttribute("href", "/mon-espace");
+	});
+
+	it("does not start the second factor on its own", () => {
+		// The passage through ProConnect is triggered by a click, never by the
+		// screen itself: an automatic redirect could bounce the agent between
+		// Egapro and the issuer.
+		render(<AdminAccessPage reason="expired" returnPath="/admin" />);
+
+		expect(mockSignIn).not.toHaveBeenCalled();
+	});
+
+	it("aims the resume action at the requested deep link", async () => {
+		render(
+			<AdminAccessPage reason="missing" returnPath="/admin/declarations/abc" />,
+		);
+
+		await userEvent.click(
+			screen.getByRole("button", { name: "Refaire la double authentification" }),
+		);
+
+		expect(mockSignIn).toHaveBeenCalledWith("proconnect", {
+			callbackUrl: "/admin/declarations/abc",
+		});
+	});
+});

--- a/packages/app/src/modules/admin/access/__tests__/AdminAccessPage.test.tsx
+++ b/packages/app/src/modules/admin/access/__tests__/AdminAccessPage.test.tsx
@@ -41,7 +41,9 @@ describe("AdminAccessPage", () => {
 				name: "La double authentification n'a pas abouti",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText(/Votre session n'en porte pas/)).toBeInTheDocument();
+		expect(
+			screen.getByText(/Votre session n'en porte pas/),
+		).toBeInTheDocument();
 	});
 
 	it("keeps Mon espace reachable while the backoffice is refused", () => {
@@ -67,7 +69,9 @@ describe("AdminAccessPage", () => {
 		);
 
 		await userEvent.click(
-			screen.getByRole("button", { name: "Refaire la double authentification" }),
+			screen.getByRole("button", {
+				name: "Refaire la double authentification",
+			}),
 		);
 
 		expect(mockSignIn).toHaveBeenCalledWith("proconnect", {

--- a/packages/app/src/modules/admin/access/__tests__/adminReturnPath.test.ts
+++ b/packages/app/src/modules/admin/access/__tests__/adminReturnPath.test.ts
@@ -15,6 +15,12 @@ describe("sanitizeAdminReturnPath", () => {
 		).toBe("/admin/declarations?onglet=historique");
 	});
 
+	it("resolves dot segments inside the backoffice", () => {
+		expect(sanitizeAdminReturnPath("/admin/stats/../declarations")).toBe(
+			"/admin/declarations",
+		);
+	});
+
 	it("keeps a fragment on a backoffice path", () => {
 		expect(sanitizeAdminReturnPath("/admin#contenu")).toBe("/admin#contenu");
 	});
@@ -31,6 +37,11 @@ describe("sanitizeAdminReturnPath", () => {
 		// `/administration` merely shares a prefix with `/admin`: the comparison
 		// is segment-aware, so this must not be mistaken for a backoffice path.
 		["a path that only shares the prefix", "/administration/secret"],
+		// `/admin/../mon-espace` opens with `/admin` as a string, but every
+		// consumer collapses it to `/mon-espace` before requesting it.
+		["dot segments escaping the backoffice", "/admin/../mon-espace"],
+		["dot segments climbing above the root", "/admin/../../mon-espace"],
+		["encoded dot segments", "/admin/%2E%2E/mon-espace"],
 		["a relative path", "admin/declarations"],
 		["an absolute URL", "https://evil.example/admin"],
 		["a protocol-relative URL", "//evil.example/admin"],

--- a/packages/app/src/modules/admin/access/__tests__/adminReturnPath.test.ts
+++ b/packages/app/src/modules/admin/access/__tests__/adminReturnPath.test.ts
@@ -37,8 +37,6 @@ describe("sanitizeAdminReturnPath", () => {
 		// `/administration` merely shares a prefix with `/admin`: the comparison
 		// is segment-aware, so this must not be mistaken for a backoffice path.
 		["a path that only shares the prefix", "/administration/secret"],
-		// `/admin/../mon-espace` opens with `/admin` as a string, but every
-		// consumer collapses it to `/mon-espace` before requesting it.
 		["dot segments escaping the backoffice", "/admin/../mon-espace"],
 		["dot segments climbing above the root", "/admin/../../mon-espace"],
 		["encoded dot segments", "/admin/%2E%2E/mon-espace"],

--- a/packages/app/src/modules/admin/access/__tests__/adminReturnPath.test.ts
+++ b/packages/app/src/modules/admin/access/__tests__/adminReturnPath.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { ADMIN_HOME_PATH, sanitizeAdminReturnPath } from "../adminReturnPath";
+
+describe("sanitizeAdminReturnPath", () => {
+	it("keeps a backoffice deep link", () => {
+		expect(sanitizeAdminReturnPath("/admin/declarations/abc")).toBe(
+			"/admin/declarations/abc",
+		);
+	});
+
+	it("keeps the query string of a backoffice deep link", () => {
+		expect(
+			sanitizeAdminReturnPath("/admin/declarations?onglet=historique"),
+		).toBe("/admin/declarations?onglet=historique");
+	});
+
+	it("keeps a fragment on a backoffice path", () => {
+		expect(sanitizeAdminReturnPath("/admin#contenu")).toBe("/admin#contenu");
+	});
+
+	it("keeps the backoffice home itself", () => {
+		expect(sanitizeAdminReturnPath(ADMIN_HOME_PATH)).toBe(ADMIN_HOME_PATH);
+	});
+
+	it.each([
+		["nothing at all", undefined],
+		["an empty string", ""],
+		["a path outside the backoffice", "/mon-espace"],
+		["the site root", "/"],
+		// `/administration` merely shares a prefix with `/admin`: the comparison
+		// is segment-aware, so this must not be mistaken for a backoffice path.
+		["a path that only shares the prefix", "/administration/secret"],
+		["a relative path", "admin/declarations"],
+		["an absolute URL", "https://evil.example/admin"],
+		["a protocol-relative URL", "//evil.example/admin"],
+		["a backslash authority", "/\\evil.example/admin"],
+		["a percent-encoded authority", "/%2F%2Fevil.example/admin"],
+		["malformed percent-encoding", "/admin/%E0%A4%A"],
+	])("falls back to the backoffice home for %s", (_label, value) => {
+		expect(sanitizeAdminReturnPath(value)).toBe(ADMIN_HOME_PATH);
+	});
+});

--- a/packages/app/src/modules/admin/access/adminReturnPath.ts
+++ b/packages/app/src/modules/admin/access/adminReturnPath.ts
@@ -1,25 +1,28 @@
 import { sanitizeCallbackUrl } from "~/modules/login";
 
-/** Where an agent is sent when the requested path cannot be trusted. */
 export const ADMIN_HOME_PATH = "/admin";
 
-// Segment-aware: `/administration` merely shares a prefix with `/admin` and is
-// not a backoffice path.
+// Segment-aware: `/administration` merely shares a prefix with `/admin`.
 const BACKOFFICE_PATH = new RegExp(`^${ADMIN_HOME_PATH}([/?#]|$)`);
 
-/**
- * Normalize the `retour` parameter of the resume screen into a backoffice path
- * the resume action may target.
- *
- * Two constraints, both required: the existing `callbackUrl` sanitizer rules
- * out anything that a browser could collapse into a foreign authority, and the
- * `/admin` prefix keeps the resume screen from being turned into a redirector
- * towards any other page of the site. `/administration` is not `/admin`, hence
- * the segment-aware comparison rather than a bare `startsWith`.
- */
+// Dummy base, as in the callback sanitizer: nothing of it reaches the result.
+const RESOLUTION_ORIGIN = "https://internal.invalid";
+
 export function sanitizeAdminReturnPath(value?: string): string {
 	const safe = sanitizeCallbackUrl(value);
-	if (!safe || !BACKOFFICE_PATH.test(safe)) return ADMIN_HOME_PATH;
+	if (!safe) return ADMIN_HOME_PATH;
 
-	return safe;
+	// `/admin/../mon-espace` opens with `/admin` as a string, yet every consumer
+	// — a browser following a `Location`, the NextAuth `redirect` callback —
+	// collapses it to `/mon-espace` first, so the prefix is judged on the
+	// resolved form. Parsing cannot throw: the callback sanitizer just resolved
+	// this same value.
+	const resolved = new URL(safe, RESOLUTION_ORIGIN);
+	const normalized = `${resolved.pathname}${resolved.search}${resolved.hash}`;
+
+	// Without the `/admin` confinement the resume screen becomes a redirector
+	// towards any page of the site.
+	if (!BACKOFFICE_PATH.test(normalized)) return ADMIN_HOME_PATH;
+
+	return normalized;
 }

--- a/packages/app/src/modules/admin/access/adminReturnPath.ts
+++ b/packages/app/src/modules/admin/access/adminReturnPath.ts
@@ -12,16 +12,11 @@ export function sanitizeAdminReturnPath(value?: string): string {
 	const safe = sanitizeCallbackUrl(value);
 	if (!safe) return ADMIN_HOME_PATH;
 
-	// `/admin/../mon-espace` opens with `/admin` as a string, yet every consumer
-	// — a browser following a `Location`, the NextAuth `redirect` callback —
-	// collapses it to `/mon-espace` first, so the prefix is judged on the
-	// resolved form. Parsing cannot throw: the callback sanitizer just resolved
-	// this same value.
+	// `/admin/../mon-espace` opens with `/admin` as a string, yet every consumer collapses it to `/mon-espace` before requesting it.
 	const resolved = new URL(safe, RESOLUTION_ORIGIN);
 	const normalized = `${resolved.pathname}${resolved.search}${resolved.hash}`;
 
-	// Without the `/admin` confinement the resume screen becomes a redirector
-	// towards any page of the site.
+	// Without this confinement the resume screen becomes a redirector towards any page of the site.
 	if (!BACKOFFICE_PATH.test(normalized)) return ADMIN_HOME_PATH;
 
 	return normalized;

--- a/packages/app/src/modules/admin/access/adminReturnPath.ts
+++ b/packages/app/src/modules/admin/access/adminReturnPath.ts
@@ -1,0 +1,25 @@
+import { sanitizeCallbackUrl } from "~/modules/login";
+
+/** Where an agent is sent when the requested path cannot be trusted. */
+export const ADMIN_HOME_PATH = "/admin";
+
+// Segment-aware: `/administration` merely shares a prefix with `/admin` and is
+// not a backoffice path.
+const BACKOFFICE_PATH = new RegExp(`^${ADMIN_HOME_PATH}([/?#]|$)`);
+
+/**
+ * Normalize the `retour` parameter of the resume screen into a backoffice path
+ * the resume action may target.
+ *
+ * Two constraints, both required: the existing `callbackUrl` sanitizer rules
+ * out anything that a browser could collapse into a foreign authority, and the
+ * `/admin` prefix keeps the resume screen from being turned into a redirector
+ * towards any other page of the site. `/administration` is not `/admin`, hence
+ * the segment-aware comparison rather than a bare `startsWith`.
+ */
+export function sanitizeAdminReturnPath(value?: string): string {
+	const safe = sanitizeCallbackUrl(value);
+	if (!safe || !BACKOFFICE_PATH.test(safe)) return ADMIN_HOME_PATH;
+
+	return safe;
+}

--- a/packages/app/src/modules/admin/access/index.ts
+++ b/packages/app/src/modules/admin/access/index.ts
@@ -1,0 +1,2 @@
+export { AdminAccessPage } from "./AdminAccessPage";
+export { ADMIN_HOME_PATH, sanitizeAdminReturnPath } from "./adminReturnPath";

--- a/packages/app/src/modules/domain/__tests__/adminMfa.test.ts
+++ b/packages/app/src/modules/domain/__tests__/adminMfa.test.ts
@@ -4,6 +4,7 @@ import {
 	ADMIN_MFA_WINDOW_SECONDS,
 	isAdminMfaAcr,
 	isAdminMfaFresh,
+	resolveAdminAccess,
 } from "~/modules/domain";
 
 const AUTH_AT = Math.floor(Date.parse("2026-03-10T08:00:00.000Z") / 1000);
@@ -106,3 +107,79 @@ describe("isAdminMfaFresh", () => {
 		expect(isAdminMfaFresh(adminMfaAt, at(0))).toBe(false);
 	});
 });
+
+describe("resolveAdminAccess", () => {
+	it.each([
+		["no session at all", null],
+		["an undefined session", undefined],
+	])("sends %s back to the sign-in page", (_label, session) => {
+		expect(resolveAdminAccess(session, at(0))).toEqual({ type: "login" });
+	});
+
+	it("sends a token predating the admin field back to the sign-in page", () => {
+		// Signed in before the grant was minted into the token: the absence of
+		// the field is not the same as `false`, and only a fresh sign-in can
+		// tell them apart.
+		expect(resolveAdminAccess({ adminMfaAt: AUTH_AT }, at(0))).toEqual({
+			type: "login",
+		});
+	});
+
+	it("turns a user without the admin grant away towards Mon espace", () => {
+		// Silent refusal, even with a fresh second factor: the backoffice is
+		// never mentioned to someone who has no business there.
+		expect(
+			resolveAdminAccess({ isAdmin: false, adminMfaAt: AUTH_AT }, at(0)),
+		).toEqual({ type: "monEspace" });
+	});
+
+	it("lets an eligible agent in inside the window", () => {
+		expect(
+			resolveAdminAccess({ isAdmin: true, adminMfaAt: AUTH_AT }, at(0)),
+		).toEqual({ type: "allow" });
+	});
+
+	it("still lets an eligible agent in one second before the window closes", () => {
+		expect(
+			resolveAdminAccess(
+				{ isAdmin: true, adminMfaAt: AUTH_AT },
+				at(ADMIN_MFA_WINDOW_SECONDS - 1),
+			),
+		).toEqual({ type: "allow" });
+	});
+
+	it("reports an expiry exactly on the window boundary", () => {
+		expect(
+			resolveAdminAccess(
+				{ isAdmin: true, adminMfaAt: AUTH_AT },
+				at(ADMIN_MFA_WINDOW_SECONDS),
+			),
+		).toEqual({ type: "resume", reason: "expired" });
+	});
+
+	it("reports an expiry when the authentication is older than the window", () => {
+		expect(
+			resolveAdminAccess(
+				{ isAdmin: true, adminMfaAt: AUTH_AT },
+				at(ADMIN_MFA_WINDOW_SECONDS + 1),
+			),
+		).toEqual({ type: "resume", reason: "expired" });
+	});
+
+	it.each([
+		["undefined", undefined],
+		["null", null],
+		["NaN", Number.NaN],
+		["Infinity", Number.POSITIVE_INFINITY],
+	])(
+		"reports an authentication that never happened when the date is %s",
+		(_label, adminMfaAt) => {
+			// A session opened before this feature shipped lands here too: the
+			// wording stays true, and the action offered is the same.
+			expect(resolveAdminAccess({ isAdmin: true, adminMfaAt }, at(0))).toEqual({
+				type: "resume",
+				reason: "missing",
+			});
+		},
+	);
+})

--- a/packages/app/src/modules/domain/__tests__/adminMfa.test.ts
+++ b/packages/app/src/modules/domain/__tests__/adminMfa.test.ts
@@ -171,15 +171,12 @@ describe("resolveAdminAccess", () => {
 		["null", null],
 		["NaN", Number.NaN],
 		["Infinity", Number.POSITIVE_INFINITY],
-	])(
-		"reports an authentication that never happened when the date is %s",
-		(_label, adminMfaAt) => {
-			// A session opened before this feature shipped lands here too: the
-			// wording stays true, and the action offered is the same.
-			expect(resolveAdminAccess({ isAdmin: true, adminMfaAt }, at(0))).toEqual({
-				type: "resume",
-				reason: "missing",
-			});
-		},
-	);
-})
+	])("reports an authentication that never happened when the date is %s", (_label, adminMfaAt) => {
+		// A session opened before this feature shipped lands here too: the
+		// wording stays true, and the action offered is the same.
+		expect(resolveAdminAccess({ isAdmin: true, adminMfaAt }, at(0))).toEqual({
+			type: "resume",
+			reason: "missing",
+		});
+	});
+});

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -1,11 +1,17 @@
 // Types
 
 // Admin two-factor authentication — accepted levels and freshness window
+export type {
+	AdminAccessDecision,
+	AdminMfaFailure,
+	AdminSessionState,
+} from "./shared/adminMfa";
 export {
 	ADMIN_MFA_ACR_VALUES,
 	ADMIN_MFA_WINDOW_SECONDS,
 	isAdminMfaAcr,
 	isAdminMfaFresh,
+	resolveAdminAccess,
 } from "./shared/adminMfa";
 // Campaign
 export {

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -1,11 +1,7 @@
 // Types
 
 // Admin two-factor authentication — accepted levels and freshness window
-export type {
-	AdminAccessDecision,
-	AdminMfaFailure,
-	AdminSessionState,
-} from "./shared/adminMfa";
+export type { AdminMfaFailure } from "./shared/adminMfa";
 export {
 	ADMIN_MFA_ACR_VALUES,
 	ADMIN_MFA_WINDOW_SECONDS,

--- a/packages/app/src/modules/domain/shared/adminMfa.ts
+++ b/packages/app/src/modules/domain/shared/adminMfa.ts
@@ -27,8 +27,7 @@ export function isAdminMfaFresh(
 	return elapsedSeconds < ADMIN_MFA_WINDOW_SECONDS;
 }
 
-// Derived from the session alone — a reason carried in the URL would be
-// displayable at will.
+// Read from the session alone: a reason carried in the URL would be displayable at will.
 export type AdminMfaFailure = "expired" | "missing";
 
 export type AdminAccessDecision =
@@ -37,23 +36,18 @@ export type AdminAccessDecision =
 	| { type: "resume"; reason: AdminMfaFailure }
 	| { type: "allow" };
 
-// `isAdmin` is optional on purpose: a token minted before the field existed
-// carries no value, and that absence is not the same thing as `false`.
+// `isAdmin` is optional because a token minted before the field existed carries no value, which is not `false`.
 export type AdminSessionState = {
 	isAdmin?: boolean;
 	adminMfaAt?: number | null;
 };
 
-// The single decision table of the `/admin` surface, applied identically by the
-// Edge middleware, the backoffice layout and the resume screen. It compares
-// values the token already carries — which is why the authentication date lives
-// in the token in the first place.
+// The single decision table of the `/admin` surface: Edge middleware, backoffice layout and resume screen all run this one.
 export function resolveAdminAccess(
 	session: AdminSessionState | null | undefined,
 	now: Date,
 ): AdminAccessDecision {
-	// No session, or a token predating the admin field: only a fresh sign-in
-	// produces a token we are able to judge.
+	// A token predating the admin field cannot be judged; only a fresh sign-in produces one that can.
 	if (!session || session.isAdmin === undefined) return { type: "login" };
 
 	if (!session.isAdmin) return { type: "monEspace" };

--- a/packages/app/src/modules/domain/shared/adminMfa.ts
+++ b/packages/app/src/modules/domain/shared/adminMfa.ts
@@ -26,3 +26,61 @@ export function isAdminMfaFresh(
 	// back to ProConnect after a successful second factor.
 	return elapsedSeconds < ADMIN_MFA_WINDOW_SECONDS;
 }
+
+/**
+ * Why an eligible agent is sent to the resume screen rather than into the
+ * backoffice. Derived from the session alone — never from a query parameter,
+ * which any visitor could set at will.
+ */
+export type AdminMfaFailure = "expired" | "missing";
+
+export type AdminAccessDecision =
+	| { type: "login" }
+	| { type: "monEspace" }
+	| { type: "resume"; reason: AdminMfaFailure }
+	| { type: "allow" };
+
+/**
+ * The subset of a session the decision reads. `isAdmin` is optional on purpose:
+ * a token minted before the field existed carries no value at all, and that
+ * absence is not the same thing as `false`.
+ */
+export type AdminSessionState = {
+	isAdmin?: boolean;
+	adminMfaAt?: number | null;
+};
+
+/**
+ * The single decision table for the `/admin` surface, applied identically by
+ * the Edge middleware, the backoffice layout and the resume screen.
+ *
+ * It compares values the token already carries: no database, no Node API,
+ * nothing the Edge runtime cannot do — which is why the authentication date
+ * lives in the token in the first place.
+ *
+ * A user without the admin grant is turned away silently towards `/mon-espace`:
+ * telling them the backoffice exists is itself the disclosure we refuse.
+ */
+export function resolveAdminAccess(
+	session: AdminSessionState | null | undefined,
+	now: Date,
+): AdminAccessDecision {
+	// No session, or a token predating the admin field: only a fresh sign-in
+	// produces a token we are able to judge.
+	if (!session || session.isAdmin === undefined) return { type: "login" };
+
+	if (!session.isAdmin) return { type: "monEspace" };
+
+	if (!isAdminMfaFresh(session.adminMfaAt, now)) {
+		return {
+			type: "resume",
+			reason:
+				typeof session.adminMfaAt === "number" &&
+				Number.isFinite(session.adminMfaAt)
+					? "expired"
+					: "missing",
+		};
+	}
+
+	return { type: "allow" };
+}

--- a/packages/app/src/modules/domain/shared/adminMfa.ts
+++ b/packages/app/src/modules/domain/shared/adminMfa.ts
@@ -27,11 +27,8 @@ export function isAdminMfaFresh(
 	return elapsedSeconds < ADMIN_MFA_WINDOW_SECONDS;
 }
 
-/**
- * Why an eligible agent is sent to the resume screen rather than into the
- * backoffice. Derived from the session alone — never from a query parameter,
- * which any visitor could set at will.
- */
+// Derived from the session alone — a reason carried in the URL would be
+// displayable at will.
 export type AdminMfaFailure = "expired" | "missing";
 
 export type AdminAccessDecision =
@@ -40,27 +37,17 @@ export type AdminAccessDecision =
 	| { type: "resume"; reason: AdminMfaFailure }
 	| { type: "allow" };
 
-/**
- * The subset of a session the decision reads. `isAdmin` is optional on purpose:
- * a token minted before the field existed carries no value at all, and that
- * absence is not the same thing as `false`.
- */
+// `isAdmin` is optional on purpose: a token minted before the field existed
+// carries no value, and that absence is not the same thing as `false`.
 export type AdminSessionState = {
 	isAdmin?: boolean;
 	adminMfaAt?: number | null;
 };
 
-/**
- * The single decision table for the `/admin` surface, applied identically by
- * the Edge middleware, the backoffice layout and the resume screen.
- *
- * It compares values the token already carries: no database, no Node API,
- * nothing the Edge runtime cannot do — which is why the authentication date
- * lives in the token in the first place.
- *
- * A user without the admin grant is turned away silently towards `/mon-espace`:
- * telling them the backoffice exists is itself the disclosure we refuse.
- */
+// The single decision table of the `/admin` surface, applied identically by the
+// Edge middleware, the backoffice layout and the resume screen. It compares
+// values the token already carries — which is why the authentication date lives
+// in the token in the first place.
 export function resolveAdminAccess(
 	session: AdminSessionState | null | undefined,
 	now: Date,


### PR DESCRIPTION
Closes #4462

## Résumé

Première des trois surfaces privilégiées de l'epic #4405 : les pages `/admin/**` exigent désormais une double authentification ProConnect **récente** en plus de l'habilitation, et un agent habilité qui ne l'a pas atterrit sur un écran Egapro plutôt que d'être renvoyé en silence vers ProConnect au milieu de sa navigation.

- **Une seule table de décision** — `resolveAdminAccess` (`~/modules/domain/shared/adminMfa.ts`, à côté de `isAdminMfaFresh` posé par #4461), appliquée à l'identique par le middleware Edge, le layout `/admin` (défense en profondeur, runtime Node) et l'écran de reprise lui-même.

  | État de la session | Destination |
  |---|---|
  | aucun jeton, ou jeton sans champ d'habilitation | `/login?callbackUrl=<chemin demandé>` |
  | habilitation absente | `/mon-espace` — refus **silencieux** |
  | habilité, `adminMfaAt` absent ou hors fenêtre | `/acces-backoffice?retour=<chemin demandé>` — refus **explicite** |
  | habilité, `adminMfaAt` dans la fenêtre | la page demandée |

  Le middleware Edge tranche la fraîcheur lui-même : il décode déjà le jeton pour lire l'habilitation, et la règle est une comparaison de deux nombres — aucune base, aucune API Node.

- **Écran de reprise `/acces-backoffice`** — hors `/admin` pour ne pas boucler avec sa propre garde. Il déduit son état de la session seule (`adminMfaAt` hors fenêtre → « votre accès a expiré » ; aucun `adminMfaAt` → « la double authentification n'a pas abouti »), jamais d'un paramètre d'URL. Il applique la même table de décision que la garde : sans session → `/login`, sans habilitation → `/mon-espace`, du même refus silencieux — sinon l'écran deviendrait l'aveu que la garde refuse de faire. La page ne redirige jamais d'elle-même vers ProConnect : le passage est déclenché par un clic.

- **`retour` validé et confiné** — `sanitizeAdminReturnPath` passe la valeur par le nettoyeur de `callbackUrl` existant, **résout les segments `..`**, puis exige le préfixe `/admin` sur la forme résolue ; à défaut, `/admin`.

- **`Cache-Control: no-store`** sur les réponses `/admin/**` servies, pour qu'un retour arrière après expiration ne restitue pas une page du backoffice depuis le cache.

Le chrome ne bouge pas : le header applicatif reste rendu sur `/admin`, le pied de page et le bandeau d'aide y restent masqués.

## Vérification

Sur le dev server du worktree, session de développement pour un compte habilité (donc **sans** marqueur de double authentification, la connexion de dev ne produisant pas d'`id_token` MFA) :

| Ce qui a été fait | Résultat observé |
|---|---|
| `GET /admin` sans session | `307` → `/login?callbackUrl=%2Fadmin` |
| `GET /acces-backoffice` sans session | `307` → `/login?callbackUrl=%2Fadmin` |
| `GET /admin/declarations` avec une session habilitée sans double authentification | `307` → `/acces-backoffice?retour=%2Fadmin%2Fdeclarations`, deep link préservé |
| L'écran de reprise ainsi atteint | titre « La double authentification n'a pas abouti », action « Refaire la double authentification », lien « Retourner à Mon espace » ; aucune redirection vers un site externe |
| `/mon-espace` pendant ce refus | reste accessible, page entreprise servie normalement |

**Vérification dégradée, assumée** : l'état « habilité **avec** double authentification fraîche » n'est pas atteignable en local — la connexion de développement ne peut pas produire d'`acr` MFA, et c'est l'objet du ticket #4467 (obtenir une session backoffice à double authentification valide pour l'E2E). Les deux comportements qui en dépendent — accès direct à la page demandée (S5) et en-tête `Cache-Control: no-store` — sont couverts par les tests unitaires du middleware et du layout, pas par une observation navigateur.

## Tests

- `src/modules/domain/__tests__/adminMfa.test.ts` — table de décision : absence de jeton, jeton antérieur au champ d'habilitation, habilitation absente (même avec un second facteur frais), les deux côtés et le point exact de la fenêtre de 8 h, distinction `expired` / `missing`.
- `src/__tests__/middleware.test.ts` — les quatre destinations, le deep link avec query string porté dans `retour`, l'en-tête `no-store`, et le fait qu'aucun refus ne sorte de l'origine.
- `src/modules/admin/__tests__/AdminLayout.test.tsx` — même table côté Node.
- `src/modules/admin/access/__tests__/` — `sanitizeAdminReturnPath` (chemins backoffice, préfixe partagé `/administration`, segments `..` littéraux et encodés, URL absolues et protocol-relative), écran de reprise (deux états, action visant le deep link, aucune ouverture automatique de ProConnect) et route `/acces-backoffice` (refus silencieux, entrée directe quand la session est déjà fraîche).

100 % de couverture (instructions, branches, fonctions, lignes) sur les fichiers touchés. Deux assertions existantes ont été re-ciblées — un jeton admin **sans** `adminMfaAt` n'est plus laissé passer — et l'ancien cas reste testé sous sa nouvelle sémantique.

Gates internes : `validator` PASS · `structural-auditor` PASS · `rgaa-auditor` PASS (0 finding ultra11y) · `security-auditor` SECURE.

## Suite

L'action de l'écran de reprise appelle aujourd'hui directement la connexion ProConnect ; #4465 la fera passer par le point d'entrée de step-up partagé avec le menu « Administration » et la page de connexion.
