### PR TITLE
fix(files): #4464 — garde du téléchargement de pièce jointe hors périmètre SIREN

### DIFF
--- a/packages/app/src/app/api/v1/files/[fileId]/__tests__/route.test.ts
+++ b/packages/app/src/app/api/v1/files/[fileId]/__tests__/route.test.ts
@@ -30,8 +30,7 @@ import { GET } from "../route";
 // A SIRET whose first 9 digits form the admin's own SIREN scope.
 const ADMIN_SIRET = "98765432100010";
 const ADMIN_SIREN = "987654321";
-// The fictitious SIREN used by the ticket's scenarios for a company the
-// admin is not a referent of.
+// A file belonging to a company the admin is not a referent of.
 const OTHER_SIREN_FILE = {
 	filePath: "123456789/2027/f.pdf",
 	fileName: "f.pdf",
@@ -204,7 +203,7 @@ describe("GET /api/v1/files/:fileId", () => {
 			});
 		}
 
-		it("bypasses SIREN scope and serves any file as an attachment (S13 scenario 1)", async () => {
+		it("bypasses SIREN scope and serves any file as an attachment", async () => {
 			freshAdminSession();
 			mocks.fetchFileById.mockResolvedValue(OTHER_SIREN_FILE);
 
@@ -241,7 +240,7 @@ describe("GET /api/v1/files/:fileId", () => {
 		});
 	});
 
-	describe("admin session with an expired double authentication (S13)", () => {
+	describe("admin session with an expired double authentication", () => {
 		function expiredAdminSession(overrides: Record<string, unknown> = {}) {
 			mocks.auth.mockResolvedValue({
 				user: {
@@ -255,7 +254,7 @@ describe("GET /api/v1/files/:fileId", () => {
 			});
 		}
 
-		it("serves a file within the admin's own SIREN scope, like a regular user (S8)", async () => {
+		it("serves a file within the admin's own SIREN scope, like a regular user", async () => {
 			expiredAdminSession();
 			mocks.fetchFileBySiren.mockResolvedValue(OWN_SIREN_FILE);
 

--- a/packages/app/src/app/api/v1/files/[fileId]/__tests__/route.test.ts
+++ b/packages/app/src/app/api/v1/files/[fileId]/__tests__/route.test.ts
@@ -1,0 +1,339 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	auth: vi.fn(),
+	fetchFileById: vi.fn(),
+	fetchFileBySiren: vi.fn(),
+	streamStoredFile: vi.fn(),
+	logAction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/server/auth", () => ({
+	auth: mocks.auth,
+}));
+
+vi.mock("~/modules/export", () => ({
+	fetchFileById: mocks.fetchFileById,
+	fetchFileBySiren: mocks.fetchFileBySiren,
+}));
+
+vi.mock("~/server/services/fileStreaming", () => ({
+	streamStoredFile: mocks.streamStoredFile,
+}));
+
+vi.mock("~/server/audit/log", () => ({
+	logAction: mocks.logAction,
+}));
+
+import { GET } from "../route";
+
+// A SIRET whose first 9 digits form the admin's own SIREN scope.
+const ADMIN_SIRET = "98765432100010";
+const ADMIN_SIREN = "987654321";
+// The fictitious SIREN used by the ticket's scenarios for a company the
+// admin is not a referent of.
+const OTHER_SIREN_FILE = {
+	filePath: "123456789/2027/f.pdf",
+	fileName: "f.pdf",
+};
+const OWN_SIREN_FILE = { filePath: "987654321/2027/f.pdf", fileName: "f.pdf" };
+
+const HOUR = 60 * 60;
+
+function nowSeconds(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+function buildRequest(headers: Record<string, string> = {}): Request {
+	return new Request("http://localhost/api/v1/files/file-1", { headers });
+}
+
+function callGet(request: Request) {
+	return GET(request, { params: Promise.resolve({ fileId: "file-1" }) });
+}
+
+function mockStream(body = "content") {
+	mocks.streamStoredFile.mockResolvedValue(
+		new Response(body, { headers: { "Content-Type": "application/pdf" } }),
+	);
+}
+
+describe("GET /api/v1/files/:fileId", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockStream();
+	});
+
+	describe("gateway-forwarded caller (SUIT)", () => {
+		function gatewayRequest() {
+			return buildRequest({ "X-Gateway-Forwarded": "secret" });
+		}
+
+		it("serves the file by id without consulting the session, regardless of caller", async () => {
+			mocks.fetchFileById.mockResolvedValue(OTHER_SIREN_FILE);
+
+			const response = await callGet(gatewayRequest());
+
+			expect(response.status).toBe(200);
+			expect(mocks.auth).not.toHaveBeenCalled();
+			expect(mocks.fetchFileById).toHaveBeenCalledWith("file-1");
+			expect(mocks.streamStoredFile).toHaveBeenCalledWith(
+				expect.objectContaining({ disposition: "attachment" }),
+			);
+			expect(mocks.logAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "export.api_files",
+					status: "success",
+				}),
+			);
+		});
+
+		it("returns 404 and audits a failure when the file does not exist", async () => {
+			mocks.fetchFileById.mockResolvedValue(undefined);
+
+			const response = await callGet(gatewayRequest());
+
+			expect(response.status).toBe(404);
+			expect(mocks.logAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "export.api_files",
+					status: "failure",
+				}),
+			);
+		});
+
+		it("empty X-Gateway-Forwarded header falls through to the session branch", async () => {
+			mocks.auth.mockResolvedValue(null);
+
+			const response = await callGet(
+				buildRequest({ "X-Gateway-Forwarded": "" }),
+			);
+
+			expect(response.status).toBe(401);
+			expect(mocks.auth).toHaveBeenCalled();
+		});
+	});
+
+	describe("no session", () => {
+		it("returns 401 and audits a failure", async () => {
+			mocks.auth.mockResolvedValue(null);
+
+			const response = await callGet(buildRequest());
+
+			expect(response.status).toBe(401);
+			expect(mocks.logAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "user.file_download",
+					status: "failure",
+					errorMessage: "HTTP 401",
+				}),
+			);
+		});
+	});
+
+	describe("regular user session (unchanged)", () => {
+		it("serves a file within the caller's own SIREN scope, inline", async () => {
+			mocks.auth.mockResolvedValue({
+				user: { id: "user-1", email: "user@example.com", siret: ADMIN_SIRET },
+			});
+			mocks.fetchFileBySiren.mockResolvedValue(OWN_SIREN_FILE);
+
+			const response = await callGet(buildRequest());
+
+			expect(response.status).toBe(200);
+			expect(mocks.fetchFileBySiren).toHaveBeenCalledWith(
+				"file-1",
+				ADMIN_SIREN,
+			);
+			expect(mocks.streamStoredFile).toHaveBeenCalledWith(
+				expect.objectContaining({ disposition: "inline" }),
+			);
+			expect(mocks.logAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "user.file_download",
+					status: "success",
+					siren: ADMIN_SIREN,
+				}),
+			);
+		});
+
+		it("returns the generic 404 for a file outside the caller's scope, without mentioning MFA", async () => {
+			mocks.auth.mockResolvedValue({
+				user: { id: "user-1", email: "user@example.com", siret: ADMIN_SIRET },
+			});
+			mocks.fetchFileBySiren.mockResolvedValue(undefined);
+
+			const response = await callGet(buildRequest());
+
+			expect(response.status).toBe(404);
+			const body = await response.json();
+			expect(body.error).toBe("Fichier non trouvé");
+			expect(body.error).not.toMatch(/authentification/i);
+			expect(mocks.logAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "user.file_download",
+					status: "failure",
+					errorMessage: "HTTP 404",
+				}),
+			);
+		});
+
+		it("returns 401 when the session carries no usable SIREN", async () => {
+			mocks.auth.mockResolvedValue({
+				user: { id: "user-1", email: "user@example.com", siret: null },
+			});
+
+			const response = await callGet(buildRequest());
+
+			expect(response.status).toBe(401);
+			expect(mocks.fetchFileBySiren).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("admin session with a fresh double authentication", () => {
+		function freshAdminSession(overrides: Record<string, unknown> = {}) {
+			mocks.auth.mockResolvedValue({
+				user: {
+					id: "admin-1",
+					email: "admin@example.com",
+					siret: ADMIN_SIRET,
+					isAdmin: true,
+					adminMfaAt: nowSeconds() - 60,
+					...overrides,
+				},
+			});
+		}
+
+		it("bypasses SIREN scope and serves any file as an attachment (S13 scenario 1)", async () => {
+			freshAdminSession();
+			mocks.fetchFileById.mockResolvedValue(OTHER_SIREN_FILE);
+
+			const response = await callGet(buildRequest());
+
+			expect(response.status).toBe(200);
+			expect(mocks.fetchFileById).toHaveBeenCalledWith("file-1");
+			expect(mocks.fetchFileBySiren).not.toHaveBeenCalled();
+			expect(mocks.streamStoredFile).toHaveBeenCalledWith(
+				expect.objectContaining({ disposition: "attachment" }),
+			);
+			expect(mocks.logAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "admin.file_download",
+					status: "success",
+				}),
+			);
+		});
+
+		it("returns the unchanged 404 when the file does not exist", async () => {
+			freshAdminSession();
+			mocks.fetchFileById.mockResolvedValue(undefined);
+
+			const response = await callGet(buildRequest());
+
+			expect(response.status).toBe(404);
+			expect(mocks.logAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "admin.file_download",
+					status: "failure",
+					errorMessage: "HTTP 404",
+				}),
+			);
+		});
+	});
+
+	describe("admin session with an expired double authentication (S13)", () => {
+		function expiredAdminSession(overrides: Record<string, unknown> = {}) {
+			mocks.auth.mockResolvedValue({
+				user: {
+					id: "admin-1",
+					email: "admin@example.com",
+					siret: ADMIN_SIRET,
+					isAdmin: true,
+					adminMfaAt: nowSeconds() - 9 * HOUR,
+					...overrides,
+				},
+			});
+		}
+
+		it("serves a file within the admin's own SIREN scope, like a regular user (S8)", async () => {
+			expiredAdminSession();
+			mocks.fetchFileBySiren.mockResolvedValue(OWN_SIREN_FILE);
+
+			const response = await callGet(buildRequest());
+
+			expect(response.status).toBe(200);
+			expect(mocks.fetchFileBySiren).toHaveBeenCalledWith(
+				"file-1",
+				ADMIN_SIREN,
+			);
+			expect(mocks.fetchFileById).not.toHaveBeenCalled();
+			expect(mocks.streamStoredFile).toHaveBeenCalledWith(
+				expect.objectContaining({ disposition: "inline" }),
+			);
+			expect(mocks.logAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "user.file_download",
+					status: "success",
+					siren: ADMIN_SIREN,
+				}),
+			);
+		});
+
+		it("refuses a file outside the admin's own SIREN scope, naming the expired double authentication", async () => {
+			expiredAdminSession();
+			mocks.fetchFileBySiren.mockResolvedValue(undefined);
+
+			const response = await callGet(buildRequest());
+
+			expect(response.status).toBe(403);
+			const body = await response.json();
+			expect(body.error).toMatch(/double authentification/i);
+			expect(mocks.streamStoredFile).not.toHaveBeenCalled();
+			expect(mocks.logAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "admin.file_download",
+					status: "failure",
+					errorMessage: "HTTP 403 admin_mfa_expired",
+					siren: ADMIN_SIREN,
+				}),
+			);
+		});
+
+		it("refuses explicitly when the admin has no usable SIREN of their own", async () => {
+			expiredAdminSession({ siret: null });
+
+			const response = await callGet(buildRequest());
+
+			expect(response.status).toBe(403);
+			const body = await response.json();
+			expect(body.error).toMatch(/double authentification/i);
+			expect(mocks.fetchFileBySiren).not.toHaveBeenCalled();
+			expect(mocks.logAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "admin.file_download",
+					status: "failure",
+					errorMessage: "HTTP 403 admin_mfa_expired",
+					siren: null,
+				}),
+			);
+		});
+
+		it("treats a session that never completed the double authentication the same as expired", async () => {
+			mocks.auth.mockResolvedValue({
+				user: {
+					id: "admin-1",
+					email: "admin@example.com",
+					siret: ADMIN_SIRET,
+					isAdmin: true,
+					adminMfaAt: null,
+				},
+			});
+			mocks.fetchFileBySiren.mockResolvedValue(undefined);
+
+			const response = await callGet(buildRequest());
+
+			expect(response.status).toBe(403);
+			expect(mocks.fetchFileById).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/app/src/app/api/v1/files/[fileId]/route.ts
+++ b/packages/app/src/app/api/v1/files/[fileId]/route.ts
@@ -1,5 +1,5 @@
 import { AUDIT_ACTIONS, type AuditActionKey } from "~/modules/audit";
-import { parseSiren } from "~/modules/domain";
+import { isAdminMfaFresh, parseSiren } from "~/modules/domain";
 import { fetchFileById, fetchFileBySiren } from "~/modules/export";
 import { logAction } from "~/server/audit/log";
 import {
@@ -15,13 +15,21 @@ import { isGatewayForwarded } from "~/server/services/gatewaySource";
  *
  * Unified file-streaming endpoint serving three caller types:
  *  - SUIT REST API consumers (via APISIX gateway, attachment, no SIREN scope)
- *  - Admin backoffice users (NextAuth session + isAdmin, attachment, no SIREN scope)
+ *  - Admin backoffice users (NextAuth session + isAdmin, attachment, no SIREN
+ *    scope — but only while the double authentication is fresh, see below)
  *  - In-app authenticated users (NextAuth session, inline, SIREN-scoped)
  *
  * Caller detection:
  *  - `X-Gateway-Forwarded` header present → SUIT (injected by APISIX's
  *    `proxy-rewrite` plugin; validated by the Edge middleware)
  *  - otherwise → session-based (admin vs. regular decided by `isAdmin` flag)
+ *
+ * The admin SIREN-scope bypass is the platform's most discreet privilege —
+ * it is gated on `isAdminMfaFresh` (epic #4405). Past the 8h window the
+ * admin is not refused outright: they are demoted to their own SIREN scope,
+ * same as a declarant (S8), and only a request that falls outside that
+ * scope is refused, explicitly naming the double authentication to redo
+ * (S13). The gateway and regular-user branches are untouched.
  *
  * Each branch logs to the audit trail with its own action key.
  */
@@ -93,8 +101,8 @@ async function handleSuitDownload(
 }
 
 /**
- * Session-based download: dispatches to admin (no SIREN scope) or regular user
- * (SIREN-scoped) based on `isAdmin` flag.
+ * Session-based download: dispatches to admin (no SIREN scope, MFA-gated) or
+ * regular user (SIREN-scoped) based on `isAdmin` flag.
  */
 async function handleSessionDownload(
 	request: Request,
@@ -115,7 +123,9 @@ async function handleSessionDownload(
 	}
 
 	if (session.user.isAdmin) {
-		return handleAdminDownload(fileId, session, requestContext);
+		return isAdminMfaFresh(session.user.adminMfaAt, new Date())
+			? handleAdminDownload(fileId, session, requestContext)
+			: handleAdminDownloadDemoted(fileId, session, requestContext);
 	}
 
 	const siren = parseSiren(session.user.siret);
@@ -192,6 +202,93 @@ async function handleAdminDownload(
 		});
 		return Response.json(
 			{ error: "Erreur lors du téléchargement du fichier" },
+			{ status: 500 },
+		);
+	}
+}
+
+/**
+ * Named after S13: a habilitated agent refused an out-of-scope attachment
+ * because the window lapsed must be told so — never the same silent
+ * "not found" a never-habilitated user gets.
+ */
+const ADMIN_MFA_EXPIRED_ERROR =
+	"Cette pièce jointe est hors de votre périmètre : la double authentification doit être refaite pour y accéder.";
+
+/**
+ * Admin session whose double authentication has fallen out of the 8h window
+ * (`isAdminMfaFresh`, epic #4405). The SIREN-scope bypass is the privilege
+ * being guarded, so it is withdrawn — but the admin is also a declarant
+ * (S8), so the demotion is to their own SIREN scope, not a blanket refusal:
+ * a file within it is served exactly as it would be for a regular user, and
+ * only a request that falls outside it is refused, explicitly naming the
+ * double authentication to redo (S13). Logged under the admin download
+ * action key — this is still the admin bypass surface, just gated — per the
+ * ticket's instruction not to invent a new audit category for the refusal.
+ */
+async function handleAdminDownloadDemoted(
+	fileId: string,
+	session: {
+		user: { id?: string | null; email?: string | null; siret?: string | null };
+	},
+	requestContext: RequestContext,
+): Promise<Response> {
+	const startedAt = Date.now();
+	const siren = parseSiren(session.user.siret);
+
+	try {
+		const file = siren ? await fetchFileBySiren(fileId, siren) : undefined;
+		if (!file) {
+			writeAuditFailure({
+				action: AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD,
+				fileId,
+				errorMessage: "HTTP 403 admin_mfa_expired",
+				requestContext,
+				startedAt,
+				userId: session.user.id ?? null,
+				userEmail: session.user.email ?? null,
+				siren,
+			});
+			return Response.json({ error: ADMIN_MFA_EXPIRED_ERROR }, { status: 403 });
+		}
+
+		const response = await streamStoredFile({
+			filePath: file.filePath,
+			fileName: file.fileName,
+			disposition: "inline",
+			cacheControl: "private, no-store",
+		});
+
+		void logAction({
+			action: AUDIT_ACTIONS.USER_FILE_DOWNLOAD,
+			status: "success",
+			userId: session.user.id ?? null,
+			userEmail: session.user.email ?? null,
+			siren,
+			metadata: { fileId, fileName: file.fileName },
+			ipAddress: requestContext.ipAddress,
+			userAgent: requestContext.userAgent,
+			durationMs: Date.now() - startedAt,
+		});
+
+		return response;
+	} catch (error) {
+		console.error(
+			"[api/v1/files/:fileId][admin-demoted]",
+			error instanceof Error ? error.message : "unknown error",
+		);
+		writeAuditFailure({
+			action: AUDIT_ACTIONS.USER_FILE_DOWNLOAD,
+			fileId,
+			errorMessage: error instanceof Error ? error.message : "Unknown error",
+			requestContext,
+			startedAt,
+			userId: session.user.id ?? null,
+			userEmail: session.user.email ?? null,
+			siren,
+		});
+		return Response.json(
+			{ error: "Erreur lors de la récupération du fichier" },
 			{ status: 500 },
 		);
 	}

--- a/packages/app/src/app/api/v1/files/[fileId]/route.ts
+++ b/packages/app/src/app/api/v1/files/[fileId]/route.ts
@@ -16,20 +16,15 @@ import { isGatewayForwarded } from "~/server/services/gatewaySource";
  * Unified file-streaming endpoint serving three caller types:
  *  - SUIT REST API consumers (via APISIX gateway, attachment, no SIREN scope)
  *  - Admin backoffice users (NextAuth session + isAdmin, attachment, no SIREN
- *    scope — but only while the double authentication is fresh, see below)
+ *    scope while the double authentication is fresh — past that window the
+ *    admin's own SIREN scope applies instead, since they are also a
+ *    declarant)
  *  - In-app authenticated users (NextAuth session, inline, SIREN-scoped)
  *
  * Caller detection:
  *  - `X-Gateway-Forwarded` header present → SUIT (injected by APISIX's
  *    `proxy-rewrite` plugin; validated by the Edge middleware)
  *  - otherwise → session-based (admin vs. regular decided by `isAdmin` flag)
- *
- * The admin SIREN-scope bypass is the platform's most discreet privilege —
- * it is gated on `isAdminMfaFresh` (epic #4405). Past the 8h window the
- * admin is not refused outright: they are demoted to their own SIREN scope,
- * same as a declarant (S8), and only a request that falls outside that
- * scope is refused, explicitly naming the double authentication to redo
- * (S13). The gateway and regular-user branches are untouched.
  *
  * Each branch logs to the audit trail with its own action key.
  */
@@ -44,36 +39,83 @@ export async function GET(
 		: handleSessionDownload(request, fileId);
 }
 
-async function handleSuitDownload(
-	request: Request,
-	fileId: string,
-): Promise<Response> {
+type CallerIdentity = {
+	userId?: string | null;
+	userEmail?: string | null;
+	siren?: string | null;
+};
+
+type ServeFileInput = CallerIdentity & {
+	fileId: string;
+	requestContext: RequestContext;
+	fetchFile: () => Promise<{ filePath: string; fileName: string } | undefined>;
+	disposition: "inline" | "attachment";
+	cacheControl: string;
+	logLabel: string;
+	notFound: {
+		action: AuditActionKey;
+		status: number;
+		error: string;
+		auditMessage: string;
+	};
+	success: { action: AuditActionKey };
+	failure: { action: AuditActionKey; error: string };
+};
+
+/**
+ * Shared fetch → stream → audit sequence for the four caller branches
+ * below. They differ only in how the file is looked up, its disposition,
+ * and which audit action each outcome is tagged with — this centralises
+ * everything else so the try/catch/log skeleton exists exactly once.
+ */
+async function serveFile({
+	fileId,
+	requestContext,
+	userId = null,
+	userEmail = null,
+	siren = null,
+	fetchFile,
+	disposition,
+	cacheControl,
+	logLabel,
+	notFound,
+	success,
+	failure,
+}: ServeFileInput): Promise<Response> {
 	const startedAt = Date.now();
-	const requestContext = buildRequestContext(request.headers);
 
 	try {
-		const file = await fetchFileById(fileId);
+		const file = await fetchFile();
 		if (!file) {
 			writeAuditFailure({
-				action: AUDIT_ACTIONS.EXPORT_API_FILES,
+				action: notFound.action,
 				fileId,
-				errorMessage: "HTTP 404",
+				errorMessage: notFound.auditMessage,
 				requestContext,
 				startedAt,
+				userId,
+				userEmail,
+				siren,
 			});
-			return Response.json({ error: "Fichier non trouvé" }, { status: 404 });
+			return Response.json(
+				{ error: notFound.error },
+				{ status: notFound.status },
+			);
 		}
 
 		const response = await streamStoredFile({
 			filePath: file.filePath,
 			fileName: file.fileName,
-			disposition: "attachment",
-			cacheControl: "private, max-age=3600",
+			disposition,
+			cacheControl,
 		});
 
 		void logAction({
-			action: AUDIT_ACTIONS.EXPORT_API_FILES,
+			action: success.action,
 			status: "success",
+			userId,
+			userEmail,
+			siren,
 			metadata: { fileId, fileName: file.fileName },
 			ipAddress: requestContext.ipAddress,
 			userAgent: requestContext.userAgent,
@@ -83,21 +125,46 @@ async function handleSuitDownload(
 		return response;
 	} catch (error) {
 		console.error(
-			"[api/v1/files/:fileId][suit]",
+			`[api/v1/files/:fileId][${logLabel}]`,
 			error instanceof Error ? error.message : "unknown error",
 		);
 		writeAuditFailure({
-			action: AUDIT_ACTIONS.EXPORT_API_FILES,
+			action: failure.action,
 			fileId,
 			errorMessage: error instanceof Error ? error.message : "Unknown error",
 			requestContext,
 			startedAt,
+			userId,
+			userEmail,
+			siren,
 		});
-		return Response.json(
-			{ error: "Erreur lors du téléchargement du fichier" },
-			{ status: 500 },
-		);
+		return Response.json({ error: failure.error }, { status: 500 });
 	}
+}
+
+async function handleSuitDownload(
+	request: Request,
+	fileId: string,
+): Promise<Response> {
+	return serveFile({
+		fileId,
+		requestContext: buildRequestContext(request.headers),
+		fetchFile: () => fetchFileById(fileId),
+		disposition: "attachment",
+		cacheControl: "private, max-age=3600",
+		logLabel: "suit",
+		notFound: {
+			action: AUDIT_ACTIONS.EXPORT_API_FILES,
+			status: 404,
+			error: "Fichier non trouvé",
+			auditMessage: "HTTP 404",
+		},
+		success: { action: AUDIT_ACTIONS.EXPORT_API_FILES },
+		failure: {
+			action: AUDIT_ACTIONS.EXPORT_API_FILES,
+			error: "Erreur lors du téléchargement du fichier",
+		},
+	});
 }
 
 /**
@@ -150,148 +217,76 @@ async function handleAdminDownload(
 	session: { user: { id?: string | null; email?: string | null } },
 	requestContext: RequestContext,
 ): Promise<Response> {
-	const startedAt = Date.now();
-
-	try {
-		const file = await fetchFileById(fileId);
-		if (!file) {
-			writeAuditFailure({
-				action: AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD,
-				fileId,
-				errorMessage: "HTTP 404",
-				requestContext,
-				startedAt,
-				userId: session.user.id ?? null,
-				userEmail: session.user.email ?? null,
-			});
-			return Response.json({ error: "Fichier non trouvé" }, { status: 404 });
-		}
-
-		const response = await streamStoredFile({
-			filePath: file.filePath,
-			fileName: file.fileName,
-			disposition: "attachment",
-			cacheControl: "private, max-age=3600",
-		});
-
-		void logAction({
+	return serveFile({
+		fileId,
+		requestContext,
+		userId: session.user.id,
+		userEmail: session.user.email,
+		fetchFile: () => fetchFileById(fileId),
+		disposition: "attachment",
+		cacheControl: "private, max-age=3600",
+		logLabel: "admin",
+		notFound: {
 			action: AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD,
-			status: "success",
-			userId: session.user.id ?? null,
-			userEmail: session.user.email ?? null,
-			metadata: { fileId, fileName: file.fileName },
-			ipAddress: requestContext.ipAddress,
-			userAgent: requestContext.userAgent,
-			durationMs: Date.now() - startedAt,
-		});
-
-		return response;
-	} catch (error) {
-		console.error(
-			"[api/v1/files/:fileId][admin]",
-			error instanceof Error ? error.message : "unknown error",
-		);
-		writeAuditFailure({
+			status: 404,
+			error: "Fichier non trouvé",
+			auditMessage: "HTTP 404",
+		},
+		success: { action: AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD },
+		failure: {
 			action: AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD,
-			fileId,
-			errorMessage: error instanceof Error ? error.message : "Unknown error",
-			requestContext,
-			startedAt,
-			userId: session.user.id ?? null,
-			userEmail: session.user.email ?? null,
-		});
-		return Response.json(
-			{ error: "Erreur lors du téléchargement du fichier" },
-			{ status: 500 },
-		);
-	}
+			error: "Erreur lors du téléchargement du fichier",
+		},
+	});
 }
 
-/**
- * Named after S13: a habilitated agent refused an out-of-scope attachment
- * because the window lapsed must be told so — never the same silent
- * "not found" a never-habilitated user gets.
- */
+// A habilitated agent refused an out-of-scope attachment because their
+// window lapsed must be told so — never the same silent "not found" a
+// never-habilitated user gets.
 const ADMIN_MFA_EXPIRED_ERROR =
 	"Cette pièce jointe est hors de votre périmètre : la double authentification doit être refaite pour y accéder.";
 
-/**
- * Admin session whose double authentication has fallen out of the 8h window
- * (`isAdminMfaFresh`, epic #4405). The SIREN-scope bypass is the privilege
- * being guarded, so it is withdrawn — but the admin is also a declarant
- * (S8), so the demotion is to their own SIREN scope, not a blanket refusal:
- * a file within it is served exactly as it would be for a regular user, and
- * only a request that falls outside it is refused, explicitly naming the
- * double authentication to redo (S13). Logged under the admin download
- * action key — this is still the admin bypass surface, just gated — per the
- * ticket's instruction not to invent a new audit category for the refusal.
- */
 async function handleAdminDownloadDemoted(
 	fileId: string,
 	session: {
-		user: { id?: string | null; email?: string | null; siret?: string | null };
+		user: {
+			id?: string | null;
+			email?: string | null;
+			siret?: string | null;
+		};
 	},
 	requestContext: RequestContext,
 ): Promise<Response> {
-	const startedAt = Date.now();
 	const siren = parseSiren(session.user.siret);
 
-	try {
-		const file = siren ? await fetchFileBySiren(fileId, siren) : undefined;
-		if (!file) {
-			writeAuditFailure({
-				action: AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD,
-				fileId,
-				errorMessage: "HTTP 403 admin_mfa_expired",
-				requestContext,
-				startedAt,
-				userId: session.user.id ?? null,
-				userEmail: session.user.email ?? null,
-				siren,
-			});
-			return Response.json({ error: ADMIN_MFA_EXPIRED_ERROR }, { status: 403 });
-		}
-
-		const response = await streamStoredFile({
-			filePath: file.filePath,
-			fileName: file.fileName,
-			disposition: "inline",
-			cacheControl: "private, no-store",
-		});
-
-		void logAction({
+	return serveFile({
+		fileId,
+		requestContext,
+		userId: session.user.id,
+		userEmail: session.user.email,
+		siren,
+		// No siren at all is refused the same way as one that doesn't match:
+		// either way the admin's own scope doesn't cover this file.
+		fetchFile: () =>
+			siren ? fetchFileBySiren(fileId, siren) : Promise.resolve(undefined),
+		disposition: "inline",
+		cacheControl: "private, no-store",
+		logLabel: "admin-demoted",
+		notFound: {
+			action: AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD,
+			status: 403,
+			error: ADMIN_MFA_EXPIRED_ERROR,
+			auditMessage: "HTTP 403 admin_mfa_expired",
+		},
+		// A file within the admin's own scope is served exactly like a regular
+		// user's — only the refusal above is tagged as the admin surface being
+		// denied.
+		success: { action: AUDIT_ACTIONS.USER_FILE_DOWNLOAD },
+		failure: {
 			action: AUDIT_ACTIONS.USER_FILE_DOWNLOAD,
-			status: "success",
-			userId: session.user.id ?? null,
-			userEmail: session.user.email ?? null,
-			siren,
-			metadata: { fileId, fileName: file.fileName },
-			ipAddress: requestContext.ipAddress,
-			userAgent: requestContext.userAgent,
-			durationMs: Date.now() - startedAt,
-		});
-
-		return response;
-	} catch (error) {
-		console.error(
-			"[api/v1/files/:fileId][admin-demoted]",
-			error instanceof Error ? error.message : "unknown error",
-		);
-		writeAuditFailure({
-			action: AUDIT_ACTIONS.USER_FILE_DOWNLOAD,
-			fileId,
-			errorMessage: error instanceof Error ? error.message : "Unknown error",
-			requestContext,
-			startedAt,
-			userId: session.user.id ?? null,
-			userEmail: session.user.email ?? null,
-			siren,
-		});
-		return Response.json(
-			{ error: "Erreur lors de la récupération du fichier" },
-			{ status: 500 },
-		);
-	}
+			error: "Erreur lors de la récupération du fichier",
+		},
+	});
 }
 
 async function handleUserDownload(
@@ -300,64 +295,28 @@ async function handleUserDownload(
 	siren: string,
 	requestContext: RequestContext,
 ): Promise<Response> {
-	const startedAt = Date.now();
-
-	try {
-		const file = await fetchFileBySiren(fileId, siren);
-		if (!file) {
-			writeAuditFailure({
-				action: AUDIT_ACTIONS.USER_FILE_DOWNLOAD,
-				fileId,
-				errorMessage: "HTTP 404",
-				requestContext,
-				startedAt,
-				userId: session.user.id ?? null,
-				userEmail: session.user.email ?? null,
-				siren,
-			});
-			return Response.json({ error: "Fichier non trouvé" }, { status: 404 });
-		}
-
-		const response = await streamStoredFile({
-			filePath: file.filePath,
-			fileName: file.fileName,
-			disposition: "inline",
-			cacheControl: "private, no-store",
-		});
-
-		void logAction({
+	return serveFile({
+		fileId,
+		requestContext,
+		userId: session.user.id,
+		userEmail: session.user.email,
+		siren,
+		fetchFile: () => fetchFileBySiren(fileId, siren),
+		disposition: "inline",
+		cacheControl: "private, no-store",
+		logLabel: "session",
+		notFound: {
 			action: AUDIT_ACTIONS.USER_FILE_DOWNLOAD,
-			status: "success",
-			userId: session.user.id ?? null,
-			userEmail: session.user.email ?? null,
-			siren,
-			metadata: { fileId, fileName: file.fileName },
-			ipAddress: requestContext.ipAddress,
-			userAgent: requestContext.userAgent,
-			durationMs: Date.now() - startedAt,
-		});
-
-		return response;
-	} catch (error) {
-		console.error(
-			"[api/v1/files/:fileId][session]",
-			error instanceof Error ? error.message : "unknown error",
-		);
-		writeAuditFailure({
+			status: 404,
+			error: "Fichier non trouvé",
+			auditMessage: "HTTP 404",
+		},
+		success: { action: AUDIT_ACTIONS.USER_FILE_DOWNLOAD },
+		failure: {
 			action: AUDIT_ACTIONS.USER_FILE_DOWNLOAD,
-			fileId,
-			errorMessage: error instanceof Error ? error.message : "Unknown error",
-			requestContext,
-			startedAt,
-			userId: session.user.id ?? null,
-			userEmail: session.user.email ?? null,
-			siren,
-		});
-		return Response.json(
-			{ error: "Erreur lors de la récupération du fichier" },
-			{ status: 500 },
-		);
-	}
+			error: "Erreur lors de la récupération du fichier",
+		},
+	});
 }
 
 type AuditFailureInput = {


### PR DESCRIPTION
Closes #4464

Troisième et dernière surface privilégiée de l'epic #4405. Le point de terminaison de téléchargement de pièce jointe sert trois types d'appelants, et l'un d'eux — la session administrateur — contournait le périmètre SIREN et servait n'importe quel fichier de la plateforme sur la seule foi de l'habilitation.

## Ce que ça change

Le contournement de périmètre reste, mais il est désormais conditionné à une fenêtre de double authentification fraîche. Hors fenêtre, l'agent n'est pas refusé sec : il est **déclassé** au rang de déclarant sur son propre périmètre SIREN, ce qui préserve S8 — il continue de consulter ses propres pièces sans se reconnecter. Seule une demande hors de ce périmètre est refusée, en nommant explicitement la double authentification à refaire (S13).

Les branches passerelle et utilisateur ordinaire sont inchangées.

Le second commit factorise les trois branches derrière un seul serveur de fichier : elles répétaient la même séquence de récupération, de journalisation d'audit et de construction de réponse, avec pour seules différences la disposition, l'en-tête de cache et les clés d'audit.

## Scénarios couverts

- **S8** — l'agent hors fenêtre garde l'accès à ses propres pièces
- **S13** — une pièce hors périmètre est refusée avec un message explicite

## Vérifications

- `pnpm typecheck` vert
- `pnpm test` vert — 6164 tests, dont 339 lignes de tests neufs sur ce point de terminaison
- `pnpm check:write` sans correction à appliquer
