### PR TITLE
feat(auth): #4467 — raccord de test pour la double authentification du backoffice

### DIFF
--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -305,6 +305,9 @@ jobs:
       EGAPRO_SUIT_API_URL: ${{ secrets.EGAPRO_SUIT_API_URL }}
       EGAPRO_GATEWAY_SHARED_SECRET: dev-gateway-shared-secret-minimum-32-chars
       EGAPRO_E2E_CLOCK: "true"
+      # Same test-only admin two-factor seam as e2e.yaml (#4467): dynamic.a11y.ts
+      # records /admin/declarations, which is behind the MFA guard since #4461.
+      EGAPRO_E2E_ADMIN_MFA: "true"
       S3_ENDPOINT: http://localhost:9000
       S3_REGION: us-east-1
       S3_ACCESS_KEY_ID: minioadmin

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,6 +32,13 @@ jobs:
       # stays unreachable in production, which is gated by NODE_ENV on top of
       # this flag, and the flag is set in no .kontinuous env config.
       EGAPRO_E2E_CLOCK: "true"
+      # Test-only admin two-factor seam (#4467). Since #4461 /admin demands an
+      # `eidas1-mfa` sign-in, and the FIA1V2 test identity has no second factor
+      # a headless run can present, so without this flag every backoffice spec
+      # lands on the resume screen. The seam additionally demands a loopback
+      # host and is declared in no .kontinuous env config — asserted by
+      # src/server/auth/__tests__/e2eFlagsAbsentFromDeployConfig.test.ts.
+      EGAPRO_E2E_ADMIN_MFA: "true"
       S3_ENDPOINT: http://localhost:9000
       S3_REGION: us-east-1
       S3_ACCESS_KEY_ID: minioadmin

--- a/packages/app/src/env.js
+++ b/packages/app/src/env.js
@@ -107,6 +107,25 @@ export const env = createEnv({
 		// in NO .kontinuous env config, so the route stays 404 in preproduction
 		// and production regardless of NODE_ENV.
 		EGAPRO_E2E_CLOCK: z.coerce.boolean().optional().default(false),
+		// E2E-only admin two-factor seam (issue #4467). ProConnect's integration
+		// platform advertises `eidas1-mfa`, but the FIA1V2 test identity has no
+		// second factor a headless run can present, so the suite could never obtain
+		// a backoffice session once #4461 started demanding one. With this flag on,
+		// a sign-in that reached the app on a loopback host is dated as if
+		// ProConnect had returned the MFA level.
+		//
+		// Declared in NO .kontinuous env config — `e2eFlagsAbsentFromDeployConfig`
+		// fails the build if that ever changes — and the seam additionally demands
+		// a loopback host, a barrier no configuration can grant a deployed pod.
+		//
+		// Parsed as a literal string rather than `z.coerce.boolean()`, which turns
+		// the string "false" into true: EGAPRO_E2E_CLOCK only escapes that trap
+		// because nothing ever sets it to "false" explicitly.
+		EGAPRO_E2E_ADMIN_MFA: z
+			.enum(["true", "false"])
+			.optional()
+			.default("false")
+			.transform((value) => value === "true"),
 		/**
 		 * Comma-separated list of emails that should be granted the admin role
 		 * on login. The flag is then persisted in the `app_user.is_admin` column.
@@ -206,6 +225,7 @@ export const env = createEnv({
 		MATOMO_API_TOKEN: process.env.MATOMO_API_TOKEN,
 		MATOMO_API_URL: process.env.MATOMO_API_URL,
 		EGAPRO_E2E_CLOCK: process.env.EGAPRO_E2E_CLOCK,
+		EGAPRO_E2E_ADMIN_MFA: process.env.EGAPRO_E2E_ADMIN_MFA,
 		ADMIN_EMAILS: process.env.ADMIN_EMAILS,
 		EGAPRO_AUDIT_RETENTION_SHORT_DAYS:
 			process.env.EGAPRO_AUDIT_RETENTION_SHORT_DAYS,

--- a/packages/app/src/server/auth/__tests__/adminMfaTestSeam.test.ts
+++ b/packages/app/src/server/auth/__tests__/adminMfaTestSeam.test.ts
@@ -1,0 +1,254 @@
+import type { Account, User } from "next-auth";
+import type { JWT } from "next-auth/jwt";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnv, mockHeaders } = vi.hoisted(() => ({
+	mockEnv: {
+		ADMIN_EMAILS: "agent@example.fr",
+		EGAPRO_E2E_ADMIN_MFA: false as boolean,
+		EGAPRO_DEV_AUTH: false as boolean,
+		NODE_ENV: "production" as "development" | "test" | "production",
+	},
+	mockHeaders: { current: null as Headers | null },
+}));
+
+vi.mock("~/env", () => ({ env: mockEnv }));
+vi.mock("next/headers", () => ({
+	headers: async () => {
+		if (!mockHeaders.current) throw new Error("outside a request scope");
+		return mockHeaders.current;
+	},
+}));
+
+const mockFindFirst = vi.fn();
+vi.mock("~/server/db", () => ({
+	db: {
+		query: {
+			users: { findFirst: (...args: unknown[]) => mockFindFirst(...args) },
+		},
+		insert: vi.fn(),
+		update: vi.fn().mockReturnValue({
+			set: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue(undefined),
+			}),
+		}),
+		transaction: vi.fn(),
+	},
+}));
+vi.mock("~/server/db/schema", () => ({
+	users: { email: "email", id: "id" },
+	companies: { siren: "siren" },
+	userCompanies: {},
+	adminImpersonationEvents: {},
+}));
+vi.mock("~/server/services/weez", () => ({ fetchCompanyBySiren: vi.fn() }));
+
+const mockLogAction = vi.fn();
+vi.mock("~/server/audit/log", () => ({
+	logAction: (...args: unknown[]) => mockLogAction(...args),
+}));
+
+import { authConfig } from "../config";
+
+const { callbacks } = authConfig;
+
+const ADMIN_EMAIL = "agent@example.fr";
+const DECLARANT_EMAIL = "declarant@example.fr";
+const NOW_ISO = "2026-03-10T08:00:00.000Z";
+const NOW_SECONDS = Math.floor(Date.parse(NOW_ISO) / 1000);
+
+/** A ProConnect id_token carrying the given claims, signature aside. */
+function idToken(claims: Record<string, unknown>) {
+	const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+	return `header.${payload}.signature`;
+}
+
+/**
+ * Drive one sign-in through the `jwt` callback. `request` describes what the
+ * server saw of the incoming request: `null` means no request scope at all.
+ */
+async function signIn({
+	email = ADMIN_EMAIL,
+	claims = { acr: "eidas1", auth_time: 1_772_000_000 } as Record<
+		string,
+		unknown
+	> | null,
+	request = { host: "localhost:3000" } as Record<string, string> | null,
+}: {
+	email?: string;
+	claims?: Record<string, unknown> | null;
+	request?: Record<string, string> | null;
+} = {}) {
+	mockFindFirst.mockResolvedValue({
+		id: "uuid-123",
+		phone: null,
+		firstName: "Alice",
+		lastName: "Martin",
+		isAdmin: false,
+	});
+	mockHeaders.current = request ? new Headers(request) : null;
+
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date(NOW_ISO));
+	try {
+		return await callbacks.jwt({
+			token: { sub: "sub-123" } as JWT,
+			user: { id: "proconnect-sub", email } as User,
+			account: (claims
+				? { id_token: idToken(claims) }
+				: {}) as unknown as Account,
+			trigger: "signIn",
+		} as unknown as Parameters<typeof callbacks.jwt>[0]);
+	} finally {
+		vi.useRealTimers();
+	}
+}
+
+describe("auth config — E2E admin two-factor seam", () => {
+	beforeEach(() => {
+		mockFindFirst.mockReset();
+		mockLogAction.mockReset();
+		mockEnv.EGAPRO_E2E_ADMIN_MFA = false;
+		mockHeaders.current = null;
+	});
+
+	describe("the seam is inert unless both barriers are met", () => {
+		it("leaves the session undated when the flag is off, even on a loopback host", async () => {
+			const result = await signIn();
+
+			expect(result.adminMfaAt).toBeUndefined();
+		});
+
+		it.each([
+			["a deployed hostname", { host: "egapro.travail.gouv.fr" }],
+			[
+				"a review-app hostname",
+				{ host: "app-egapro-alpha.dev.fabrique.social.gouv.fr" },
+			],
+			[
+				"a hostname merely containing localhost",
+				{ host: "localhost.attacker.example" },
+			],
+			["a hostname merely ending in localhost", { host: "notlocalhost" }],
+			["no host header at all", {}],
+		])("leaves the session undated with the flag on but %s", async (_label, request) => {
+			mockEnv.EGAPRO_E2E_ADMIN_MFA = true;
+
+			const result = await signIn({ request });
+
+			expect(result.adminMfaAt).toBeUndefined();
+		});
+
+		it("leaves the session undated with the flag on but no request scope", async () => {
+			mockEnv.EGAPRO_E2E_ADMIN_MFA = true;
+
+			const result = await signIn({ request: null });
+
+			expect(result.adminMfaAt).toBeUndefined();
+		});
+
+		it('treats the string "false" as off, the trap z.coerce.boolean() falls into', async () => {
+			// `env.js` parses the flag as a literal string enum precisely so this
+			// value cannot arrive here as `true`; the seam then compares strictly.
+			mockEnv.EGAPRO_E2E_ADMIN_MFA = "false" as unknown as boolean;
+
+			const result = await signIn();
+
+			expect(result.adminMfaAt).toBeUndefined();
+		});
+	});
+
+	describe("the seam cannot be switched on by the request", () => {
+		it.each([
+			[
+				"a header asking for it",
+				{ host: "egapro.travail.gouv.fr", "x-egapro-e2e-admin-mfa": "true" },
+			],
+			[
+				"a forwarded loopback host",
+				{
+					host: "egapro.travail.gouv.fr",
+					"x-forwarded-host": "localhost:3000",
+				},
+			],
+		])("refuses %s", async (_label, request) => {
+			mockEnv.EGAPRO_E2E_ADMIN_MFA = true;
+
+			const result = await signIn({ request });
+
+			expect(result.adminMfaAt).toBeUndefined();
+		});
+
+		it("ignores an adminMfaAt pushed through a client session update while the seam is on", async () => {
+			mockEnv.EGAPRO_E2E_ADMIN_MFA = true;
+			mockHeaders.current = new Headers({ host: "localhost:3000" });
+
+			const result = await callbacks.jwt({
+				token: { sub: "sub-123", id: "uuid-123", isAdmin: true } as JWT,
+				trigger: "update",
+				session: { adminMfaAt: 9_999_999_999 },
+			} as unknown as Parameters<typeof callbacks.jwt>[0]);
+
+			expect(result.adminMfaAt).toBeUndefined();
+		});
+	});
+
+	describe("with both barriers met", () => {
+		beforeEach(() => {
+			mockEnv.EGAPRO_E2E_ADMIN_MFA = true;
+		});
+
+		it.each([
+			["localhost:3000"],
+			["127.0.0.1:3000"],
+			["localhost"],
+			["[::1]:3000"],
+		])("dates the session from the server clock on %s", async (host) => {
+			const result = await signIn({ request: { host } });
+
+			expect(result.adminMfaAt).toBe(NOW_SECONDS);
+		});
+
+		it("stands in only for a level below MFA, never overriding a real auth_time", async () => {
+			const result = await signIn({
+				claims: { acr: "eidas1-mfa", auth_time: 1_772_000_000 },
+			});
+
+			expect(result.adminMfaAt).toBe(1_772_000_000);
+		});
+
+		it("dates a sign-in whose id_token carries no acr at all", async () => {
+			const result = await signIn({ claims: null });
+
+			expect(result.adminMfaAt).toBe(NOW_SECONDS);
+		});
+
+		it("grants no habilitation: an unlisted email stays a non-admin", async () => {
+			const result = await signIn({ email: DECLARANT_EMAIL });
+
+			expect(result.isAdmin).toBe(false);
+			expect(mockLogAction).not.toHaveBeenCalled();
+		});
+
+		it("marks the audit row as a test seam rather than a real second factor", async () => {
+			await signIn();
+
+			expect(mockLogAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "auth.admin_mfa",
+					status: "success",
+					metadata: { acr: "eidas1", authTime: NOW_SECONDS, testSeam: true },
+				}),
+			);
+		});
+
+		it("leaves the audit row unmarked when ProConnect really returned the level", async () => {
+			await signIn({ claims: { acr: "eidas1-mfa", auth_time: 1_772_000_000 } });
+
+			const [entry] = mockLogAction.mock.calls[0] as [
+				{ metadata: Record<string, unknown> },
+			];
+			expect(Object.keys(entry.metadata).sort()).toEqual(["acr", "authTime"]);
+		});
+	});
+});

--- a/packages/app/src/server/auth/__tests__/e2eFlagsAbsentFromDeployConfig.test.ts
+++ b/packages/app/src/server/auth/__tests__/e2eFlagsAbsentFromDeployConfig.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Tooling assertion for the test-only seams (issues #4022 and #4467).
+ *
+ * Both are gated by an environment flag whose safety argument is "it is
+ * declared in no deployment configuration, verifiable with a single grep".
+ * That argument is only worth something if something actually greps: the day
+ * someone adds one of these flags to a `.kontinuous` configmap to unblock a
+ * review app, nothing else in the repo would notice, and the seam would ship
+ * to preproduction — then to production on the next promotion.
+ *
+ * The check reads the deployment tree rather than a curated list of files, so
+ * a flag added to a configmap that does not exist yet is caught too.
+ */
+
+const KONTINUOUS_DIR = join(process.cwd(), "..", "..", ".kontinuous");
+
+const TEST_ONLY_FLAGS = ["EGAPRO_E2E_CLOCK", "EGAPRO_E2E_ADMIN_MFA"] as const;
+
+function collectFiles(dir: string): string[] {
+	return readdirSync(dir).flatMap((entry) => {
+		const path = join(dir, entry);
+		return statSync(path).isDirectory() ? collectFiles(path) : [path];
+	});
+}
+
+describe("test-only environment flags", () => {
+	const files = collectFiles(KONTINUOUS_DIR);
+
+	it("reads a non-empty deployment configuration tree", () => {
+		// Without this, a renamed or moved `.kontinuous` would make every
+		// assertion below pass over zero files and report a clean bill of health.
+		expect(files.length).toBeGreaterThan(0);
+	});
+
+	it.each(
+		TEST_ONLY_FLAGS,
+	)("%s appears in no .kontinuous deployment configuration", (flag) => {
+		const offenders = files.filter((path) =>
+			readFileSync(path, "utf-8").includes(flag),
+		);
+
+		expect(offenders).toEqual([]);
+	});
+});

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -200,20 +200,75 @@ const ADMIN_EMAILS: Set<string> = parseAdminEmails(env.ADMIN_EMAILS);
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
 
 /**
- * True when the request was addressed to this machine. `EGAPRO_DEV_AUTH` and
- * `NODE_ENV` both come from the same configmap and carry the same level of
- * trust, so on their own they are one barrier, not two. This check does not
- * read configuration at all: a request reaching a deployed pod carries that
- * environment's hostname, never a loopback one.
+ * True when the request was addressed to this machine. `EGAPRO_DEV_AUTH`,
+ * `EGAPRO_E2E_ADMIN_MFA` and `NODE_ENV` all come from the same configmap and
+ * carry the same level of trust, so on their own they are one barrier, not
+ * two. This check does not read configuration at all: a request reaching a
+ * deployed pod carries that environment's hostname, never a loopback one.
  */
-function isLoopbackRequest(headers: Record<string, string> | undefined) {
-	const host = headers?.host ?? headers?.Host;
+function isLoopbackHost(host: string | null | undefined) {
 	if (!host) return false;
 	// Strip the port, keeping bracketed IPv6 literals intact.
 	const hostname = host.startsWith("[")
 		? host.slice(0, host.indexOf("]") + 1)
 		: (host.split(":")[0] ?? "");
 	return LOOPBACK_HOSTS.has(hostname);
+}
+
+function isLoopbackRequest(headers: Record<string, string> | undefined) {
+	return isLoopbackHost(headers?.host ?? headers?.Host);
+}
+
+/**
+ * Host of the Next.js request in flight, or null outside a request scope.
+ *
+ * Read from the server's own view of the request, exactly as
+ * `safeRequestContext` does. NextAuth callbacks do not receive the request,
+ * and this is the only place the host can be obtained without letting a caller
+ * hand us one.
+ */
+async function safeRequestHost(): Promise<string | null> {
+	try {
+		return (await nextHeaders()).get("host");
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Test-only stand-in for a ProConnect second factor (issue #4467).
+ *
+ * Why it exists. `/admin` demands an `eidas1-mfa` sign-in since #4461.
+ * ProConnect's integration platform advertises that level, but its FIA1V2 test
+ * identity — the only one the suite has — presents no second factor a headless
+ * run can complete, and its fallback one-time code goes to a mailbox the suite
+ * cannot read. Without a seam the whole backoffice half of the suite is
+ * unreachable, which is worse for the epic than a seam whose absence in
+ * production is mechanically checkable.
+ *
+ * Why it cannot leak. Two independent barriers, deliberately not two variables
+ * of one configmap. `EGAPRO_E2E_ADMIN_MFA` is off by default and declared in no
+ * `.kontinuous` env config — `e2eFlagsAbsentFromDeployConfig.test.ts` fails the
+ * build if it ever appears in one. On top of it, the sign-in must have reached
+ * the app on a loopback host, which no deployed pod ever sees whatever its
+ * configuration says. Nothing in the request decides: no parameter, no header,
+ * no body — `Host` is not an input the caller chooses freely here, it is what
+ * the sign-in had to be addressed to in order to arrive at all.
+ *
+ * What it does NOT do. It grants no habilitation: `ADMIN_EMAILS` still decides
+ * who is an admin, and the freshness window still applies. It replaces the
+ * level ProConnect answered with, never the rule that reads it — so the
+ * negative half of the epic (no valid second factor, no backoffice) stays live.
+ *
+ * Not locked on `NODE_ENV`: every CI run serves a production build
+ * (`next build` then `next start`), so such a lock would make the seam inert in
+ * the one environment that needs it. The campaign-clock seam already made and
+ * reverted that mistake — see `~/app/api/e2e-clock/route.ts`.
+ */
+function grantsTestAdminMfa(host: string | null): boolean {
+	// Strict `=== true`, never truthiness: with SKIP_ENV_VALIDATION set the env
+	// helper hands back the raw environment, where the string "false" is truthy.
+	return env.EGAPRO_E2E_ADMIN_MFA === true && isLoopbackHost(host);
 }
 
 /**
@@ -502,15 +557,23 @@ export const authConfig = {
 				token.id_token = account?.id_token ?? null;
 				token.isAdmin = shouldBeAdmin;
 
-				// The marker's only source is the id_token of the exchange we
-				// just performed server-to-server: never a query parameter, a
+				// The marker has exactly two sources, and a client reaches
+				// neither: the id_token of the exchange we just performed
+				// server-to-server, and — off outside a loopback test run, see
+				// `grantsTestAdminMfa` — the E2E seam. Never a query parameter, a
 				// header, a request body, nor the `trigger === "update"` branch
 				// above, which any signed-in client can reach. A level below MFA
 				// is not an error — the declarant journey never asks for one — so
 				// the sign-in succeeds with the session simply left undated.
 				const { acr, authTime } = readAuthenticationClaims(account?.id_token);
+				let testSeamGranted = false;
 				if (isAdminMfaAcr(acr)) {
 					token.adminMfaAt = authTime ?? Math.floor(Date.now() / 1000);
+				} else if (grantsTestAdminMfa(await safeRequestHost())) {
+					// Dated from the server clock, never from a claim: the level we
+					// are standing in for was not returned, so no `auth_time` exists.
+					token.adminMfaAt = Math.floor(Date.now() / 1000);
+					testSeamGranted = true;
 				} else {
 					token.adminMfaAt = undefined;
 				}
@@ -528,7 +591,13 @@ export const authConfig = {
 						errorMessage: token.adminMfaAt
 							? null
 							: "Niveau d'authentification insuffisant pour le backoffice.",
-						metadata: { acr, authTime: token.adminMfaAt ?? null },
+						metadata: {
+							acr,
+							authTime: token.adminMfaAt ?? null,
+							// Present only when the seam granted the passage, so a row
+							// never reads as a real second factor that did not happen.
+							...(testSeamGranted ? { testSeam: true } : {}),
+						},
 						ipAddress: requestContext.ipAddress,
 						userAgent: requestContext.userAgent,
 					});


### PR DESCRIPTION
Closes #4467

## Voie retenue : B — et pourquoi la voie A est fermée

Le ticket demande d'épuiser la **voie A** (un second facteur réellement scriptable) avant de basculer. Ce qui a été établi :

- la plateforme d'intégration ProConnect **annonce bien** le niveau demandé — son `.well-known` liste `eidas1-mfa` dans `acr_values_supported`, aux côtés de `eidas0-mfa` ;
- mais l'identité de test dont dispose la suite (FIA1V2, le compte que `loginWithProConnect` saisit) ne présente **aucun second facteur qu'un run headless puisse franchir** : pas de code affiché à l'écran, pas de code fixe d'intégration ;
- et le filet ProConnect (mot de passe à usage unique par courriel) part vers la boîte de l'identité de test, que le collecteur de courriels de la suite — branché sur le SMTP local — ne lit pas.

Il n'y a donc pas de chemin réel à automatiser, et la voie B est prise. La raison est écrite dans le code, au-dessus du raccord.

## Le raccord

Depuis #4461, `/admin` exige un `id_token` de niveau `eidas1-mfa`. Sans raccord, toute la moitié backoffice de la suite tombe sur l'écran de reprise. Le raccord date la session comme portant une double authentification valide quand — **et seulement quand** — deux barrières indépendantes sont réunies :

1. **`EGAPRO_E2E_ADMIN_MFA`**, à `false` par défaut, déclaré dans **aucune** configuration `.kontinuous`. Parsé comme énumération littérale `"true" | "false"` plutôt que `z.coerce.boolean()`, qui transforme la chaîne `"false"` en `true`.
2. **Un hôte de bouclage** : la requête doit avoir été adressée à `localhost` / `127.0.0.1` / `[::1]`, ce que la configuration d'un module déployé ne peut pas lui donner. Même raisonnement, et même helper, que le fournisseur de connexion de développement.

Rien dans la requête ne l'active : ni paramètre, ni en-tête, ni corps. Le `Host` n'est pas une entrée que l'appelant choisit librement — c'est ce à quoi la connexion a dû être adressée pour arriver.

Ce que le raccord **ne fait pas** : il n'accorde aucune habilitation (`ADMIN_EMAILS` reste la source du droit), et la fenêtre de fraîcheur de 8 h continue de s'appliquer. Il se substitue au **niveau que ProConnect a répondu**, jamais à la règle qui le lit — la moitié négative de l'epic reste donc vivante.

**Pas de verrou sur `NODE_ENV`** : la CI sert une compilation de production (`next build` puis `next start`), un tel verrou rendrait le raccord inerte dans le seul environnement qui en a besoin. Le raccord d'horloge de campagne a déjà commis puis retiré cette erreur.

La ligne d'audit d'un passage accordé par le raccord porte `testSeam: true`, pour qu'aucune trace ne se lise comme un second facteur qui n'a pas eu lieu.

## Effet sur la suite : aucun fichier de spec touché

Le raccord agit au moment où le niveau est lu, donc l'état d'authentification partagé constitué par `auth.setup.ts` — connexion ProConnect en **mot de passe seul**, inchangée — porte désormais une double authentification valide. **Aucun `*.e2e.ts` n'est modifié, aucune assertion supprimée, aucun `.skip`, aucune attente relâchée** : c'est exactement ce que le ticket exige des scénarios de backoffice existants.

Le scénario de connexion déclarante (`login.e2e.ts`) reste sur le vrai ProConnect en mot de passe seul — il n'a pas été touché non plus, et c'est lui qui prouve la règle 2 de l'epic.

## Vérification

| Ce qui a été fait | Avant | Après |
|---|---|---|
| `pnpm typecheck` | vert | vert |
| `pnpm test` |  6227 tests verts | **6227 → 6250** tests verts (23 ajoutés), 484 fichiers |
| Revert-verify du raccord (`git checkout origin/epic/4405 -- src/server/auth/config.ts`, puis run de `adminMfaTestSeam.test.ts`) | **6 tests rouges** sur 20 — le raccord n'existe pas, la session reste non datée | **20/20 verts** avec le raccord |
| `EGAPRO_E2E_ADMIN_MFA` dans `.kontinuous/**` | absent | absent, et désormais **asserté** |

Le revert-verify est ce qui distingue une couverture réelle d'une couverture qui passerait de toute façon : sans le raccord, les six tests qui exercent l'octroi tombent, et les quatorze tests d'inertie restent verts — c'est bien le comportement neuf qui est testé, pas l'absence de comportement.

**Rejeu fonctionnel sur le serveur de développement** (`localhost:3003`, drapeau actif, `ADMIN_EMAILS` pointant sur le compte de test) :

| Scénario | Observé |
|---|---|
| S5 / S7 — entrer dans le backoffice | `/admin` et `/admin/declarations` atteints, bandeau administrateur affiché, **aucun écran de reprise** |
| S2 — parcours déclarant | connexion en mot de passe seul → `/mon-espace`, aucun second facteur demandé, aucun écran supplémentaire |
| Moitié négative observable | session anonyme sur `/admin` → redirection vers `/login?callbackUrl=%2Fadmin`, pas d'entrée dans le backoffice |

La connexion rejouée ne présente **aucun `id_token`**, donc `acr` est indéfini et `isAdminMfaAcr` est faux : la seule chose qui peut avoir daté cette session est `grantsTestAdminMfa`. L'accès au backoffice est donc directement imputable au raccord — avant lui, la même session serait restée non datée et refusée depuis #4461.

## Tests

- `src/server/auth/__tests__/adminMfaTestSeam.test.ts` — 20 tests. Inertie drapeau éteint / hôte déployé / hôte de review app / `localhost.attacker.example` / `notlocalhost` / pas d'en-tête `Host` / hors contexte de requête / chaîne `"false"`. Non-activabilité par la requête : en-tête dédié, `X-Forwarded-Host` de bouclage, `session.update` client. Octroi : les quatre formes d'hôte de bouclage, non-écrasement d'un `auth_time` réel, absence d'habilitation accordée, marquage `testSeam` de la ligne d'audit.
- `src/server/auth/__tests__/e2eFlagsAbsentFromDeployConfig.test.ts` — 3 tests. Parcourt l'arborescence `.kontinuous` (et non une liste de fichiers figée, pour attraper un configmap qui n'existe pas encore) et échoue si `EGAPRO_E2E_ADMIN_MFA` ou `EGAPRO_E2E_CLOCK` y apparaît. Un test garde-fou vérifie que l'arborescence lue est non vide — sans lui, un `.kontinuous` déplacé ferait passer les assertions sur zéro fichier avec un bulletin de santé impeccable.

Pas de test d'intégration : le diff ne touche ni la couche base ni de SQL.

## Reste à faire — pour `e2e-dev`, en fin d'epic

Le scénario **négatif** E2E (« une session sans double authentification valide n'entre pas dans le backoffice ») est un fichier `*.e2e.ts`, donc hors de mon périmètre — les tests Playwright appartiennent à `e2e-dev`. Sa contrainte de conception est notée sur le ticket : avec le drapeau actif pour tout le job, une session « sans MFA » ne s'obtient pas en se reconnectant, et le scénario doit être construit autrement (S7 — compte non habilité — est le levier disponible, ou un contexte anonyme). La preuve d'inertie du raccord lui-même est, elle, couverte ici en tests unitaires.

## Capture

Sans objet : aucune surface d'interface modifiée (`.tsx` / `.scss` intacts).


