### PR TITLE
feat(admin): #4463 — garde des procédures tRPC d'administration hors fenêtre MFA

### DIFF
--- a/packages/app/src/modules/admin/index.ts
+++ b/packages/app/src/modules/admin/index.ts
@@ -14,3 +14,9 @@ export {
 	releaseLockSchema,
 	sirenSchema,
 } from "./schemas";
+export {
+	ADMIN_MFA_REQUIRED_MARKER,
+	ADMIN_MFA_REQUIRED_MESSAGE,
+	AdminMfaRequiredError,
+	isAdminMfaRequiredErrorData,
+} from "./shared/adminMfaGuard";

--- a/packages/app/src/modules/admin/shared/__tests__/adminMfaGuard.test.ts
+++ b/packages/app/src/modules/admin/shared/__tests__/adminMfaGuard.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+	ADMIN_MFA_REQUIRED_MARKER,
+	AdminMfaRequiredError,
+	isAdminMfaRequiredErrorData,
+} from "../adminMfaGuard";
+
+describe("isAdminMfaRequiredErrorData", () => {
+	it("returns true when the marker is set to true", () => {
+		expect(
+			isAdminMfaRequiredErrorData({ [ADMIN_MFA_REQUIRED_MARKER]: true }),
+		).toBe(true);
+	});
+
+	it("returns false when the marker is set to false", () => {
+		expect(
+			isAdminMfaRequiredErrorData({ [ADMIN_MFA_REQUIRED_MARKER]: false }),
+		).toBe(false);
+	});
+
+	it("returns false when the marker is absent", () => {
+		expect(isAdminMfaRequiredErrorData({ code: "FORBIDDEN" })).toBe(false);
+	});
+
+	it("returns false for null, undefined and non-object data", () => {
+		expect(isAdminMfaRequiredErrorData(null)).toBe(false);
+		expect(isAdminMfaRequiredErrorData(undefined)).toBe(false);
+		expect(isAdminMfaRequiredErrorData("adminMfaRequired")).toBe(false);
+	});
+});
+
+describe("AdminMfaRequiredError", () => {
+	it("carries the shared refusal message and a stable name", () => {
+		const error = new AdminMfaRequiredError();
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe("AdminMfaRequiredError");
+		expect(error.message).toContain("double authentification");
+	});
+});

--- a/packages/app/src/modules/admin/shared/adminMfaGuard.ts
+++ b/packages/app/src/modules/admin/shared/adminMfaGuard.ts
@@ -1,0 +1,23 @@
+export const ADMIN_MFA_REQUIRED_MARKER = "adminMfaRequired" as const;
+
+export const ADMIN_MFA_REQUIRED_MESSAGE =
+	"La double authentification administrateur doit être refaite pour continuer.";
+
+// Distinguishes an MFA-window refusal from every other error `adminProcedure`
+// can throw (habilitation, or any downstream procedure error): only this
+// cause flips the marker in the tRPC error shape, so callers never compare
+// the message string to tell the two refusals apart.
+export class AdminMfaRequiredError extends Error {
+	constructor() {
+		super(ADMIN_MFA_REQUIRED_MESSAGE);
+		this.name = "AdminMfaRequiredError";
+	}
+}
+
+export function isAdminMfaRequiredErrorData(data: unknown): boolean {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		(data as Record<string, unknown>)[ADMIN_MFA_REQUIRED_MARKER] === true
+	);
+}

--- a/packages/app/src/server/api/__tests__/adminProcedure.test.ts
+++ b/packages/app/src/server/api/__tests__/adminProcedure.test.ts
@@ -1,24 +1,38 @@
 import { TRPCError } from "@trpc/server";
 import { describe, expect, it, vi } from "vitest";
+import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
 
 vi.mock("~/server/auth", () => ({ auth: vi.fn() }));
 vi.mock("~/server/db", () => ({ db: {} }));
 
-import { adminProcedure, createTRPCRouter } from "../trpc";
+import {
+	adminProcedure,
+	createTRPCRouter,
+	isAdminMfaRequiredTRPCError,
+} from "../trpc";
 
-const pingRouter = createTRPCRouter({
+const NOW_SECONDS = Math.floor(Date.now() / 1000);
+const FRESH_MFA_AT = NOW_SECONDS - 60;
+const STALE_MFA_AT = NOW_SECONDS - (ADMIN_MFA_WINDOW_SECONDS + 60);
+
+const dbWriteSpy = vi.fn();
+const guardedRouter = createTRPCRouter({
 	ping: adminProcedure.query(() => "pong"),
+	write: adminProcedure.mutation(() => {
+		dbWriteSpy();
+		return "written";
+	}),
 });
 
-function createCaller(isAdmin: boolean | null) {
+function createCaller(isAdmin: boolean | null, adminMfaAt?: number | null) {
 	const session =
 		isAdmin === null
 			? null
 			: {
-					user: { id: "user-1", email: "u@example.com", isAdmin },
+					user: { id: "user-1", email: "u@example.com", isAdmin, adminMfaAt },
 					expires: "",
 				};
-	return pingRouter.createCaller({
+	return guardedRouter.createCaller({
 		db: {},
 		session,
 		headers: new Headers(),
@@ -32,14 +46,76 @@ describe("adminProcedure", () => {
 		});
 	});
 
-	it("throws FORBIDDEN when the user is not admin", async () => {
+	it("throws FORBIDDEN with the unchanged message when the user is not admin", async () => {
 		await expect(createCaller(false).ping()).rejects.toBeInstanceOf(TRPCError);
 		await expect(createCaller(false).ping()).rejects.toMatchObject({
 			code: "FORBIDDEN",
+			message: "Accès réservé aux administrateurs.",
 		});
 	});
 
-	it("resolves for an admin user", async () => {
-		await expect(createCaller(true).ping()).resolves.toBe("pong");
+	it("does not mark the non-admin refusal with the MFA-required cause", async () => {
+		try {
+			await createCaller(false).ping();
+			throw new Error("expected ping() to throw");
+		} catch (error) {
+			expect(isAdminMfaRequiredTRPCError(error as TRPCError)).toBe(false);
+		}
+	});
+
+	it("resolves for an admin user with a fresh MFA", async () => {
+		await expect(createCaller(true, FRESH_MFA_AT).ping()).resolves.toBe("pong");
+	});
+
+	it("throws FORBIDDEN with the MFA-required marker when the admin has no MFA timestamp", async () => {
+		try {
+			await createCaller(true, null).ping();
+			throw new Error("expected ping() to throw");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+			expect((error as TRPCError).code).toBe("FORBIDDEN");
+			expect(isAdminMfaRequiredTRPCError(error as TRPCError)).toBe(true);
+		}
+	});
+
+	it("throws FORBIDDEN with the MFA-required marker when the admin MFA is stale", async () => {
+		try {
+			await createCaller(true, STALE_MFA_AT).ping();
+			throw new Error("expected ping() to throw");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+			expect((error as TRPCError).code).toBe("FORBIDDEN");
+			expect(isAdminMfaRequiredTRPCError(error as TRPCError)).toBe(true);
+		}
+	});
+
+	it("refuses a read the same way a write is refused when the MFA is stale", async () => {
+		await expect(createCaller(true, STALE_MFA_AT).ping()).rejects.toMatchObject(
+			{ code: "FORBIDDEN" },
+		);
+	});
+
+	it("never runs the mutation body — and never touches the database — when the MFA is stale", async () => {
+		dbWriteSpy.mockClear();
+		await expect(
+			createCaller(true, STALE_MFA_AT).write(),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+		expect(dbWriteSpy).not.toHaveBeenCalled();
+	});
+
+	it("runs the mutation body when the admin MFA is fresh", async () => {
+		dbWriteSpy.mockClear();
+		await expect(createCaller(true, FRESH_MFA_AT).write()).resolves.toBe(
+			"written",
+		);
+		expect(dbWriteSpy).toHaveBeenCalledOnce();
+	});
+});
+
+describe("isAdminMfaRequiredTRPCError", () => {
+	it("is false for a plain TRPCError with no cause", () => {
+		expect(
+			isAdminMfaRequiredTRPCError(new TRPCError({ code: "FORBIDDEN" })),
+		).toBe(false);
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/admin.searchCompany.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/admin.searchCompany.test.ts
@@ -36,7 +36,12 @@ async function callSearchCompany(
 	const caller = adminRouter.createCaller({
 		db: buildDb(gipRows),
 		session: {
-			user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+			user: {
+				id: "admin-1",
+				email: "admin@example.fr",
+				isAdmin: true,
+				adminMfaAt: Math.floor(Date.now() / 1000),
+			},
 			expires: "",
 		},
 		headers: new Headers(),
@@ -127,7 +132,12 @@ describe("adminRouter.searchCompany", () => {
 		const caller = adminRouter.createCaller({
 			db,
 			session: {
-				user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+				user: {
+					id: "admin-1",
+					email: "admin@example.fr",
+					isAdmin: true,
+					adminMfaAt: Math.floor(Date.now() / 1000),
+				},
 				expires: "",
 			},
 			headers: new Headers(),

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.cancel.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.cancel.test.ts
@@ -23,7 +23,12 @@ const DECL_ID_3 = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
 const DECL_ID_4 = "6ba7b813-9dad-11d1-80b4-00c04fd430c8";
 
 const adminSession = {
-	user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+	user: {
+		id: "admin-1",
+		email: "admin@example.fr",
+		isAdmin: true,
+		adminMfaAt: Math.floor(Date.now() / 1000),
+	},
 	expires: "",
 };
 

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.getById.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.getById.test.ts
@@ -13,7 +13,12 @@ const DECL_ID_2 = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
 const DECL_ID_3 = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
 
 const adminSession = {
-	user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+	user: {
+		id: "admin-1",
+		email: "admin@example.fr",
+		isAdmin: true,
+		adminMfaAt: Math.floor(Date.now() / 1000),
+	},
 	expires: "",
 };
 

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.getRecap.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.getRecap.test.ts
@@ -20,7 +20,12 @@ const DECL_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 const MISSING_ID = "6ba7b899-9dad-11d1-80b4-00c04fd430c8";
 
 const adminSession = {
-	user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+	user: {
+		id: "admin-1",
+		email: "admin@example.fr",
+		isAdmin: true,
+		adminMfaAt: Math.floor(Date.now() / 1000),
+	},
 	expires: "",
 };
 

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.releaseLock.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.releaseLock.test.ts
@@ -12,7 +12,12 @@ vi.mock("~/server/db", () => ({
 const DECL_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 
 const adminSession = {
-	user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+	user: {
+		id: "admin-1",
+		email: "admin@example.fr",
+		isAdmin: true,
+		adminMfaAt: Math.floor(Date.now() / 1000),
+	},
 	expires: "",
 };
 

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.search.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.search.test.ts
@@ -12,7 +12,12 @@ const DECL_ID_1 = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 const DECL_ID_2 = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
 
 const adminSession = {
-	user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+	user: {
+		id: "admin-1",
+		email: "admin@example.fr",
+		isAdmin: true,
+		adminMfaAt: Math.floor(Date.now() / 1000),
+	},
 	expires: "",
 };
 

--- a/packages/app/src/server/api/routers/__tests__/adminReferents.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminReferents.test.ts
@@ -83,7 +83,12 @@ async function createCaller(mockDb: unknown, isAdmin = true) {
 	return adminReferentsRouter.createCaller({
 		db: mockDb,
 		session: {
-			user: { id: "admin-1", email: "admin@gov.fr", isAdmin },
+			user: {
+				id: "admin-1",
+				email: "admin@gov.fr",
+				isAdmin,
+				adminMfaAt: Math.floor(Date.now() / 1000),
+			},
 			expires: "",
 		},
 		headers: new Headers(),

--- a/packages/app/src/server/api/routers/__tests__/adminSettings.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminSettings.test.ts
@@ -54,7 +54,12 @@ function buildDb(overrides: Partial<Record<string, unknown>> = {}) {
 }
 
 const adminSession = {
-	user: { id: "admin-1", email: "a@b.c", isAdmin: true },
+	user: {
+		id: "admin-1",
+		email: "a@b.c",
+		isAdmin: true,
+		adminMfaAt: Math.floor(Date.now() / 1000),
+	},
 	expires: "",
 };
 

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -187,7 +187,12 @@ function flattenSql(value: unknown): string {
 }
 
 const adminSession = {
-	user: { id: "admin-1", email: "a@b.c", isAdmin: true },
+	user: {
+		id: "admin-1",
+		email: "a@b.c",
+		isAdmin: true,
+		adminMfaAt: Math.floor(Date.now() / 1000),
+	},
 	expires: "",
 };
 
@@ -1997,7 +2002,12 @@ describe("adminStatsRouter.getMatomoFunnel", () => {
 		const caller = adminStatsRouter.createCaller({
 			db: buildDb(),
 			session: {
-				user: { id: "admin", email: "a@x", isAdmin: true },
+				user: {
+					id: "admin",
+					email: "a@x",
+					isAdmin: true,
+					adminMfaAt: Math.floor(Date.now() / 1000),
+				},
 				expires: "",
 			},
 			headers: new Headers(),

--- a/packages/app/src/server/api/routers/__tests__/gipMds.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/gipMds.test.ts
@@ -22,7 +22,12 @@ vi.mock("~/server/services/gipMds", () => ({
 }));
 
 const adminSession = {
-	user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+	user: {
+		id: "admin-1",
+		email: "admin@example.fr",
+		isAdmin: true,
+		adminMfaAt: Math.floor(Date.now() / 1000),
+	},
 	expires: "",
 };
 

--- a/packages/app/src/server/api/trpc.ts
+++ b/packages/app/src/server/api/trpc.ts
@@ -12,8 +12,14 @@ import { and, eq, isNull } from "drizzle-orm";
 import superjson from "superjson";
 import { ZodError } from "zod";
 import {
+	ADMIN_MFA_REQUIRED_MARKER,
+	ADMIN_MFA_REQUIRED_MESSAGE,
+	AdminMfaRequiredError,
+} from "~/modules/admin/shared/adminMfaGuard";
+import {
 	DECLARATION_LOCK_CONFLICT_MESSAGE,
 	getCurrentYear,
+	isAdminMfaFresh,
 	isDeadlinePassed,
 	isDeclarationSubmitted,
 	isSecondDeclarationDeadlineApplicable,
@@ -56,6 +62,13 @@ export const createTRPCContext = async (opts: { headers: Headers }) => {
  * ZodErrors so that you get typesafety on the frontend if your procedure fails due to validation
  * errors on the backend.
  */
+// Extracted so the marker detection is unit-testable without a full tRPC HTTP round trip.
+export function isAdminMfaRequiredTRPCError(error: {
+	cause?: unknown;
+}): boolean {
+	return error.cause instanceof AdminMfaRequiredError;
+}
+
 const t = initTRPC.context<typeof createTRPCContext>().create({
 	transformer: superjson,
 	errorFormatter({ shape, error }) {
@@ -65,6 +78,7 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
 				...shape.data,
 				zodError:
 					error.cause instanceof ZodError ? error.cause.flatten() : null,
+				[ADMIN_MFA_REQUIRED_MARKER]: isAdminMfaRequiredTRPCError(error),
 			},
 		};
 	},
@@ -160,6 +174,13 @@ export const adminProcedure = protectedProcedure.use(({ ctx, next }) => {
 		throw new TRPCError({
 			code: "FORBIDDEN",
 			message: "Accès réservé aux administrateurs.",
+		});
+	}
+	if (!isAdminMfaFresh(ctx.session.user.adminMfaAt, new Date())) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: ADMIN_MFA_REQUIRED_MESSAGE,
+			cause: new AdminMfaRequiredError(),
 		});
 	}
 	return next({ ctx });

--- a/packages/app/src/trpc/react.tsx
+++ b/packages/app/src/trpc/react.tsx
@@ -1,14 +1,41 @@
 "use client";
 
 import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { httpBatchStreamLink, loggerLink } from "@trpc/client";
+import { httpBatchStreamLink, loggerLink, type TRPCLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
+import { observable } from "@trpc/server/observable";
 import { useState } from "react";
 import SuperJSON from "superjson";
 
+import { isAdminMfaRequiredErrorData } from "~/modules/admin/shared/adminMfaGuard";
 import type { AppRouter } from "~/server/api/root";
 import { createQueryClient } from "./query-client";
+
+const ADMIN_MFA_RESUME_PATH = "/acces-backoffice";
+
+function adminMfaGuardLink(): TRPCLink<AppRouter> {
+	return () =>
+		({ next, op }) =>
+			observable((observer) => {
+				const subscription = next(op).subscribe({
+					next(value) {
+						observer.next(value);
+					},
+					error(error) {
+						if (isAdminMfaRequiredErrorData(error.data)) {
+							window.location.assign(ADMIN_MFA_RESUME_PATH);
+							return;
+						}
+						observer.error(error);
+					},
+					complete() {
+						observer.complete();
+					},
+				});
+				return subscription;
+			});
+}
 
 let clientQueryClientSingleton: QueryClient | undefined;
 const getQueryClient = () => {
@@ -49,6 +76,7 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 						process.env.NODE_ENV === "development" ||
 						(op.direction === "down" && op.result instanceof Error),
 				}),
+				adminMfaGuardLink(),
 				httpBatchStreamLink({
 					transformer: SuperJSON,
 					url: `${getBaseUrl()}/api/trpc`,


### PR DESCRIPTION
Closes #4463

Deuxième des trois surfaces privilégiées de l'epic #4405. Une quarantaine de procédures d'administration — recherche et annulation de déclarations, déverrouillage, référents, échéances de campagne, statistiques, import GIP, recherche d'entreprise — ne vérifiaient que l'habilitation. Une exigence limitée aux pages aurait laissé un agent sans double authentification valide déclencher ces actions depuis un onglet resté ouvert : elle aurait été cosmétique.

## Ce que ça change

La garde est posée sur `adminProcedure`, le point de passage unique des quarante procédures — pas répétée procédure par procédure. Elle réutilise `isAdminMfaFresh` du socle #4461, donc la règle de fraîcheur reste définie à un seul endroit.

Le refus voyage jusqu'au client par un marqueur porté dans l'`errorFormatter`, ce qui permet à l'interface de distinguer « double authentification à refaire » d'un refus d'habilitation ordinaire, sans se fier au texte du message.

## Scénario couvert

- **S13** — une action déclenchée depuis une page du backoffice restée ouverte au-delà de la fenêtre ne s'exécute pas, et rien n'est modifié en base.

## Vérifications

- `pnpm typecheck` vert
- `pnpm test` vert — 6163 tests, 478 fichiers
- `pnpm check:write` sans correction à appliquer

Les onze fichiers de tests des routers d'administration voient leur session de test porter une double authentification fraîche ; le refus lui-même est testé au point de passage, dans `adminProcedure.test.ts`.
