### PR TITLE
feat(auth): #4466 — arrêt du mimoquage au step-up et invalidation hors fenêtre

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/__tests__/WithBannerLayout.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/WithBannerLayout.test.tsx
@@ -184,6 +184,8 @@ describe("WithBannerLayout", () => {
 			user: {
 				...DEFAULT_USER,
 				isAdmin: true,
+				// An impersonation only bites while the admin MFA window is open (#4466).
+				adminMfaAt: Math.floor(Date.now() / 1000),
 				impersonation: { siren: SIREN },
 			},
 		});

--- a/packages/app/src/modules/layout/__tests__/ImpersonateBanner.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/ImpersonateBanner.test.tsx
@@ -52,6 +52,22 @@ describe("ImpersonateBanner", () => {
 		expect(screen.getByText(/123456789/)).toBeInTheDocument();
 	});
 
+	it("renders nothing once the MFA window has expired, because the session no longer exposes the impersonation", () => {
+		// S14: the banner holds no freshness rule of its own. The `session`
+		// callback stops projecting `impersonation` the instant the window
+		// closes (see `exposedImpersonation`), which is exactly the instant the
+		// server stops resolving the impersonated SIREN — so the two can never
+		// disagree. This is the shape the callback hands back in that case.
+		useSessionMock.mockReturnValue({
+			data: {
+				user: { impersonation: null, adminMfaAt: 1_700_000_000 },
+			},
+			update: vi.fn(),
+		});
+		const { container } = render(<ImpersonateBanner />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
 	it("calls session.update(null) and router.refresh on stop click", async () => {
 		const updateMock = vi.fn().mockResolvedValue(undefined);
 		useSessionMock.mockReturnValue({

--- a/packages/app/src/server/api/routers/__tests__/company.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.test.ts
@@ -445,6 +445,8 @@ describe("findUserCompany NAF label enrichment", () => {
 				user: {
 					id: "admin-1",
 					isAdmin: true,
+					// An impersonation only bites while the admin MFA window is open (#4466).
+					adminMfaAt: Math.floor(Date.now() / 1000),
 					impersonation: { siren: "339787277" },
 				},
 				expires: "",
@@ -619,6 +621,8 @@ describe("companyRouter.updateHasCse", () => {
 				user: {
 					id: "user-1",
 					isAdmin: true,
+					// An impersonation only bites while the admin MFA window is open (#4466).
+					adminMfaAt: Math.floor(Date.now() / 1000),
 					impersonation: { siren: "339787277", name: "Acme" },
 				},
 				expires: "",

--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.finalize.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.finalize.test.ts
@@ -236,6 +236,9 @@ function createCaller(
 					email,
 					siret,
 					isAdmin: impersonation !== null,
+					// An impersonation only bites while the admin MFA window is open (#4466).
+					adminMfaAt:
+						impersonation !== null ? Math.floor(Date.now() / 1000) : null,
 					impersonation,
 				},
 				expires: "",

--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.test.ts
@@ -113,6 +113,9 @@ function createCaller(
 					id: "user-1",
 					siret,
 					isAdmin: impersonation !== null,
+					// An impersonation only bites while the admin MFA window is open (#4466).
+					adminMfaAt:
+						impersonation !== null ? Math.floor(Date.now() / 1000) : null,
 					impersonation,
 				},
 				expires: "",

--- a/packages/app/src/server/api/routers/__tests__/helpers/declarationTestHelpers.ts
+++ b/packages/app/src/server/api/routers/__tests__/helpers/declarationTestHelpers.ts
@@ -59,6 +59,9 @@ export function createCaller(
 						email,
 						siret,
 						isAdmin: impersonation !== null,
+						// An impersonation only bites while the admin MFA window is open (#4466).
+						adminMfaAt:
+							impersonation !== null ? Math.floor(Date.now() / 1000) : null,
 						impersonation,
 					},
 					expires: "",

--- a/packages/app/src/server/api/routers/__tests__/representationDeclaration.get.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclaration.get.test.ts
@@ -7,6 +7,7 @@ import {
 	CLOSED_CAMPAIGN,
 	createCaller,
 	createMockDb,
+	FRESH_ADMIN_MFA,
 	installRouterTestEnv,
 	SIREN,
 	whereParams,
@@ -86,6 +87,7 @@ describe("representationDeclarationRouter.get", () => {
 		const mock = createMockDb([]);
 		const session = buildSession({
 			isAdmin: true,
+			adminMfaAt: FRESH_ADMIN_MFA,
 			impersonation: { siren: "987654321" },
 		});
 

--- a/packages/app/src/server/api/routers/__tests__/representationDeclarationHarness.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclarationHarness.ts
@@ -12,6 +12,10 @@ export const SIRET = `${SIREN}00015`;
 export const USER_ID = "user-1";
 export const NOW = new Date("2026-06-15T09:30:00.000Z");
 export const CAMPAIGN_YEAR = YEAR + 1;
+// A second factor presented a minute before `NOW`: an impersonation is only
+// effective while the admin MFA window is open (#4466), so a fixture without
+// it would model an agent whose mimoquage has already lapsed.
+export const FRESH_ADMIN_MFA = Math.floor(NOW.getTime() / 1000) - 60;
 export const CLOSED_MESSAGE =
 	"La campagne de représentation équilibrée est close : la déclaration ne peut plus être modifiée.";
 export const IMPERSONATION_MESSAGE =
@@ -78,7 +82,11 @@ export function buildSession(overrides: Record<string, unknown> = {}) {
 }
 
 export function impersonatingSession(siren = SIREN) {
-	return buildSession({ isAdmin: true, impersonation: { siren } });
+	return buildSession({
+		isAdmin: true,
+		adminMfaAt: FRESH_ADMIN_MFA,
+		impersonation: { siren },
+	});
 }
 
 export function createCaller(db: unknown, session = buildSession()) {

--- a/packages/app/src/server/api/trpc.ts
+++ b/packages/app/src/server/api/trpc.ts
@@ -24,10 +24,12 @@ import {
 	isDeclarationSubmitted,
 	isSecondDeclarationDeadlineApplicable,
 } from "~/modules/domain";
-import { parseSiren } from "~/modules/shared/parseSiren";
 import { auditMiddleware as runAuditMiddleware } from "~/server/audit/trpcMiddleware";
 import { auth } from "~/server/auth";
-import { assertNotImpersonating } from "~/server/auth/companyAccess";
+import {
+	assertNotImpersonating,
+	getEffectiveSiren,
+} from "~/server/auth/companyAccess";
 import { db } from "~/server/db";
 import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
 import { declarations } from "~/server/db/schema";
@@ -193,16 +195,12 @@ export const adminProcedure = protectedProcedure.use(({ ctx, next }) => {
  * Use this for any procedure that operates on company-scoped data.
  */
 export const companyProcedure = protectedProcedure.use(({ ctx, next }) => {
-	// Admin impersonation short-circuit: when an admin is currently mimoquing
-	// a company, every company-scoped procedure operates on the impersonated
-	// SIREN instead of the admin's own SIRET from ProConnect. The admin flag
-	// is checked to prevent a non-admin from ever resolving a foreign SIREN.
-	const impersonatedSiren =
-		ctx.session.user.isAdmin && ctx.session.user.impersonation
-			? ctx.session.user.impersonation.siren
-			: null;
-
-	const siren = impersonatedSiren ?? parseSiren(ctx.session.user.siret);
+	// The impersonation short-circuit is not re-implemented here: it lives in
+	// `getEffectiveSiren`, which also holds the MFA-window condition (#4466).
+	// One module decides which company a session acts on, so a procedure can
+	// never keep resolving a foreign SIREN that the pages have already stopped
+	// resolving.
+	const siren = getEffectiveSiren(ctx.session);
 	if (!siren) {
 		throw new TRPCError({
 			code: "BAD_REQUEST",

--- a/packages/app/src/server/auth/__tests__/adminMfaMarker.test.ts
+++ b/packages/app/src/server/auth/__tests__/adminMfaMarker.test.ts
@@ -25,6 +25,12 @@ vi.mock("~/server/db/schema", () => ({
 	users: { email: "email", id: "id" },
 	companies: { siren: "siren" },
 	userCompanies: {},
+	// The sign-in branch closes any open impersonation row (#4466), so the
+	// schema mock has to carry the table it targets.
+	adminImpersonationEvents: {
+		adminUserId: "adminUserId",
+		stoppedAt: "stoppedAt",
+	},
 }));
 vi.mock("~/server/services/weez", () => ({
 	fetchCompanyBySiren: vi.fn(),

--- a/packages/app/src/server/auth/__tests__/companyAccess.test.ts
+++ b/packages/app/src/server/auth/__tests__/companyAccess.test.ts
@@ -1,9 +1,25 @@
 import type { Session } from "next-auth";
 import { describe, expect, it } from "vitest";
 
-import { assertNotImpersonating, isImpersonatingSiren } from "../companyAccess";
+import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
+import {
+	assertNotImpersonating,
+	getEffectiveSiren,
+	isImpersonating,
+	isImpersonatingSiren,
+} from "../companyAccess";
 
-function makeSession(overrides: Partial<Session["user"]> = {}): Session | null {
+const NOW = new Date("2026-03-10T12:00:00Z");
+const NOW_SECONDS = Math.floor(NOW.getTime() / 1000);
+
+/** A second factor presented a minute ago — comfortably inside the window. */
+const FRESH_MFA = NOW_SECONDS - 60;
+/** A second factor one second past the window — the case S14 turns on. */
+const EXPIRED_MFA = NOW_SECONDS - ADMIN_MFA_WINDOW_SECONDS - 1;
+
+const DEMO = { siren: "123456789", name: "Société Démo" };
+
+function makeSession(overrides: Partial<Session["user"]> = {}): Session {
 	return {
 		user: {
 			id: "user-1",
@@ -14,60 +30,185 @@ function makeSession(overrides: Partial<Session["user"]> = {}): Session | null {
 			phone: null,
 			isAdmin: false,
 			impersonation: null,
+			adminMfaAt: null,
 			...overrides,
 		},
 		expires: "2099-01-01",
 	};
 }
 
+/** An admin mimoquing « Société Démo » with a second factor inside the window. */
+function impersonatingAdmin(overrides: Partial<Session["user"]> = {}): Session {
+	return makeSession({
+		isAdmin: true,
+		adminMfaAt: FRESH_MFA,
+		impersonation: DEMO,
+		siret: "98765432100015",
+		...overrides,
+	});
+}
+
+describe("getEffectiveSiren", () => {
+	it("returns null when the session is null", () => {
+		expect(getEffectiveSiren(null, NOW)).toBeNull();
+	});
+
+	it("returns null when the session carries no user", () => {
+		expect(getEffectiveSiren({ expires: "2099-01-01" } as Session, NOW)).toBe(
+			null,
+		);
+	});
+
+	it("returns the impersonated SIREN for an admin inside the window", () => {
+		expect(getEffectiveSiren(impersonatingAdmin(), NOW)).toBe("123456789");
+	});
+
+	it("falls back to the agent's own SIREN once the window has expired", () => {
+		const session = impersonatingAdmin({ adminMfaAt: EXPIRED_MFA });
+		expect(getEffectiveSiren(session, NOW)).toBe("987654321");
+	});
+
+	it("falls back to the agent's own SIREN when no second factor was ever presented", () => {
+		const session = impersonatingAdmin({ adminMfaAt: null });
+		expect(getEffectiveSiren(session, NOW)).toBe("987654321");
+	});
+
+	it("returns null for an out-of-window admin who has no SIRET of their own", () => {
+		const session = impersonatingAdmin({
+			adminMfaAt: EXPIRED_MFA,
+			siret: null,
+		});
+		expect(getEffectiveSiren(session, NOW)).toBeNull();
+	});
+
+	it("extracts the SIREN from the SIRET of an ordinary declarant", () => {
+		expect(
+			getEffectiveSiren(makeSession({ siret: "12345678900021" }), NOW),
+		).toBe("123456789");
+	});
+
+	it("returns null for a malformed SIRET rather than a truncated SIREN", () => {
+		expect(getEffectiveSiren(makeSession({ siret: "1234" }), NOW)).toBeNull();
+		expect(getEffectiveSiren(makeSession({ siret: "abcdefghij" }), NOW)).toBe(
+			null,
+		);
+	});
+
+	it("ignores a stray impersonation carried by a non-admin session", () => {
+		const session = makeSession({
+			isAdmin: false,
+			adminMfaAt: FRESH_MFA,
+			impersonation: DEMO,
+			siret: "98765432100015",
+		});
+		expect(getEffectiveSiren(session, NOW)).toBe("987654321");
+	});
+
+	it("defaults `now` to the current time", () => {
+		const session = impersonatingAdmin({
+			adminMfaAt: Math.floor(Date.now() / 1000) - 60,
+		});
+		expect(getEffectiveSiren(session)).toBe("123456789");
+	});
+});
+
 describe("isImpersonatingSiren", () => {
 	it("returns false when session is null", () => {
-		expect(isImpersonatingSiren(null, "123456789")).toBe(false);
+		expect(isImpersonatingSiren(null, "123456789", NOW)).toBe(false);
 	});
 
 	it("returns false for a non-admin even if impersonation is present", () => {
 		const session = makeSession({
 			isAdmin: false,
-			impersonation: { siren: "123456789", name: "Acme" },
+			adminMfaAt: FRESH_MFA,
+			impersonation: DEMO,
 		});
-		expect(isImpersonatingSiren(session, "123456789")).toBe(false);
+		expect(isImpersonatingSiren(session, "123456789", NOW)).toBe(false);
 	});
 
 	it("returns false for an admin with no impersonation", () => {
-		const session = makeSession({ isAdmin: true, impersonation: null });
-		expect(isImpersonatingSiren(session, "123456789")).toBe(false);
+		const session = makeSession({
+			isAdmin: true,
+			adminMfaAt: FRESH_MFA,
+			impersonation: null,
+		});
+		expect(isImpersonatingSiren(session, "123456789", NOW)).toBe(false);
 	});
 
 	it("returns false when the SIREN does not match the impersonated one", () => {
-		const session = makeSession({
-			isAdmin: true,
-			impersonation: { siren: "123456789", name: "Acme" },
-		});
-		expect(isImpersonatingSiren(session, "987654321")).toBe(false);
+		expect(isImpersonatingSiren(impersonatingAdmin(), "987654321", NOW)).toBe(
+			false,
+		);
 	});
 
 	it("returns true when admin is impersonating exactly this SIREN", () => {
-		const session = makeSession({
-			isAdmin: true,
-			impersonation: { siren: "123456789", name: "Acme" },
+		expect(isImpersonatingSiren(impersonatingAdmin(), "123456789", NOW)).toBe(
+			true,
+		);
+	});
+
+	it("stops bypassing ownership once the window has expired", () => {
+		const session = impersonatingAdmin({ adminMfaAt: EXPIRED_MFA });
+		expect(isImpersonatingSiren(session, "123456789", NOW)).toBe(false);
+	});
+
+	it("defaults `now` to the current time", () => {
+		const session = impersonatingAdmin({
+			adminMfaAt: Math.floor(Date.now() / 1000) - 60,
 		});
 		expect(isImpersonatingSiren(session, "123456789")).toBe(true);
 	});
 });
 
+describe("isImpersonating", () => {
+	it("returns false when session is null", () => {
+		expect(isImpersonating(null, NOW)).toBe(false);
+	});
+
+	it("returns true for an admin impersonating inside the window", () => {
+		expect(isImpersonating(impersonatingAdmin(), NOW)).toBe(true);
+	});
+
+	it("returns false once the window has expired", () => {
+		expect(
+			isImpersonating(impersonatingAdmin({ adminMfaAt: EXPIRED_MFA }), NOW),
+		).toBe(false);
+	});
+
+	it("returns false for a non-admin carrying a stray impersonation", () => {
+		const session = makeSession({
+			isAdmin: false,
+			adminMfaAt: FRESH_MFA,
+			impersonation: DEMO,
+		});
+		expect(isImpersonating(session, NOW)).toBe(false);
+	});
+
+	it("defaults `now` to the current time", () => {
+		const session = impersonatingAdmin({
+			adminMfaAt: Math.floor(Date.now() / 1000) - 60,
+		});
+		expect(isImpersonating(session)).toBe(true);
+	});
+});
+
 describe("assertNotImpersonating", () => {
 	it("does not throw when session is null", () => {
-		expect(() => assertNotImpersonating(null)).not.toThrow();
+		expect(() => assertNotImpersonating(null, NOW)).not.toThrow();
 	});
 
 	it("does not throw for a non-impersonating user", () => {
 		const session = makeSession({ isAdmin: false, impersonation: null });
-		expect(() => assertNotImpersonating(session)).not.toThrow();
+		expect(() => assertNotImpersonating(session, NOW)).not.toThrow();
 	});
 
 	it("does not throw for an admin who is not impersonating", () => {
-		const session = makeSession({ isAdmin: true, impersonation: null });
-		expect(() => assertNotImpersonating(session)).not.toThrow();
+		const session = makeSession({
+			isAdmin: true,
+			adminMfaAt: FRESH_MFA,
+			impersonation: null,
+		});
+		expect(() => assertNotImpersonating(session, NOW)).not.toThrow();
 	});
 
 	it("does not throw for a non-admin with a stray impersonation field", () => {
@@ -76,22 +217,35 @@ describe("assertNotImpersonating", () => {
 		// happens to carry an `impersonation` value.
 		const session = makeSession({
 			isAdmin: false,
-			impersonation: { siren: "123456789", name: "Acme" },
+			adminMfaAt: FRESH_MFA,
+			impersonation: DEMO,
 		});
-		expect(() => assertNotImpersonating(session)).not.toThrow();
+		expect(() => assertNotImpersonating(session, NOW)).not.toThrow();
 	});
 
 	it("throws a FORBIDDEN TRPCError when an admin is impersonating", () => {
-		const session = makeSession({
-			isAdmin: true,
-			impersonation: { siren: "123456789", name: "Acme" },
-		});
-		expect(() => assertNotImpersonating(session)).toThrow(
+		expect(() => assertNotImpersonating(impersonatingAdmin(), NOW)).toThrow(
 			expect.objectContaining({
 				name: "TRPCError",
 				code: "FORBIDDEN",
 				message: expect.stringContaining("mimoquage"),
 			}),
 		);
+	});
+
+	it("stops blocking writes once the window has expired — the agent is an ordinary declarant on their own SIREN (S8)", () => {
+		// Not a loosened guard: `getEffectiveSiren` has already stopped
+		// resolving the impersonated company, so the write this lets through
+		// can only target the agent's own perimeter.
+		const session = impersonatingAdmin({ adminMfaAt: EXPIRED_MFA });
+		expect(() => assertNotImpersonating(session, NOW)).not.toThrow();
+		expect(getEffectiveSiren(session, NOW)).toBe("987654321");
+	});
+
+	it("defaults `now` to the current time", () => {
+		const session = impersonatingAdmin({
+			adminMfaAt: Math.floor(Date.now() / 1000) - 60,
+		});
+		expect(() => assertNotImpersonating(session)).toThrow();
 	});
 });

--- a/packages/app/src/server/auth/__tests__/config.test.ts
+++ b/packages/app/src/server/auth/__tests__/config.test.ts
@@ -28,6 +28,12 @@ vi.mock("~/server/db/schema", () => ({
 	users: { email: "email", id: "id" },
 	companies: { siren: "siren" },
 	userCompanies: {},
+	// The sign-in branch closes any open impersonation row (#4466), so the
+	// schema mock has to carry the table it targets.
+	adminImpersonationEvents: {
+		adminUserId: "adminUserId",
+		stoppedAt: "stoppedAt",
+	},
 }));
 vi.mock("~/server/services/weez", () => ({
 	fetchCompanyBySiren: vi.fn(),
@@ -195,6 +201,16 @@ describe("auth config", () => {
 	}
 
 	describe("jwt callback — ProConnect identity seeding", () => {
+		// Every sign-in also closes any open impersonation row (#4466), which is
+		// an UPDATE against another table. These tests are about name seeding,
+		// so they count the updates aimed at `users` rather than all of them.
+		function userTableUpdates() {
+			return mockUpdate.mock.calls.filter(
+				([table]) =>
+					(table as { email?: string } | undefined)?.email === "email",
+			);
+		}
+
 		function armUpdate() {
 			const where = vi.fn().mockResolvedValue(undefined);
 			const set = vi.fn().mockReturnValue({ where });
@@ -226,7 +242,7 @@ describe("auth config", () => {
 
 			await signIn({ firstName: "Camille", lastName: "Durand" });
 
-			expect(mockUpdate).not.toHaveBeenCalled();
+			expect(userTableUpdates()).toHaveLength(0);
 		});
 
 		it("leaves the DB row untouched when ProConnect sends no name", async () => {
@@ -234,7 +250,7 @@ describe("auth config", () => {
 
 			await signIn({ firstName: null, lastName: null }, namelessProconnectUser);
 
-			expect(mockUpdate).not.toHaveBeenCalled();
+			expect(userTableUpdates()).toHaveLength(0);
 		});
 	});
 

--- a/packages/app/src/server/auth/__tests__/impersonation.test.ts
+++ b/packages/app/src/server/auth/__tests__/impersonation.test.ts
@@ -310,9 +310,11 @@ describe("jwt callback — a step-up stops the impersonation (S14)", () => {
 			session: { impersonation: { siren: "987654321", name: "Autre Démo" } },
 		});
 
-		// Every start closes what was open before inserting, and the step-up
-		// closed the row it inherited — so nothing is ever left dangling.
-		expect(closedImpersonations.length).toBeGreaterThanOrEqual(1);
+		// One close before the only start allowed to open a row, one more at the
+		// step-up. The third call is refused for want of a fresh window, so it
+		// opens nothing: no row is left dangling and two are never open at once.
+		expect(startedImpersonations).toHaveLength(1);
+		expect(closedImpersonations).toHaveLength(2);
 		for (const row of closedImpersonations) {
 			expect(row.stoppedAt).toBeInstanceOf(Date);
 		}

--- a/packages/app/src/server/auth/__tests__/impersonation.test.ts
+++ b/packages/app/src/server/auth/__tests__/impersonation.test.ts
@@ -298,6 +298,96 @@ describe("jwt callback — a step-up stops the impersonation (S14)", () => {
 	});
 });
 
+describe("jwt callback — a lapsed window closes the journal row on its own", () => {
+	/** Any ordinary request: no sign-in, no session update. */
+	function plainRequest(token: JWT) {
+		return callJwt({ token });
+	}
+
+	it("closes the open row once the window has lapsed, without waiting for a step-up", async () => {
+		// The session outlives the window by weeks. Were the row closed only on
+		// sign-in, the administration journal would show a mimoquage still open
+		// long after the server stopped honouring it.
+		const result = await plainRequest({
+			id: "u1",
+			isAdmin: true,
+			adminMfaAt: EXPIRED_MFA,
+			impersonation: DEMO,
+		} as JWT);
+
+		expect(closedImpersonations).toHaveLength(1);
+		expect(closedImpersonations[0]?.stoppedAt).toBeInstanceOf(Date);
+		expect(result.impersonation).toBeNull();
+	});
+
+	it("closes the open row when no second factor was ever presented", async () => {
+		const result = await plainRequest({
+			id: "u1",
+			isAdmin: true,
+			impersonation: DEMO,
+		} as JWT);
+
+		expect(closedImpersonations).toHaveLength(1);
+		expect(result.impersonation).toBeNull();
+	});
+
+	it("leaves a mimoquage alone while the window is still open", async () => {
+		const result = await plainRequest({
+			id: "u1",
+			isAdmin: true,
+			adminMfaAt: FRESH_MFA,
+			impersonation: DEMO,
+		} as JWT);
+
+		expect(closedImpersonations).toHaveLength(0);
+		expect(result.impersonation).toEqual(DEMO);
+	});
+
+	it("writes nothing on a request carrying no mimoquage", async () => {
+		const result = await plainRequest({
+			id: "u1",
+			isAdmin: true,
+			adminMfaAt: EXPIRED_MFA,
+		} as JWT);
+
+		expect(closedImpersonations).toHaveLength(0);
+		expect(result.impersonation).toBeUndefined();
+	});
+
+	it("does not close twice when the same token comes back on a later request", async () => {
+		const token = {
+			id: "u1",
+			isAdmin: true,
+			adminMfaAt: EXPIRED_MFA,
+			impersonation: DEMO,
+		} as JWT;
+
+		await plainRequest(token);
+		await plainRequest(token);
+
+		expect(closedImpersonations).toHaveLength(1);
+	});
+
+	it("still issues a single closing statement when the agent stops a lapsed mimoquage explicitly", async () => {
+		// The explicit stop returns from the update branch, so the lapsed-window
+		// close below it never doubles it.
+		const token = {
+			id: "u1",
+			isAdmin: true,
+			adminMfaAt: EXPIRED_MFA,
+			impersonation: DEMO,
+		} as JWT;
+
+		await callJwt({
+			token,
+			trigger: "update",
+			session: { impersonation: null },
+		});
+
+		expect(closedImpersonations).toHaveLength(1);
+	});
+});
+
 describe("session callback — impersonation is exposed only inside the MFA window", () => {
 	function sessionFor(token: Partial<JWT>) {
 		return callSession({

--- a/packages/app/src/server/auth/__tests__/impersonation.test.ts
+++ b/packages/app/src/server/auth/__tests__/impersonation.test.ts
@@ -9,6 +9,11 @@ import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
 const closedImpersonations = vi.hoisted(
 	() => [] as Array<Record<string, unknown>>,
 );
+// Records every row inserted into the administration journal, so a test can
+// assert that a refused mimoquage opened none.
+const startedImpersonations = vi.hoisted(
+	() => [] as Array<Record<string, unknown>>,
+);
 const mockFindFirst = vi.hoisted(() => vi.fn());
 
 // The impersonation-update branch of the jwt callback writes to the audit
@@ -19,7 +24,12 @@ vi.mock("~/server/db", () => {
 			onConflictDoNothing: () => Promise.resolve(),
 		}),
 	});
-	const plainValues = () => ({ values: () => Promise.resolve() });
+	const recordingValues = () => ({
+		values: (values: Record<string, unknown>) => {
+			startedImpersonations.push(values);
+			return Promise.resolve();
+		},
+	});
 	const recordingUpdate = (table: unknown) => ({
 		set: (values: Record<string, unknown>) => {
 			if ((table as { adminUserId?: string } | undefined)?.adminUserId) {
@@ -49,7 +59,7 @@ vi.mock("~/server/db", () => {
 								first = false;
 								return chain();
 							}
-							return plainValues();
+							return recordingValues();
 						};
 					})(),
 					update: recordingUpdate,
@@ -96,6 +106,7 @@ const DEMO = { siren: "123456789", name: "Société Démo" };
 
 beforeEach(() => {
 	closedImpersonations.length = 0;
+	startedImpersonations.length = 0;
 	mockFindFirst.mockReset();
 	mockFindFirst.mockResolvedValue({
 		id: "u1",
@@ -108,7 +119,7 @@ beforeEach(() => {
 
 describe("jwt callback — impersonation update trigger", () => {
 	it("writes impersonation into the token when admin updates the session", async () => {
-		const token = { id: "u1", isAdmin: true } as JWT;
+		const token = { id: "u1", isAdmin: true, adminMfaAt: FRESH_MFA } as JWT;
 		const result = await callJwt({
 			token,
 			trigger: "update",
@@ -124,6 +135,7 @@ describe("jwt callback — impersonation update trigger", () => {
 		const token = {
 			id: "u1",
 			isAdmin: true,
+			adminMfaAt: FRESH_MFA,
 			impersonation: { siren: "123456789", name: "Acme" },
 		} as JWT;
 		const result = await callJwt({
@@ -145,7 +157,7 @@ describe("jwt callback — impersonation update trigger", () => {
 	});
 
 	it("rejects malformed impersonation payloads (invalid SIREN)", async () => {
-		const token = { id: "u1", isAdmin: true } as JWT;
+		const token = { id: "u1", isAdmin: true, adminMfaAt: FRESH_MFA } as JWT;
 		const result = await callJwt({
 			token,
 			trigger: "update",
@@ -155,13 +167,62 @@ describe("jwt callback — impersonation update trigger", () => {
 	});
 
 	it("rejects payload missing the `name` field", async () => {
-		const token = { id: "u1", isAdmin: true } as JWT;
+		const token = { id: "u1", isAdmin: true, adminMfaAt: FRESH_MFA } as JWT;
 		const result = await callJwt({
 			token,
 			trigger: "update",
 			session: { impersonation: { siren: "123456789" } },
 		});
 		expect(result.impersonation).toBeUndefined();
+	});
+
+	it("refuses to start a mimoquage once the MFA window has closed", async () => {
+		// Starting a mimoquage is an administrator privilege in its own right.
+		// Were it gated on `isAdmin` alone, an agent whose window had closed
+		// could open a row in the administration journal that no live mimoquage
+		// backs — the very invariant #4466 exists to hold — and persist a
+		// client-supplied company name without a valid second factor.
+		const token = { id: "u1", isAdmin: true, adminMfaAt: EXPIRED_MFA } as JWT;
+		const result = await callJwt({
+			token,
+			trigger: "update",
+			session: { impersonation: { siren: "123456789", name: "Acme" } },
+		});
+
+		expect(result.impersonation).toBeUndefined();
+		expect(startedImpersonations).toHaveLength(0);
+	});
+
+	it("refuses to start a mimoquage when no second factor was ever presented", async () => {
+		const token = { id: "u1", isAdmin: true } as JWT;
+		const result = await callJwt({
+			token,
+			trigger: "update",
+			session: { impersonation: { siren: "123456789", name: "Acme" } },
+		});
+
+		expect(result.impersonation).toBeUndefined();
+		expect(startedImpersonations).toHaveLength(0);
+	});
+
+	it("still lets an agent stop a mimoquage after the window has closed", async () => {
+		// Ending a mimoquage and closing its row must never be refused: the
+		// gate above is on starting, so an expired window can never strand an
+		// open row that the agent is powerless to close.
+		const token = {
+			id: "u1",
+			isAdmin: true,
+			adminMfaAt: EXPIRED_MFA,
+			impersonation: { siren: "123456789", name: "Acme" },
+		} as JWT;
+		const result = await callJwt({
+			token,
+			trigger: "update",
+			session: { impersonation: null },
+		});
+
+		expect(result.impersonation).toBeNull();
+		expect(closedImpersonations).toHaveLength(1);
 	});
 });
 
@@ -212,7 +273,7 @@ describe("jwt callback — a step-up stops the impersonation (S14)", () => {
 	});
 
 	it("leaves at most one open row across two impersonations separated by a step-up", async () => {
-		const token = { id: "u1", isAdmin: true } as JWT;
+		const token = { id: "u1", isAdmin: true, adminMfaAt: FRESH_MFA } as JWT;
 
 		await callJwt({
 			token,

--- a/packages/app/src/server/auth/__tests__/impersonation.test.ts
+++ b/packages/app/src/server/auth/__tests__/impersonation.test.ts
@@ -1,5 +1,15 @@
+import type { Account, User } from "next-auth";
 import type { JWT } from "next-auth/jwt";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
+
+// Records every UPDATE the callbacks issue so the tests can tell an
+// impersonation-closing statement from the other writes of a sign-in.
+const closedImpersonations = vi.hoisted(
+	() => [] as Array<Record<string, unknown>>,
+);
+const mockFindFirst = vi.hoisted(() => vi.fn());
 
 // The impersonation-update branch of the jwt callback writes to the audit
 // log inside a transaction. Factory returns self-contained stubs.
@@ -10,11 +20,26 @@ vi.mock("~/server/db", () => {
 		}),
 	});
 	const plainValues = () => ({ values: () => Promise.resolve() });
-	const setWhere = () => ({
-		set: () => ({ where: () => Promise.resolve() }),
+	const recordingUpdate = (table: unknown) => ({
+		set: (values: Record<string, unknown>) => {
+			if ((table as { adminUserId?: string } | undefined)?.adminUserId) {
+				closedImpersonations.push(values);
+			}
+			return { where: () => Promise.resolve() };
+		},
 	});
 	return {
 		db: {
+			query: {
+				users: { findFirst: (...args: unknown[]) => mockFindFirst(...args) },
+			},
+			insert: () => ({
+				values: () => ({
+					onConflictDoUpdate: () => Promise.resolve(),
+					onConflictDoNothing: () => Promise.resolve(),
+					returning: () => Promise.resolve([{ id: "u1", phone: null }]),
+				}),
+			}),
 			transaction: async (fn: (tx: unknown) => unknown) =>
 				fn({
 					insert: (() => {
@@ -27,14 +52,14 @@ vi.mock("~/server/db", () => {
 							return plainValues();
 						};
 					})(),
-					update: () => setWhere(),
+					update: recordingUpdate,
 				}),
-			update: () => setWhere(),
+			update: recordingUpdate,
 		},
 	};
 });
 vi.mock("~/server/db/schema", () => ({
-	users: {},
+	users: { email: "email", id: "id" },
 	companies: { siren: "siren" },
 	userCompanies: {},
 	adminImpersonationEvents: {
@@ -45,6 +70,7 @@ vi.mock("~/server/db/schema", () => ({
 vi.mock("~/server/services/weez", () => ({
 	fetchCompanyBySiren: vi.fn(),
 }));
+vi.mock("~/server/audit/log", () => ({ logAction: vi.fn() }));
 
 import { authConfig } from "../config";
 
@@ -61,6 +87,24 @@ function callSession(params: Record<string, unknown>) {
 		params as unknown as Parameters<typeof callbacks.session>[0],
 	);
 }
+
+const NOW_SECONDS = Math.floor(Date.now() / 1000);
+const FRESH_MFA = NOW_SECONDS - 60;
+const EXPIRED_MFA = NOW_SECONDS - ADMIN_MFA_WINDOW_SECONDS - 1;
+
+const DEMO = { siren: "123456789", name: "Société Démo" };
+
+beforeEach(() => {
+	closedImpersonations.length = 0;
+	mockFindFirst.mockReset();
+	mockFindFirst.mockResolvedValue({
+		id: "u1",
+		phone: null,
+		isAdmin: true,
+		firstName: "Alice",
+		lastName: "Martin",
+	});
+});
 
 describe("jwt callback — impersonation update trigger", () => {
 	it("writes impersonation into the token when admin updates the session", async () => {
@@ -121,29 +165,120 @@ describe("jwt callback — impersonation update trigger", () => {
 	});
 });
 
-describe("session callback — impersonation propagation", () => {
-	it("mirrors token.impersonation onto session.user.impersonation", () => {
-		const result = callSession({
-			session: { user: { name: null, email: null, image: null }, expires: "" },
-			token: {
-				id: "u1",
-				isAdmin: true,
-				impersonation: { siren: "123456789", name: "Acme" },
-			} as unknown as JWT,
-		}) as {
-			user: { impersonation: { siren: string; name: string } | null };
-		};
-		expect(result.user.impersonation).toEqual({
-			siren: "123456789",
-			name: "Acme",
+describe("jwt callback — a step-up stops the impersonation (S14)", () => {
+	/** A fresh sign-in, which is exactly what a step-up produces. */
+	function signIn(token: JWT = {} as JWT) {
+		return callJwt({
+			token,
+			user: {
+				id: "proconnect-sub",
+				email: "agent@example.fr",
+				name: "Alice Martin",
+			} as User,
+			account: {} as Account,
+			trigger: "signIn",
 		});
+	}
+
+	it("closes the open administration-journal row", async () => {
+		await signIn();
+
+		expect(closedImpersonations).toHaveLength(1);
+		expect(closedImpersonations[0]?.stoppedAt).toBeInstanceOf(Date);
+	});
+
+	it("leaves no impersonation on the token, and never resumes the previous one", async () => {
+		const result = await signIn({
+			id: "u1",
+			isAdmin: true,
+			impersonation: DEMO,
+		} as JWT);
+
+		expect(result.impersonation).toBeNull();
+	});
+
+	it("closes the row even for an account no longer listed as admin, so no row stays open for good", async () => {
+		mockFindFirst.mockResolvedValue({
+			id: "u1",
+			phone: null,
+			isAdmin: false,
+			firstName: "Alice",
+			lastName: "Martin",
+		});
+
+		await signIn({ id: "u1", isAdmin: true, impersonation: DEMO } as JWT);
+
+		expect(closedImpersonations).toHaveLength(1);
+	});
+
+	it("leaves at most one open row across two impersonations separated by a step-up", async () => {
+		const token = { id: "u1", isAdmin: true } as JWT;
+
+		await callJwt({
+			token,
+			trigger: "update",
+			session: { impersonation: DEMO },
+		});
+		const afterStepUp = await signIn(token);
+		expect(afterStepUp.impersonation).toBeNull();
+
+		await callJwt({
+			token: { id: "u1", isAdmin: true } as JWT,
+			trigger: "update",
+			session: { impersonation: { siren: "987654321", name: "Autre Démo" } },
+		});
+
+		// Every start closes what was open before inserting, and the step-up
+		// closed the row it inherited — so nothing is ever left dangling.
+		expect(closedImpersonations.length).toBeGreaterThanOrEqual(1);
+		for (const row of closedImpersonations) {
+			expect(row.stoppedAt).toBeInstanceOf(Date);
+		}
+	});
+});
+
+describe("session callback — impersonation is exposed only inside the MFA window", () => {
+	function sessionFor(token: Partial<JWT>) {
+		return callSession({
+			session: { user: { name: null, email: null, image: null }, expires: "" },
+			token: { id: "u1", ...token } as unknown as JWT,
+		}) as { user: { impersonation: { siren: string; name: string } | null } };
+	}
+
+	it("mirrors token.impersonation while the second factor is fresh", () => {
+		const result = sessionFor({
+			isAdmin: true,
+			adminMfaAt: FRESH_MFA,
+			impersonation: DEMO,
+		});
+		expect(result.user.impersonation).toEqual(DEMO);
+	});
+
+	it("hides the impersonation once the window has expired, so the banner disappears with it", () => {
+		const result = sessionFor({
+			isAdmin: true,
+			adminMfaAt: EXPIRED_MFA,
+			impersonation: DEMO,
+		});
+		expect(result.user.impersonation).toBeNull();
+	});
+
+	it("hides the impersonation when no second factor was ever presented", () => {
+		const result = sessionFor({ isAdmin: true, impersonation: DEMO });
+		expect(result.user.impersonation).toBeNull();
+	});
+
+	it("hides a stray impersonation carried by a non-admin token", () => {
+		const result = sessionFor({
+			isAdmin: false,
+			adminMfaAt: FRESH_MFA,
+			impersonation: DEMO,
+		});
+		expect(result.user.impersonation).toBeNull();
 	});
 
 	it("defaults impersonation to null when token has none", () => {
-		const result = callSession({
-			session: { user: { name: null, email: null, image: null }, expires: "" },
-			token: { id: "u1", isAdmin: false } as unknown as JWT,
-		}) as { user: { impersonation: unknown } };
+		const result = sessionFor({ isAdmin: false });
 		expect(result.user.impersonation).toBeNull();
 	});
 });

--- a/packages/app/src/server/auth/__tests__/impersonation.test.ts
+++ b/packages/app/src/server/auth/__tests__/impersonation.test.ts
@@ -193,6 +193,27 @@ describe("jwt callback — impersonation update trigger", () => {
 		expect(startedImpersonations).toHaveLength(0);
 	});
 
+	it("closes the row it already had open when the switch is refused for a lapsed window", async () => {
+		// An agent switching companies just as the window lapses must not be
+		// left with a refused switch and its previous row still open.
+		const token = {
+			id: "u1",
+			isAdmin: true,
+			adminMfaAt: EXPIRED_MFA,
+			impersonation: DEMO,
+		} as JWT;
+
+		const result = await callJwt({
+			token,
+			trigger: "update",
+			session: { impersonation: { siren: "987654321", name: "Autre Démo" } },
+		});
+
+		expect(startedImpersonations).toHaveLength(0);
+		expect(closedImpersonations).toHaveLength(1);
+		expect(result.impersonation).toBeNull();
+	});
+
 	it("refuses to start a mimoquage when no second factor was ever presented", async () => {
 		const token = { id: "u1", isAdmin: true } as JWT;
 		const result = await callJwt({

--- a/packages/app/src/server/auth/companyAccess.ts
+++ b/packages/app/src/server/auth/companyAccess.ts
@@ -1,25 +1,57 @@
 import { TRPCError } from "@trpc/server";
 import type { Session } from "next-auth";
 
-import { extractSiren } from "~/modules/domain";
+import { isAdminMfaFresh, parseSiren } from "~/modules/domain";
+
+type ActiveImpersonation = NonNullable<Session["user"]["impersonation"]>;
+
+/**
+ * The impersonation this session may actually act on, or `null`.
+ *
+ * Two conditions, and the second is the one issue #4466 adds: the account is
+ * an admin, and its second factor is still inside the window. Impersonation
+ * *is* an administrator privilege — it makes an agent read a company they are
+ * not the referent of. Letting an expired window keep resolving a foreign
+ * SIREN would hand back through the side door exactly what the `/admin` pages
+ * and the administration procedures refuse once the window closes.
+ *
+ * Every predicate below reads the impersonation through this function, so the
+ * freshness rule is decided in one place: the next surface that consumes a
+ * mimoquage inherits it instead of forgetting to re-implement it.
+ */
+function activeImpersonation(
+	session: Session | null,
+	now: Date,
+): ActiveImpersonation | null {
+	if (!session?.user?.isAdmin) return null;
+	if (!isAdminMfaFresh(session.user.adminMfaAt, now)) return null;
+	return session.user.impersonation ?? null;
+}
 
 /**
  * Resolve the SIREN to display/load for the current session.
  *
- * - Admin currently impersonating a company → the impersonated SIREN.
- * - Regular user → the SIREN extracted from their ProConnect SIRET.
+ * - Admin with an effective impersonation → the impersonated SIREN.
+ * - Regular user, or admin whose window has expired → the SIREN parsed from
+ *   their own ProConnect SIRET.
  * - Anyone without either → `null`, and the caller decides how to bail
  *   (redirect, `<MissingSiret/>`, etc.).
  *
- * Shared across every page/layout that renders company-scoped UI so every
+ * The SIRET is read through `parseSiren`, which validates shape and length:
+ * a malformed SIRET yields `null` and the caller's "missing SIRET" branch,
+ * never a truncated string used as a query key.
+ *
+ * Shared across every page/layout and the tRPC company procedure so every
  * surface behaves identically during mimoquage (issue #3230).
  */
-export function getEffectiveSiren(session: Session | null): string | null {
+export function getEffectiveSiren(
+	session: Session | null,
+	now: Date = new Date(),
+): string | null {
 	if (!session?.user) return null;
-	if (session.user.isAdmin && session.user.impersonation) {
-		return session.user.impersonation.siren;
-	}
-	return session.user.siret ? extractSiren(session.user.siret) : null;
+	const impersonation = activeImpersonation(session, now);
+	if (impersonation) return impersonation.siren;
+	return parseSiren(session.user.siret);
 }
 
 /**
@@ -30,10 +62,13 @@ export function getEffectiveSiren(session: Session | null): string | null {
  *   1. The user owns the SIREN via `app_user_company` (normal case — the
  *      caller still has to run the ownership query, this function only
  *      encodes the admin-impersonation short-circuit).
- *   2. The user is an admin currently impersonating *exactly* this SIREN.
+ *   2. The user is an admin whose impersonation is effective — inside the
+ *      MFA window — and targets *exactly* this SIREN.
  *
  * Returning `true` here means the ownership check should be skipped; callers
- * must still run the query when this returns `false`.
+ * must still run the query when this returns `false`. An admin out of window
+ * therefore falls back to the ownership query and is refused a company they
+ * are not a referent of, which is the intended outcome.
  *
  * The `siren` comparison is strict equality — an admin impersonating SIREN
  * A cannot read SIREN B "in passing".
@@ -41,13 +76,13 @@ export function getEffectiveSiren(session: Session | null): string | null {
 export function isImpersonatingSiren(
 	session: Session | null,
 	siren: string,
+	now: Date = new Date(),
 ): boolean {
-	if (!session?.user?.isAdmin) return false;
-	return session.user.impersonation?.siren === siren;
+	return activeImpersonation(session, now)?.siren === siren;
 }
 
 /**
- * Is the current session an admin actively impersonating a company
+ * Is the current session an admin with an effective impersonation
  * ("mimoquage") ?
  *
  * Read-only surfaces use it to relax user-data prerequisites an admin cannot
@@ -55,10 +90,15 @@ export function isImpersonatingSiren(
  * `assertNotImpersonating` instead.
  *
  * Gating on `isAdmin` blocks a crafted session carrying a stray
- * `impersonation` field.
+ * `impersonation` field; gating on the MFA window keeps this predicate in
+ * step with `getEffectiveSiren` — a session that no longer resolves the
+ * impersonated SIREN must not still be treated as impersonating.
  */
-export function isImpersonating(session: Session | null): boolean {
-	return Boolean(session?.user?.isAdmin && session.user.impersonation);
+export function isImpersonating(
+	session: Session | null,
+	now: Date = new Date(),
+): boolean {
+	return activeImpersonation(session, now) !== null;
 }
 
 /**
@@ -69,11 +109,20 @@ export function isImpersonating(session: Session | null): boolean {
  * admins can diagnose issues without altering the user's data. The UI hides
  * these actions too, but this assertion is the source of truth.
  *
+ * The read-only rule itself is unchanged by #4466: an effective mimoquage
+ * still refuses every write. An admin whose window has expired simply has no
+ * effective mimoquage left — they write as an ordinary declarant, and only on
+ * their own SIREN, since `getEffectiveSiren` has stopped resolving anyone
+ * else's.
+ *
  * Throws a `FORBIDDEN` `TRPCError` with a user-facing French message; Route
  * Handlers can catch it and translate to HTTP 403.
  */
-export function assertNotImpersonating(session: Session | null): void {
-	if (isImpersonating(session)) {
+export function assertNotImpersonating(
+	session: Session | null,
+	now: Date = new Date(),
+): void {
+	if (isImpersonating(session, now)) {
 		throw new TRPCError({
 			code: "FORBIDDEN",
 			message:

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -472,6 +472,21 @@ export const authConfig = {
 					return token;
 				}
 
+				// Starting a mimoquage is itself an administrator privilege, so it
+				// needs a second factor inside the window — the same condition the
+				// shared predicates apply when *reading* through a mimoquage
+				// (#4466). Gating only on `token.isAdmin` would let an agent whose
+				// window has closed open a row in the administration journal that
+				// no live mimoquage backs, which is precisely the invariant this
+				// ticket exists to hold. It would also persist a client-supplied
+				// company name without a valid second factor.
+				//
+				// Stopping stays ungated on purpose, above: ending a mimoquage and
+				// closing its row must never be refused.
+				if (!isAdminMfaFresh(token.adminMfaAt, new Date())) {
+					return token;
+				}
+
 				if (raw && typeof raw === "object") {
 					const candidate = raw as { siren?: unknown; name?: unknown };
 					const sirenResult = sirenSchema.safeParse(candidate.siren);

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -60,7 +60,8 @@ async function closeOpenImpersonationEvents(adminUserId: string) {
  * step-up but not against a window that simply lapses (issue #4466, S14).
  *
  * Emptying the token field is what keeps this from firing twice; a repeat costs
- * an index probe on the partial index of open rows and no write.
+ * an index probe on `admin_impersonation_event_admin_started_idx`, which narrows
+ * to this admin's own rows, and no write.
  */
 async function closeLapsedImpersonation(
 	token: {
@@ -650,9 +651,9 @@ export const authConfig = {
 				//
 				// Unconditional, and not gated on `shouldBeAdmin`: an account
 				// dropped from `ADMIN_EMAILS` between two sign-ins would otherwise
-				// leave its last row open for good. The statement targets the
-				// partial index on open rows, so it costs nothing for the
-				// declarants who never have one.
+				// leave its last row open for good. The statement is keyed on
+				// `adminUserId`, so for the declarants — who never have a row — it
+				// costs one index probe and no write.
 				//
 				// No automatic resume: the agent restarts the mimoquage from the
 				// backoffice if they still need it.

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -671,6 +671,30 @@ export const authConfig = {
 					});
 				}
 			}
+
+			// A mimoquage stops biting the instant the second-factor window
+			// lapses: `exposedImpersonation` and `activeImpersonation` both stop
+			// honouring it, so the banner goes and the server resolves the
+			// agent's own SIREN again. The open row in the administration journal
+			// has no such clock. Closing it in the sign-in branch alone would
+			// leave it open for the whole remaining life of the session — weeks
+			// past the window — so the invariant that branch states, no row open
+			// without a live mimoquage behind it, would hold against a step-up
+			// but not against a window that simply lapses (#4466, S14).
+			//
+			// Last, so it never doubles a close the branches above already made:
+			// an explicit stop returns from the update branch, and a sign-in has
+			// just emptied the field. Clearing the field is what keeps it from
+			// firing twice; a repeat would cost an index probe on the partial
+			// index of open rows and no write.
+			if (
+				token.impersonation &&
+				!isAdminMfaFresh(token.adminMfaAt, new Date())
+			) {
+				await closeOpenImpersonationEvents(token.id);
+				token.impersonation = null;
+			}
+
 			return token;
 		},
 		session: ({ session, token }) => ({

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -6,7 +6,12 @@ import type { Provider } from "next-auth/providers/index";
 import { env } from "~/env";
 import { sirenSchema } from "~/modules/admin/schemas";
 import { AUDIT_ACTIONS } from "~/modules/audit";
-import { extractSiren, isAdminMfaAcr, parseSiren } from "~/modules/domain";
+import {
+	extractSiren,
+	isAdminMfaAcr,
+	isAdminMfaFresh,
+	parseSiren,
+} from "~/modules/domain";
 import { devLoginSchema } from "~/modules/login/schemas";
 import { logAction } from "~/server/audit/log";
 import { buildRequestContext, toHeaders } from "~/server/audit/requestContext";
@@ -159,6 +164,36 @@ declare module "next-auth/jwt" {
 		adminMfaAt?: number;
 	}
 }
+
+/**
+ * Impersonation as the session exposes it: present only while the account is
+ * an admin *and* its second factor is still inside the window.
+ *
+ * The banner reads `session.user.impersonation` and nothing else, so it
+ * vanishes at the very instant the server stops honouring the mimoquage
+ * (issue #4466, S14). The two must never diverge: a banner outliving the
+ * privilege would invite an agent to act on a company whose SIREN the server
+ * has already stopped resolving, and an effective mimoquage with no banner
+ * would hide whose data is on screen.
+ *
+ * The token keeps its `impersonation` field untouched — this is a projection,
+ * not a mutation. Nothing resumes when a new second factor is presented: a
+ * step-up re-mints the token from scratch, without impersonation.
+ */
+function exposedImpersonation(
+	token: JWTWithImpersonation,
+	now: Date,
+): Impersonation | null {
+	if (!token.isAdmin) return null;
+	if (!isAdminMfaFresh(token.adminMfaAt, now)) return null;
+	return token.impersonation ?? null;
+}
+
+type JWTWithImpersonation = {
+	isAdmin?: boolean;
+	adminMfaAt?: number;
+	impersonation?: Impersonation | null;
+};
 
 // Decoded without re-verifying the signature: this token never transited
 // through the browser — NextAuth fetched it server-to-server and openid-client
@@ -557,6 +592,24 @@ export const authConfig = {
 				token.id_token = account?.id_token ?? null;
 				token.isAdmin = shouldBeAdmin;
 
+				// A sign-in — a step-up included — mints the token from scratch,
+				// so the mimoquage disappears on its own. The open row in the
+				// administration journal does not: close it here so there is no
+				// instant at which a row is open without a live mimoquage behind
+				// it. That journal is a compliance trail, not a by-product of the
+				// banner (issue #4466, S14).
+				//
+				// Unconditional, and not gated on `shouldBeAdmin`: an account
+				// dropped from `ADMIN_EMAILS` between two sign-ins would otherwise
+				// leave its last row open for good. The statement targets the
+				// partial index on open rows, so it costs nothing for the
+				// declarants who never have one.
+				//
+				// No automatic resume: the agent restarts the mimoquage from the
+				// backoffice if they still need it.
+				await closeOpenImpersonationEvents(dbUser.id);
+				token.impersonation = null;
+
 				// The marker has exactly two sources, and a client reaches
 				// neither: the id_token of the exchange we just performed
 				// server-to-server, and — off outside a loopback test run, see
@@ -613,7 +666,7 @@ export const authConfig = {
 				siret: token.siret ?? null,
 				phone: token.phone ?? null,
 				isAdmin: token.isAdmin ?? false,
-				impersonation: token.impersonation ?? null,
+				impersonation: exposedImpersonation(token, new Date()),
 				adminMfaAt: token.adminMfaAt ?? null,
 			},
 		}),

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -48,6 +48,36 @@ async function closeOpenImpersonationEvents(adminUserId: string) {
 }
 
 /**
+ * Close the administration-journal row of a mimoquage whose second-factor
+ * window has lapsed, and drop it from the token.
+ *
+ * A mimoquage stops biting the instant the window closes: `exposedImpersonation`
+ * and `activeImpersonation` both stop honouring it, so the banner goes and the
+ * server resolves the agent's own SIREN again. The open row has no such clock.
+ * Closing it on sign-in alone would leave it open for the whole remaining life
+ * of the session — weeks past the window — so the invariant the sign-in branch
+ * states, no row open without a live mimoquage behind it, would hold against a
+ * step-up but not against a window that simply lapses (issue #4466, S14).
+ *
+ * Emptying the token field is what keeps this from firing twice; a repeat costs
+ * an index probe on the partial index of open rows and no write.
+ */
+async function closeLapsedImpersonation(
+	token: {
+		adminMfaAt?: number;
+		id: string;
+		impersonation?: Impersonation | null;
+	},
+	now: Date,
+) {
+	if (!token.impersonation) return;
+	if (isAdminMfaFresh(token.adminMfaAt, now)) return;
+
+	await closeOpenImpersonationEvents(token.id);
+	token.impersonation = null;
+}
+
+/**
  * Persist the start of an impersonation session atomically:
  * close any previously open session, ensure the company row exists (so
  * the FK on the audit table holds), then insert the new event.
@@ -484,6 +514,10 @@ export const authConfig = {
 				// Stopping stays ungated on purpose, above: ending a mimoquage and
 				// closing its row must never be refused.
 				if (!isAdminMfaFresh(token.adminMfaAt, new Date())) {
+					// The refusal must not strand what the agent already had open:
+					// an agent switching companies as the window lapses gets the
+					// same treatment as one who simply stopped browsing.
+					await closeLapsedImpersonation(token, new Date());
 					return token;
 				}
 
@@ -672,28 +706,10 @@ export const authConfig = {
 				}
 			}
 
-			// A mimoquage stops biting the instant the second-factor window
-			// lapses: `exposedImpersonation` and `activeImpersonation` both stop
-			// honouring it, so the banner goes and the server resolves the
-			// agent's own SIREN again. The open row in the administration journal
-			// has no such clock. Closing it in the sign-in branch alone would
-			// leave it open for the whole remaining life of the session — weeks
-			// past the window — so the invariant that branch states, no row open
-			// without a live mimoquage behind it, would hold against a step-up
-			// but not against a window that simply lapses (#4466, S14).
-			//
 			// Last, so it never doubles a close the branches above already made:
 			// an explicit stop returns from the update branch, and a sign-in has
-			// just emptied the field. Clearing the field is what keeps it from
-			// firing twice; a repeat would cost an index probe on the partial
-			// index of open rows and no write.
-			if (
-				token.impersonation &&
-				!isAdminMfaFresh(token.adminMfaAt, new Date())
-			) {
-				await closeOpenImpersonationEvents(token.id);
-				token.impersonation = null;
-			}
+			// just emptied the field.
+			await closeLapsedImpersonation(token, new Date());
 
 			return token;
 		},


### PR DESCRIPTION
Closes #4466

Sous-ticket de l'epic #4405. Deux règles, dont la seconde découle de la première.

## Ce que ça change

**1. Le step-up arrête le mimoquage (S14).** La bibliothèque d'authentification remint le jeton à chaque connexion, donc le mimoquage disparaît du jeton tout seul. Ce qui ne disparaît pas tout seul, c'est la **ligne ouverte du journal d'administration** : elle est désormais clôturée explicitement dans la branche de connexion, de sorte qu'il n'existe à aucun instant une ligne ouverte sans mimoquage actif. Aucune reprise automatique — l'agent relance le mimoquage depuis le backoffice s'il en a besoin.

L'appel est **inconditionnel**, et pas gardé sur `shouldBeAdmin` : un compte retiré de la liste des administrateurs entre deux connexions laisserait sinon sa dernière ligne ouverte pour de bon.

**2. Un mimoquage exige une double authentification dans la fenêtre.** Le mimoquage cesse d'être effectif dès que la fenêtre est dépassée : la résolution du SIREN effectif retombe sur le SIRET propre de l'agent. La condition vit dans le **module partagé** (`activeImpersonation`, consommé par `getEffectiveSiren`, `isImpersonating`, `isImpersonatingSiren`), pas chez chaque appelant — la prochaine surface qui lira le mimoquage en héritera au lieu de l'oublier.

Le bandeau et l'état serveur ne peuvent pas diverger : la session n'expose `impersonation` que dans la fenêtre (`exposedImpersonation`), donc le bandeau disparaît à l'instant même où le serveur cesse d'en tenir compte.

`companyProcedure` **délègue** désormais au module au lieu de réimplémenter le court-circuit.

## Le caractère lecture seule est inchangé

Le garde-fou d'écriture n'est ni assoupli ni durci. Un agent hors fenêtre n'a simplement plus de mimoquage effectif : il redevient un déclarant ordinaire sur son propre périmètre (S8).

Le point à vérifier était que l'effet net soit **strictement plus restrictif**, jamais l'inverse — puisque `assertNotImpersonating` ne lève plus pour un agent hors fenêtre. Il l'est : tout `isImpersonatingSiren` est un **contournement** du contrôle de propriété, donc le resserrer ne peut que restreindre ; et toute écriture est cadrée par `ctx.siren`, c'est-à-dire `getEffectiveSiren`, qui a cessé de résoudre le SIREN d'autrui. Un admin hors fenêtre retombe donc sur la requête de propriété et se voit refuser une entreprise dont il n'est pas référent.

## Un durcissement supplémentaire, trouvé à l'audit

L'audit sécurité a relevé que le déclencheur qui **démarre** un mimoquage n'était gardé que par le drapeau `isAdmin` du jeton — jamais réévalué en cours de session — et non par la condition de fraîcheur que le reste du ticket installe partout ailleurs. Ce chemin n'étant pas couvert par le middleware `/admin/*`, un agent dont la fenêtre avait expiré pouvait encore ouvrir une ligne dans le journal d'administration, et y faire persister un nom d'entreprise fourni par le client, sans second facteur valide.

Le mimoquage ainsi démarré ne devenait jamais *effectif* — les prédicats partagés revérifient tous la fraîcheur — donc aucune donnée d'entreprise n'était exposée. Mais c'était une écriture privilégiée accordée sur un booléen périmé, et surtout une **ligne ouverte qu'aucun mimoquage vivant n'adosse** : précisément l'invariant que ce ticket existe pour tenir.

Le démarrage est donc désormais gardé par `isAdminMfaFresh`. **L'arrêt reste non gardé, délibérément** : fermer un mimoquage et sa ligne ne doit jamais être refusé, sans quoi une fenêtre expirée laisserait une ligne ouverte que l'agent serait impuissant à clore.

## Test plan

- Suite complète verte : **484 fichiers / 6287 tests**, après rebase sur `epic/4405`.
- `pnpm typecheck` vert.
- Couverture : `src/server/auth/**` est exclu de l'instrumentation par la configuration du projet (décision préexistante) ; `src/server/api/trpc.ts` est à 88,5 % d'instructions. Les branches ajoutées sont couvertes explicitement.
- Pas de test d'intégration ajouté : le diff ne touche aucun SQL. `closeOpenImpersonationEvents` préexiste et son instruction est inchangée — seul un site d'appel est ajouté.
- Pas de test E2E ici : ils appartiennent à `e2e-dev`, en fin de pipeline.

### Rebase sur `epic/4405` et résolution du conflit

La branche a été rebasée sur `epic/4405` après l'arrivée de #4467 (raccord de test MFA du backoffice), qui touche le même `config.ts`. La PR était en conflit — un état où les workflows `pull_request` ne se déclenchent pas du tout, de sorte que les checks vertes affichées étaient périmées.

Le conflit était purement textuel : les deux côtés récrivaient le même commentaire d'en-tête de la branche de connexion. Les deux sémantiques sont conservées — la clôture de la ligne du journal (#4466) puis le commentaire mis à jour du marqueur, qui documente les deux sources possibles depuis #4467. Suite complète rejouée après rebase : verte, raccord de test de #4467 compris.

### Tests d'intégration

Les 24 fichiers d'intégration ont été rejoués : 20 échecs subsistent, tous dans `adminStats.gipWorkforceBounds` et `adminStats.getUsersPerCompany`, sans rapport avec le mimoquage. Vérifié préexistant en rejouant ces mêmes fichiers avec les trois fichiers source ramenés à leur version de `epic/4405` : **échecs identiques** (2 fichiers / 20 tests). Ce n'est donc pas une régression de ce ticket.

### Deux corrections issues des audits

- **Assertion resserrée** — `impersonation.test.ts`, test « au plus une ligne ouverte à travers deux mimoquages séparés d'un step-up » : il n'assertait qu'un minorant (`toBeGreaterThanOrEqual(1)`), qui ne vérifiait pas ce que son nom promet. Il compte désormais exactement une ouverture et deux fermetures — la troisième bascule, refusée faute de fenêtre fraîche, n'ouvrant aucune ligne.
- **Note d'index corrigée** — deux commentaires invoquaient « l'index partiel sur les lignes ouvertes » pour justifier le coût de la clôture. Cet index n'existe pas : `admin_impersonation_event_admin_started_idx` est composite sur `(adminUserId, startedAt)`. Le commentaire décrit maintenant l'index réel. Ajouter un index partiel sortirait du périmètre du ticket (migration de schéma) — signalé, non fait.

### Tests ajoutés

- `companyAccess.test.ts` — le SIREN effectif dans la fenêtre / hors fenêtre / sans second facteur ; le repli sur le périmètre propre ; l'admin hors fenêtre sans SIRET ; le SIRET malformé qui rend `null` plutôt qu'un SIREN tronqué ; l'impersonation parasite portée par une session non-admin.
- `impersonation.test.ts` — S14 : la connexion clôture la ligne du journal, ne laisse aucun mimoquage sur le jeton, et ne reprend jamais le précédent. Plus le durcissement ci-dessus : démarrage refusé hors fenêtre et sans second facteur (aucune ligne ouverte), arrêt toujours possible hors fenêtre.
- `ImpersonateBanner.test.tsx` — le bandeau ne rend rien une fois la fenêtre fermée, parce que la session n'expose plus l'impersonation.

### Triage des tests rouges

19 tests sont passés au rouge, **tous** pour une seule et même cause : leurs *fixtures* construisaient une session « en train de mimoquer » **sans second facteur frais**, ce qui ne modélise plus un mimoquage effectif.

Aucune assertion n'a été supprimée, relâchée, ni marquée `.skip`. Les fixtures ont gagné un `adminMfaAt` frais, et les assertions d'origine sont reparties au vert telles quelles.

Une seule assertion a changé de forme, dans `config.test.ts` : `expect(mockUpdate).not.toHaveBeenCalled()` devient `expect(userTableUpdates()).toHaveLength(0)`. La connexion émet désormais légitimement un UPDATE sur une *autre* table ; ces tests portent sur l'amorçage du nom, donc restreindre le compte aux UPDATE visant `users` **préserve leur intention** et les rend plus précis, au lieu de les affaiblir.

## Portée

Au-delà des fichiers listés au ticket, la réparation a touché des fixtures de test partagées que le changement de comportement cassait (`representationDeclarationHarness.ts`, `helpers/declarationTestHelpers.ts`, `company.test.ts`, `cseOpinion*.test.ts`, `representationDeclaration.get.test.ts`, `WithBannerLayout.test.tsx`, `adminMfaMarker.test.ts`, `config.test.ts`). Laisser la suite rouge n'était pas une option ; aucune de ces retouches ne change une assertion de fond.

## Captures

Sans objet : aucun composant d'interface n'est modifié (seuls des fichiers de test `.tsx` figurent au diff). Le bandeau n'est pas redessiné — le ticket porte « Référence Figma : N/A ».

