### PR TITLE
feat(auth): #4465 — portes d'entrée du step-up admin (menu + /login)

### DIFF
--- a/packages/app/src/app/login/page.tsx
+++ b/packages/app/src/app/login/page.tsx
@@ -1,22 +1,44 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
+import {
+	AdminAccessPage,
+	sanitizeAdminReturnPath,
+} from "~/modules/admin/access";
+import { resolveAdminAccess } from "~/modules/domain";
 import { LoginPage, sanitizeCallbackUrl } from "~/modules/login";
 import { auth } from "~/server/auth";
 
 export const metadata: Metadata = { title: "Connexion" };
 
 type PageProps = {
-	searchParams: Promise<{ callbackUrl?: string }>;
+	searchParams: Promise<{ callbackUrl?: string; error?: string }>;
 };
 
 export default async function Page({ searchParams }: PageProps) {
-	const { callbackUrl } = await searchParams;
+	const { callbackUrl, error } = await searchParams;
 	const safeCallbackUrl = sanitizeCallbackUrl(callbackUrl);
 
 	const session = await auth();
 
 	if (session?.user) {
+		// A step-up abandoned or refused by ProConnect lands back here, still
+		// signed in under the session that was open before the attempt — the
+		// declarant journey is never closed nor degraded by the failure. Only
+		// the admin second-factor state can be stale, so the same decision
+		// table the resume screen and the `/admin` guard run is the one that
+		// tells us whether to explain the failure instead of the usual bounce.
+		if (error) {
+			const decision = resolveAdminAccess(session.user, new Date());
+			if (decision.type === "resume") {
+				return (
+					<AdminAccessPage
+						reason={decision.reason}
+						returnPath={sanitizeAdminReturnPath(safeCallbackUrl)}
+					/>
+				);
+			}
+		}
 		redirect(safeCallbackUrl ?? "/mon-espace");
 	}
 

--- a/packages/app/src/modules/admin/access/AdminAccessResumeButton.tsx
+++ b/packages/app/src/modules/admin/access/AdminAccessResumeButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { signIn } from "next-auth/react";
+import { triggerAdminStepUp } from "./adminStepUp";
 
 type Props = {
 	returnPath: string;
@@ -11,9 +11,7 @@ export function AdminAccessResumeButton({ returnPath }: Props) {
 	return (
 		<button
 			className="fr-btn"
-			onClick={() => {
-				void signIn("proconnect", { callbackUrl: returnPath });
-			}}
+			onClick={() => triggerAdminStepUp(returnPath)}
 			type="button"
 		>
 			Refaire la double authentification

--- a/packages/app/src/modules/admin/access/__tests__/AdminAccessPage.test.tsx
+++ b/packages/app/src/modules/admin/access/__tests__/AdminAccessPage.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import { signIn } from "next-auth/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
 import { AdminAccessPage } from "../AdminAccessPage";
 
 const mockSignIn = vi.mocked(signIn);
@@ -96,7 +95,7 @@ describe("AdminAccessPage", () => {
 		expect(mockSignIn).toHaveBeenCalledWith(
 			"proconnect",
 			expect.anything(),
-			buildAdminStepUpAuthorizationParams(),
+			expect.objectContaining({ claims: expect.any(String) }),
 		);
 	});
 });

--- a/packages/app/src/modules/admin/access/__tests__/AdminAccessPage.test.tsx
+++ b/packages/app/src/modules/admin/access/__tests__/AdminAccessPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { signIn } from "next-auth/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
 import { AdminAccessPage } from "../AdminAccessPage";
 
 const mockSignIn = vi.mocked(signIn);
@@ -74,8 +75,28 @@ describe("AdminAccessPage", () => {
 			}),
 		);
 
-		expect(mockSignIn).toHaveBeenCalledWith("proconnect", {
-			callbackUrl: "/admin/declarations/abc",
-		});
+		expect(mockSignIn).toHaveBeenCalledWith(
+			"proconnect",
+			{ callbackUrl: "/admin/declarations/abc" },
+			expect.anything(),
+		);
+	});
+
+	it("resumes through the same step-up entry point as the menu and the login button", async () => {
+		// One path, not three: the resume action must carry the admin step-up
+		// authorization params, exactly like the menu entry and the login button.
+		render(<AdminAccessPage reason="missing" returnPath="/admin" />);
+
+		await userEvent.click(
+			screen.getByRole("button", {
+				name: "Refaire la double authentification",
+			}),
+		);
+
+		expect(mockSignIn).toHaveBeenCalledWith(
+			"proconnect",
+			expect.anything(),
+			buildAdminStepUpAuthorizationParams(),
+		);
 	});
 });

--- a/packages/app/src/modules/admin/access/__tests__/adminReturnPath.test.ts
+++ b/packages/app/src/modules/admin/access/__tests__/adminReturnPath.test.ts
@@ -72,6 +72,12 @@ describe("isAdminReturnPath", () => {
 		expect(isAdminReturnPath("/admin#contenu")).toBe(true);
 	});
 
+	it("recognizes a backoffice destination reached through dot segments", () => {
+		// Same normalization as sanitizeAdminReturnPath: a caller testing the
+		// raw, not-yet-resolved string must see this as backoffice-bound too.
+		expect(isAdminReturnPath("/mon-espace/../admin")).toBe(true);
+	});
+
 	it.each([
 		["an empty string", ""],
 		["a path outside the backoffice", "/mon-espace"],
@@ -79,6 +85,11 @@ describe("isAdminReturnPath", () => {
 		// `/administration` merely shares a prefix with `/admin`: the comparison
 		// is segment-aware, so this must not be mistaken for a backoffice path.
 		["a path that only shares the prefix", "/administration/secret"],
+		["dot segments escaping the backoffice", "/admin/../mon-espace"],
+		["a relative path", "admin/declarations"],
+		["an absolute URL", "https://evil.example/admin"],
+		["a protocol-relative URL", "//evil.example/admin"],
+		["a backslash authority", "/\\evil.example/admin"],
 	])("does not recognize %s", (_label, value) => {
 		expect(isAdminReturnPath(value)).toBe(false);
 	});

--- a/packages/app/src/modules/admin/access/__tests__/adminReturnPath.test.ts
+++ b/packages/app/src/modules/admin/access/__tests__/adminReturnPath.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { ADMIN_HOME_PATH, sanitizeAdminReturnPath } from "../adminReturnPath";
+import {
+	ADMIN_HOME_PATH,
+	isAdminReturnPath,
+	sanitizeAdminReturnPath,
+} from "../adminReturnPath";
 
 describe("sanitizeAdminReturnPath", () => {
 	it("keeps a backoffice deep link", () => {
@@ -48,5 +52,34 @@ describe("sanitizeAdminReturnPath", () => {
 		["malformed percent-encoding", "/admin/%E0%A4%A"],
 	])("falls back to the backoffice home for %s", (_label, value) => {
 		expect(sanitizeAdminReturnPath(value)).toBe(ADMIN_HOME_PATH);
+	});
+});
+
+describe("isAdminReturnPath", () => {
+	it("recognizes the backoffice home", () => {
+		expect(isAdminReturnPath(ADMIN_HOME_PATH)).toBe(true);
+	});
+
+	it("recognizes a backoffice deep link", () => {
+		expect(isAdminReturnPath("/admin/declarations/abc")).toBe(true);
+	});
+
+	it("recognizes a backoffice path with a query string", () => {
+		expect(isAdminReturnPath("/admin?onglet=historique")).toBe(true);
+	});
+
+	it("recognizes a backoffice path with a fragment", () => {
+		expect(isAdminReturnPath("/admin#contenu")).toBe(true);
+	});
+
+	it.each([
+		["an empty string", ""],
+		["a path outside the backoffice", "/mon-espace"],
+		["the site root", "/"],
+		// `/administration` merely shares a prefix with `/admin`: the comparison
+		// is segment-aware, so this must not be mistaken for a backoffice path.
+		["a path that only shares the prefix", "/administration/secret"],
+	])("does not recognize %s", (_label, value) => {
+		expect(isAdminReturnPath(value)).toBe(false);
 	});
 });

--- a/packages/app/src/modules/admin/access/__tests__/adminStepUp.test.ts
+++ b/packages/app/src/modules/admin/access/__tests__/adminStepUp.test.ts
@@ -1,0 +1,44 @@
+import { signIn } from "next-auth/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
+import { triggerAdminStepUp } from "../adminStepUp";
+
+const mockSignIn = vi.mocked(signIn);
+
+describe("triggerAdminStepUp", () => {
+	beforeEach(() => {
+		mockSignIn.mockClear();
+	});
+
+	it("signs in through the proconnect provider", () => {
+		triggerAdminStepUp("/admin");
+
+		expect(mockSignIn).toHaveBeenCalledWith(
+			"proconnect",
+			expect.anything(),
+			expect.anything(),
+		);
+		expect(mockSignIn.mock.calls[0]?.[0]).toBe("proconnect");
+	});
+
+	it("carries the requested return path as the callback URL", () => {
+		triggerAdminStepUp("/admin/declarations/abc");
+
+		expect(mockSignIn).toHaveBeenCalledWith(
+			"proconnect",
+			{ callbackUrl: "/admin/declarations/abc" },
+			expect.anything(),
+		);
+	});
+
+	it("attaches the admin step-up authorization params, unmodified", () => {
+		triggerAdminStepUp("/admin");
+
+		expect(mockSignIn).toHaveBeenCalledWith(
+			"proconnect",
+			expect.anything(),
+			buildAdminStepUpAuthorizationParams(),
+		);
+	});
+});

--- a/packages/app/src/modules/admin/access/__tests__/adminStepUp.test.ts
+++ b/packages/app/src/modules/admin/access/__tests__/adminStepUp.test.ts
@@ -1,10 +1,33 @@
 import { signIn } from "next-auth/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
+import {
+	ADMIN_MFA_ACR_VALUES,
+	ADMIN_MFA_WINDOW_SECONDS,
+} from "~/modules/domain";
 import { triggerAdminStepUp } from "../adminStepUp";
 
 const mockSignIn = vi.mocked(signIn);
+
+type AuthorizationParams = { claims: string; max_age: string };
+
+function authorizationParamsFromCall(): AuthorizationParams {
+	const params = mockSignIn.mock.calls[0]?.[2] as
+		| AuthorizationParams
+		| undefined;
+	if (!params)
+		throw new Error("signIn was not called with authorization params");
+	return params;
+}
+
+function parsedClaims() {
+	return JSON.parse(authorizationParamsFromCall().claims) as {
+		id_token: {
+			acr: { essential: boolean; value: string };
+			auth_time: { essential: boolean };
+		};
+	};
+}
 
 describe("triggerAdminStepUp", () => {
 	beforeEach(() => {
@@ -14,11 +37,6 @@ describe("triggerAdminStepUp", () => {
 	it("signs in through the proconnect provider", () => {
 		triggerAdminStepUp("/admin");
 
-		expect(mockSignIn).toHaveBeenCalledWith(
-			"proconnect",
-			expect.anything(),
-			expect.anything(),
-		);
 		expect(mockSignIn.mock.calls[0]?.[0]).toBe("proconnect");
 	});
 
@@ -32,13 +50,53 @@ describe("triggerAdminStepUp", () => {
 		);
 	});
 
-	it("attaches the admin step-up authorization params, unmodified", () => {
+	it("demands a second factor, not a higher eIDAS level", () => {
 		triggerAdminStepUp("/admin");
 
-		expect(mockSignIn).toHaveBeenCalledWith(
-			"proconnect",
-			expect.anything(),
-			buildAdminStepUpAuthorizationParams(),
+		expect(ADMIN_MFA_ACR_VALUES[0]).toBe("eidas1-mfa");
+		expect(parsedClaims().id_token.acr.value).toBe(ADMIN_MFA_ACR_VALUES[0]);
+	});
+
+	it("makes the level binding via an essential claim", () => {
+		triggerAdminStepUp("/admin");
+
+		expect(parsedClaims().id_token.acr.essential).toBe(true);
+	});
+
+	it("requests auth_time as essential so the window is computable", () => {
+		triggerAdminStepUp("/admin");
+
+		expect(parsedClaims().id_token.auth_time).toEqual({ essential: true });
+	});
+
+	it("caps the accepted session age at the backoffice window", () => {
+		triggerAdminStepUp("/admin");
+
+		expect(authorizationParamsFromCall().max_age).toBe(
+			String(ADMIN_MFA_WINDOW_SECONDS),
 		);
+	});
+
+	it("never falls back to acr_values, which an issuer may ignore", () => {
+		triggerAdminStepUp("/admin");
+
+		expect(authorizationParamsFromCall()).not.toHaveProperty("acr_values");
+	});
+
+	it("hands every authorization param as a string, as the query expects", () => {
+		triggerAdminStepUp("/admin");
+
+		for (const value of Object.values(authorizationParamsFromCall())) {
+			expect(typeof value).toBe("string");
+		}
+	});
+
+	it("carries claims and max_age, and nothing else", () => {
+		triggerAdminStepUp("/admin");
+
+		expect(Object.keys(authorizationParamsFromCall()).sort()).toEqual([
+			"claims",
+			"max_age",
+		]);
 	});
 });

--- a/packages/app/src/modules/admin/access/adminReturnPath.ts
+++ b/packages/app/src/modules/admin/access/adminReturnPath.ts
@@ -17,7 +17,18 @@ export function sanitizeAdminReturnPath(value?: string): string {
 	const normalized = `${resolved.pathname}${resolved.search}${resolved.hash}`;
 
 	// Without this confinement the resume screen becomes a redirector towards any page of the site.
-	if (!BACKOFFICE_PATH.test(normalized)) return ADMIN_HOME_PATH;
+	if (!isAdminReturnPath(normalized)) return ADMIN_HOME_PATH;
 
 	return normalized;
+}
+
+/**
+ * True when `value` already targets the backoffice — used by the login form
+ * to decide whether the ProConnect request it is about to send must carry
+ * the admin step-up requirement. Segment-aware, same rule as
+ * {@link sanitizeAdminReturnPath}: `/administration` merely shares a prefix
+ * with `/admin` and must not match.
+ */
+export function isAdminReturnPath(value: string): boolean {
+	return BACKOFFICE_PATH.test(value);
 }

--- a/packages/app/src/modules/admin/access/adminReturnPath.ts
+++ b/packages/app/src/modules/admin/access/adminReturnPath.ts
@@ -8,22 +8,38 @@ const BACKOFFICE_PATH = new RegExp(`^${ADMIN_HOME_PATH}([/?#]|$)`);
 // Dummy base, as in the callback sanitizer: nothing of it reaches the result.
 const RESOLUTION_ORIGIN = "https://internal.invalid";
 
+// Shared by both exports below so a traversal segment resolves the same way
+// for whichever one is asked: `/mon-espace/../admin` must not test as
+// backoffice-bound for `sanitizeAdminReturnPath` while testing as such (or
+// the reverse) for `isAdminReturnPath` — one normalization, not two.
+function resolveSameOriginPath(value: string): string | undefined {
+	if (!value.startsWith("/")) return undefined;
+	try {
+		const resolved = new URL(value, RESOLUTION_ORIGIN);
+		if (resolved.origin !== RESOLUTION_ORIGIN) return undefined;
+		return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+	} catch {
+		return undefined;
+	}
+}
+
 export function sanitizeAdminReturnPath(value?: string): string {
 	const safe = sanitizeCallbackUrl(value);
 	if (!safe) return ADMIN_HOME_PATH;
 
-	// `/admin/../mon-espace` opens with `/admin` as a string, yet every consumer collapses it to `/mon-espace` before requesting it.
-	const resolved = new URL(safe, RESOLUTION_ORIGIN);
-	const normalized = `${resolved.pathname}${resolved.search}${resolved.hash}`;
+	const normalized = resolveSameOriginPath(safe);
 
 	// Without this confinement the resume screen becomes a redirector towards any page of the site.
-	if (!isAdminReturnPath(normalized)) return ADMIN_HOME_PATH;
+	if (!normalized || !isAdminReturnPath(normalized)) return ADMIN_HOME_PATH;
 
 	return normalized;
 }
 
-// Used by the login form to decide whether its ProConnect request must
-// carry the step-up requirement. Same segment-aware rule as sanitizeAdminReturnPath.
+// Used by the login form to decide whether its ProConnect request must carry
+// the step-up requirement, on a value that has not been through
+// `sanitizeAdminReturnPath` — so it normalizes traversal itself rather than
+// trusting the caller's raw string.
 export function isAdminReturnPath(value: string): boolean {
-	return BACKOFFICE_PATH.test(value);
+	const normalized = resolveSameOriginPath(value);
+	return normalized !== undefined && BACKOFFICE_PATH.test(normalized);
 }

--- a/packages/app/src/modules/admin/access/adminReturnPath.ts
+++ b/packages/app/src/modules/admin/access/adminReturnPath.ts
@@ -22,13 +22,8 @@ export function sanitizeAdminReturnPath(value?: string): string {
 	return normalized;
 }
 
-/**
- * True when `value` already targets the backoffice — used by the login form
- * to decide whether the ProConnect request it is about to send must carry
- * the admin step-up requirement. Segment-aware, same rule as
- * {@link sanitizeAdminReturnPath}: `/administration` merely shares a prefix
- * with `/admin` and must not match.
- */
+// Used by the login form to decide whether its ProConnect request must
+// carry the step-up requirement. Same segment-aware rule as sanitizeAdminReturnPath.
 export function isAdminReturnPath(value: string): boolean {
 	return BACKOFFICE_PATH.test(value);
 }

--- a/packages/app/src/modules/admin/access/adminStepUp.ts
+++ b/packages/app/src/modules/admin/access/adminStepUp.ts
@@ -1,0 +1,29 @@
+import { signIn } from "next-auth/react";
+
+import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
+
+/**
+ * Single entry point for every admin step-up sign-in: the "Administration"
+ * menu entry (when the session's admin MFA is not fresh), the resume screen
+ * at `/acces-backoffice`, and the login button when the validated
+ * destination targets the backoffice. One path rather than three copies of
+ * the same authorization params — three chances to drop one.
+ *
+ * `buildAdminStepUpAuthorizationParams` lives under `~/server/auth` but is
+ * imported here, into code that reaches the browser: it is a pure,
+ * deterministic function with no secret and no side effect — it only shapes
+ * the `claims`/`max_age` query the browser sends to ProConnect. Attaching it
+ * from the client is not itself a security control: a browser that omitted
+ * it would simply sign in without the marker, and the server-side gates
+ * (`resolveAdminAccess`, the `/admin` middleware, the admin tRPC procedures)
+ * refuse that exactly as they refuse any other stale or missing second
+ * factor. This only cuts the number of ProConnect round-trips for an agent
+ * who already holds the grant.
+ */
+export function triggerAdminStepUp(returnPath: string): void {
+	void signIn(
+		"proconnect",
+		{ callbackUrl: returnPath },
+		buildAdminStepUpAuthorizationParams(),
+	);
+}

--- a/packages/app/src/modules/admin/access/adminStepUp.ts
+++ b/packages/app/src/modules/admin/access/adminStepUp.ts
@@ -9,35 +9,24 @@ import {
 // factor — so demanding it never raises the declarant journey's identity level.
 const ADMIN_STEP_UP_ACR = ADMIN_MFA_ACR_VALUES[0];
 
-/**
- * Single entry point for every admin step-up sign-in: the "Administration"
- * menu entry (when the session's admin MFA is not fresh), the resume screen
- * at `/acces-backoffice`, and the login button when the validated
- * destination targets the backoffice. One path rather than three copies of
- * the same authorization params — three chances to drop one.
- */
+// Single entry point for every admin step-up sign-in (menu, resume screen,
+// login button) — one path rather than three copies of the same params.
+// Attaching them client-side is not a security control: the server gates
+// (resolveAdminAccess, the /admin middleware, the admin tRPC procedures)
+// refuse a stale or missing second factor regardless.
 export function triggerAdminStepUp(returnPath: string): void {
 	void signIn(
 		"proconnect",
 		{ callbackUrl: returnPath },
 		{
-			// `claims` rather than `acr_values`: in OIDC `acr_values` is a
-			// voluntary preference an issuer may silently ignore, an essential
-			// claim is binding.
+			// `claims`, not `acr_values`: an essential claim is binding, a voluntary preference is not.
 			claims: JSON.stringify({
 				id_token: {
 					acr: { essential: true, value: ADMIN_STEP_UP_ACR },
 					auth_time: { essential: true },
 				},
 			}),
-			// Without it an issuer replaying an already open session answers with
-			// an old `auth_time` that the freshness rule refuses, looping the
-			// agent between the resume screen and ProConnect. Attaching this from
-			// the client is not a security control: a browser that omitted it
-			// would simply sign in without the marker, and the server-side gates
-			// (`resolveAdminAccess`, the `/admin` middleware, the admin tRPC
-			// procedures) refuse that exactly as they refuse any other stale or
-			// missing second factor.
+			// Bounds the accepted auth_time to the backoffice freshness window.
 			max_age: String(ADMIN_MFA_WINDOW_SECONDS),
 		},
 	);

--- a/packages/app/src/modules/admin/access/adminStepUp.ts
+++ b/packages/app/src/modules/admin/access/adminStepUp.ts
@@ -1,6 +1,13 @@
 import { signIn } from "next-auth/react";
 
-import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
+import {
+	ADMIN_MFA_ACR_VALUES,
+	ADMIN_MFA_WINDOW_SECONDS,
+} from "~/modules/domain";
+
+// Orthogonal to the eIDAS scale — `eidas1-mfa` is eIDAS 1 *plus* a second
+// factor — so demanding it never raises the declarant journey's identity level.
+const ADMIN_STEP_UP_ACR = ADMIN_MFA_ACR_VALUES[0];
 
 /**
  * Single entry point for every admin step-up sign-in: the "Administration"
@@ -8,22 +15,30 @@ import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams"
  * at `/acces-backoffice`, and the login button when the validated
  * destination targets the backoffice. One path rather than three copies of
  * the same authorization params — three chances to drop one.
- *
- * `buildAdminStepUpAuthorizationParams` lives under `~/server/auth` but is
- * imported here, into code that reaches the browser: it is a pure,
- * deterministic function with no secret and no side effect — it only shapes
- * the `claims`/`max_age` query the browser sends to ProConnect. Attaching it
- * from the client is not itself a security control: a browser that omitted
- * it would simply sign in without the marker, and the server-side gates
- * (`resolveAdminAccess`, the `/admin` middleware, the admin tRPC procedures)
- * refuse that exactly as they refuse any other stale or missing second
- * factor. This only cuts the number of ProConnect round-trips for an agent
- * who already holds the grant.
  */
 export function triggerAdminStepUp(returnPath: string): void {
 	void signIn(
 		"proconnect",
 		{ callbackUrl: returnPath },
-		buildAdminStepUpAuthorizationParams(),
+		{
+			// `claims` rather than `acr_values`: in OIDC `acr_values` is a
+			// voluntary preference an issuer may silently ignore, an essential
+			// claim is binding.
+			claims: JSON.stringify({
+				id_token: {
+					acr: { essential: true, value: ADMIN_STEP_UP_ACR },
+					auth_time: { essential: true },
+				},
+			}),
+			// Without it an issuer replaying an already open session answers with
+			// an old `auth_time` that the freshness rule refuses, looping the
+			// agent between the resume screen and ProConnect. Attaching this from
+			// the client is not a security control: a browser that omitted it
+			// would simply sign in without the marker, and the server-side gates
+			// (`resolveAdminAccess`, the `/admin` middleware, the admin tRPC
+			// procedures) refuse that exactly as they refuse any other stale or
+			// missing second factor.
+			max_age: String(ADMIN_MFA_WINDOW_SECONDS),
+		},
 	);
 }

--- a/packages/app/src/modules/admin/access/index.ts
+++ b/packages/app/src/modules/admin/access/index.ts
@@ -1,2 +1,7 @@
 export { AdminAccessPage } from "./AdminAccessPage";
-export { ADMIN_HOME_PATH, sanitizeAdminReturnPath } from "./adminReturnPath";
+export {
+	ADMIN_HOME_PATH,
+	isAdminReturnPath,
+	sanitizeAdminReturnPath,
+} from "./adminReturnPath";
+export { triggerAdminStepUp } from "./adminStepUp";

--- a/packages/app/src/modules/layout/Header/HeaderQuickAccessLinks.tsx
+++ b/packages/app/src/modules/layout/Header/HeaderQuickAccessLinks.tsx
@@ -34,6 +34,7 @@ export function HeaderQuickAccessLinks({ session, userPhone }: Props) {
 			<li>
 				{session?.user ? (
 					<UserAccountMenu
+						adminMfaAt={session.user.adminMfaAt}
 						isAdmin={session.user.isAdmin}
 						userEmail={session.user.email ?? ""}
 						userName={session.user.name ?? "Utilisateur"}

--- a/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
+++ b/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	type MouseEvent as ReactMouseEvent,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 
+import { ADMIN_HOME_PATH, triggerAdminStepUp } from "~/modules/admin/access";
+import { isAdminMfaFresh } from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import styles from "./UserAccountMenu.module.scss";
 
@@ -11,6 +19,7 @@ interface UserAccountMenuProps {
 	userEmail: string;
 	userPhone?: string;
 	isAdmin?: boolean;
+	adminMfaAt?: number | null;
 }
 
 /** Dropdown menu in the header for authenticated users. */
@@ -19,6 +28,7 @@ export function UserAccountMenu({
 	userEmail,
 	userPhone,
 	isAdmin,
+	adminMfaAt,
 }: UserAccountMenuProps) {
 	const [isOpen, setIsOpen] = useState(false);
 	const wrapperRef = useRef<HTMLDivElement>(null);
@@ -35,6 +45,20 @@ export function UserAccountMenu({
 		const modal = document.getElementById("profile-modal");
 		if (modal) getDsfrModal(modal)?.disclose();
 	}, [close]);
+
+	// No intermediate Egapro screen on this door: a stale or missing second
+	// factor triggers ProConnect directly from the click, through the same
+	// step-up entry point as the resume screen and the login button. A fresh
+	// one lets the link navigate to `/admin` as-is — no ProConnect passage.
+	const handleAdminClick = useCallback(
+		(event: ReactMouseEvent<HTMLAnchorElement>) => {
+			close();
+			if (isAdminMfaFresh(adminMfaAt, new Date())) return;
+			event.preventDefault();
+			triggerAdminStepUp(ADMIN_HOME_PATH);
+		},
+		[adminMfaAt, close],
+	);
 
 	const getMenuItems = useCallback(
 		() =>
@@ -145,8 +169,8 @@ export function UserAccountMenu({
 							{isAdmin && (
 								<Link
 									className={styles.menuLink}
-									href="/admin"
-									onClick={close}
+									href={ADMIN_HOME_PATH}
+									onClick={handleAdminClick}
 									role="menuitem"
 									tabIndex={-1}
 								>

--- a/packages/app/src/modules/layout/Header/__tests__/HeaderQuickAccessLinks.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/HeaderQuickAccessLinks.test.tsx
@@ -1,8 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { Session } from "next-auth";
-import { describe, expect, it } from "vitest";
+import { signIn } from "next-auth/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HeaderQuickAccessLinks } from "../HeaderQuickAccessLinks";
+
+const mockSignIn = vi.mocked(signIn);
 
 const buildSession = (overrides: Partial<Session["user"]> = {}): Session => ({
 	expires: "2099-01-01T00:00:00.000Z",
@@ -15,6 +18,10 @@ const buildSession = (overrides: Partial<Session["user"]> = {}): Session => ({
 });
 
 describe("HeaderQuickAccessLinks", () => {
+	beforeEach(() => {
+		mockSignIn.mockClear();
+	});
+
 	it("renders the help link and login button when no session", () => {
 		render(<HeaderQuickAccessLinks session={null} />);
 
@@ -34,5 +41,24 @@ describe("HeaderQuickAccessLinks", () => {
 		expect(
 			screen.getByRole("button", { name: "Mon espace" }),
 		).toBeInTheDocument();
+	});
+
+	it("carries the session's admin MFA freshness through to the menu's Administration entry", () => {
+		render(
+			<HeaderQuickAccessLinks
+				session={buildSession({ isAdmin: true, adminMfaAt: null })}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+		fireEvent.click(screen.getByRole("menuitem", { name: "Administration" }));
+
+		// No date at all in the session is exactly the "missing" case the menu
+		// must catch before it lets the click reach `/admin`.
+		expect(mockSignIn).toHaveBeenCalledWith(
+			"proconnect",
+			{ callbackUrl: "/admin" },
+			expect.anything(),
+		);
 	});
 });

--- a/packages/app/src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx
@@ -3,7 +3,6 @@ import { signIn } from "next-auth/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
-import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
 import { UserAccountMenu } from "../UserAccountMenu";
 
 const mockSignIn = vi.mocked(signIn);
@@ -251,7 +250,7 @@ describe("UserAccountMenu", () => {
 			expect(mockSignIn).toHaveBeenCalledWith(
 				"proconnect",
 				{ callbackUrl: "/admin" },
-				buildAdminStepUpAuthorizationParams(),
+				expect.objectContaining({ claims: expect.any(String) }),
 			);
 		});
 
@@ -263,7 +262,7 @@ describe("UserAccountMenu", () => {
 			expect(mockSignIn).toHaveBeenCalledWith(
 				"proconnect",
 				{ callbackUrl: "/admin" },
-				buildAdminStepUpAuthorizationParams(),
+				expect.objectContaining({ claims: expect.any(String) }),
 			);
 		});
 

--- a/packages/app/src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx
@@ -1,14 +1,27 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { signIn } from "next-auth/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
+import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
 import { UserAccountMenu } from "../UserAccountMenu";
+
+const mockSignIn = vi.mocked(signIn);
 
 const defaultProps = {
 	userName: "Jean Dupont",
 	userEmail: "jean.dupont@example.fr",
 };
 
+function nowSeconds(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
 describe("UserAccountMenu", () => {
+	beforeEach(() => {
+		mockSignIn.mockClear();
+	});
+
 	it("renders the toggle button with 'Mon espace' label", () => {
 		render(<UserAccountMenu {...defaultProps} />);
 		expect(
@@ -206,6 +219,62 @@ describe("UserAccountMenu", () => {
 			});
 			expect(adminLink).toBeInTheDocument();
 			expect(adminLink).toHaveAttribute("href", "/admin");
+		});
+
+		it("lets the click navigate to /admin without ProConnect when the admin MFA is fresh", () => {
+			render(
+				<UserAccountMenu {...defaultProps} adminMfaAt={nowSeconds()} isAdmin />,
+			);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			const event = fireEvent.click(
+				screen.getByRole("menuitem", { name: "Administration" }),
+			);
+
+			expect(event).toBe(true); // not prevented — the link is followed
+			expect(mockSignIn).not.toHaveBeenCalled();
+		});
+
+		it("triggers the admin step-up directly, with no intermediate screen, when the admin MFA is stale", () => {
+			render(
+				<UserAccountMenu
+					{...defaultProps}
+					adminMfaAt={nowSeconds() - ADMIN_MFA_WINDOW_SECONDS - 1}
+					isAdmin
+				/>,
+			);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			const event = fireEvent.click(
+				screen.getByRole("menuitem", { name: "Administration" }),
+			);
+
+			expect(event).toBe(false); // navigation prevented
+			expect(mockSignIn).toHaveBeenCalledWith(
+				"proconnect",
+				{ callbackUrl: "/admin" },
+				buildAdminStepUpAuthorizationParams(),
+			);
+		});
+
+		it("triggers the admin step-up when the session carries no admin MFA date at all", () => {
+			render(<UserAccountMenu {...defaultProps} isAdmin />);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			fireEvent.click(screen.getByRole("menuitem", { name: "Administration" }));
+
+			expect(mockSignIn).toHaveBeenCalledWith(
+				"proconnect",
+				{ callbackUrl: "/admin" },
+				buildAdminStepUpAuthorizationParams(),
+			);
+		});
+
+		it("closes the dropdown when the admin entry is clicked, fresh or not", () => {
+			render(
+				<UserAccountMenu {...defaultProps} adminMfaAt={nowSeconds()} isAdmin />,
+			);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			fireEvent.click(screen.getByRole("menuitem", { name: "Administration" }));
+
+			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 		});
 	});
 

--- a/packages/app/src/modules/login/LoginForm.tsx
+++ b/packages/app/src/modules/login/LoginForm.tsx
@@ -1,3 +1,5 @@
+import { isAdminReturnPath } from "~/modules/admin/access";
+
 import { LoginAccordion } from "./LoginAccordion";
 import styles from "./LoginForm.module.scss";
 import { ProConnectButton } from "./ProConnectButton";
@@ -14,6 +16,12 @@ type Props = {
  * - 24px (1.5rem) between title, description, and button within the group
  */
 export function LoginForm({ callbackUrl }: Props) {
+	// `callbackUrl` reaches this component already validated by the page
+	// (`sanitizeCallbackUrl`): safe to test as-is against the backoffice
+	// prefix. Any other destination leaves the ProConnect request unchanged —
+	// that is the rule the epic does not negotiate.
+	const requiresAdminStepUp = isAdminReturnPath(callbackUrl ?? "");
+
 	return (
 		<div className={styles.form}>
 			<div className={styles.content}>
@@ -23,7 +31,10 @@ export function LoginForm({ callbackUrl }: Props) {
 					sécurisée ProConnect et votre e-mail professionnel (contact utilisé en
 					cas de contrôle).
 				</p>
-				<ProConnectButton callbackUrl={callbackUrl} />
+				<ProConnectButton
+					callbackUrl={callbackUrl}
+					requiresAdminStepUp={requiresAdminStepUp}
+				/>
 			</div>
 			<LoginAccordion />
 		</div>

--- a/packages/app/src/modules/login/ProConnectButton.tsx
+++ b/packages/app/src/modules/login/ProConnectButton.tsx
@@ -2,6 +2,7 @@
 
 import { signIn } from "next-auth/react";
 
+import { triggerAdminStepUp } from "~/modules/admin/access";
 import {
 	MATOMO_ACTION,
 	MATOMO_EVENT_CATEGORY,
@@ -13,16 +14,26 @@ import styles from "./ProConnectButton.module.scss";
 
 type Props = {
 	callbackUrl?: string;
+	// Set by the login form when the validated destination targets the
+	// backoffice: the request must then carry the admin step-up requirement
+	// from this very first sign-in, so an eligible agent never has to pass
+	// through ProConnect a second time on the resume screen.
+	requiresAdminStepUp?: boolean;
 };
 
 /** ProConnect authentication button with official branding and info link. */
-export function ProConnectButton({ callbackUrl }: Props) {
+export function ProConnectButton({ callbackUrl, requiresAdminStepUp }: Props) {
 	function handleLogin(): void {
 		trackEvent({
 			category: MATOMO_EVENT_CATEGORY.AUTH,
 			action: MATOMO_ACTION.LOGIN_START,
 		});
-		void signIn("proconnect", { callbackUrl: callbackUrl ?? "/mon-espace" });
+		const resolvedCallbackUrl = callbackUrl ?? "/mon-espace";
+		if (requiresAdminStepUp) {
+			triggerAdminStepUp(resolvedCallbackUrl);
+			return;
+		}
+		void signIn("proconnect", { callbackUrl: resolvedCallbackUrl });
 	}
 
 	return (

--- a/packages/app/src/modules/login/__tests__/LoginForm.test.tsx
+++ b/packages/app/src/modules/login/__tests__/LoginForm.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { signIn } from "next-auth/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
 import { LoginForm } from "../LoginForm";
 
 const mockSignIn = vi.mocked(signIn);
@@ -56,7 +55,7 @@ describe("LoginForm", () => {
 		expect(mockSignIn).toHaveBeenCalledWith(
 			"proconnect",
 			{ callbackUrl: "/admin/declarations" },
-			buildAdminStepUpAuthorizationParams(),
+			expect.objectContaining({ claims: expect.any(String) }),
 		);
 	});
 

--- a/packages/app/src/modules/login/__tests__/LoginForm.test.tsx
+++ b/packages/app/src/modules/login/__tests__/LoginForm.test.tsx
@@ -1,8 +1,17 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { signIn } from "next-auth/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
 import { LoginForm } from "../LoginForm";
 
+const mockSignIn = vi.mocked(signIn);
+
 describe("LoginForm", () => {
+	beforeEach(() => {
+		mockSignIn.mockClear();
+	});
+
 	it("displays the login heading", () => {
 		render(<LoginForm />);
 		expect(
@@ -36,5 +45,51 @@ describe("LoginForm", () => {
 				name: /vous n'avez pas de compte/i,
 			}),
 		).toBeInTheDocument();
+	});
+
+	it("carries the admin step-up requirement when the destination targets the backoffice", () => {
+		render(<LoginForm callbackUrl="/admin/declarations" />);
+		screen
+			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+			.click();
+
+		expect(mockSignIn).toHaveBeenCalledWith(
+			"proconnect",
+			{ callbackUrl: "/admin/declarations" },
+			buildAdminStepUpAuthorizationParams(),
+		);
+	});
+
+	it("leaves the sign-in request unchanged for any other destination", () => {
+		render(<LoginForm callbackUrl="/mon-espace/mes-entreprises" />);
+		screen
+			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+			.click();
+
+		expect(mockSignIn).toHaveBeenCalledWith("proconnect", {
+			callbackUrl: "/mon-espace/mes-entreprises",
+		});
+	});
+
+	it("leaves the sign-in request unchanged when no destination is given", () => {
+		render(<LoginForm />);
+		screen
+			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+			.click();
+
+		expect(mockSignIn).toHaveBeenCalledWith("proconnect", {
+			callbackUrl: "/mon-espace",
+		});
+	});
+
+	it("does not mistake /administration for the backoffice", () => {
+		render(<LoginForm callbackUrl="/administration/secret" />);
+		screen
+			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+			.click();
+
+		expect(mockSignIn).toHaveBeenCalledWith("proconnect", {
+			callbackUrl: "/administration/secret",
+		});
 	});
 });

--- a/packages/app/src/modules/login/__tests__/LoginPage.test.tsx
+++ b/packages/app/src/modules/login/__tests__/LoginPage.test.tsx
@@ -51,13 +51,27 @@ describe("LoginPage", () => {
 	it("forwards callbackUrl through to ProConnect signIn", () => {
 		// Observable behavior of the prop drill LoginPage → LoginForm →
 		// ProConnectButton: the deepest call receives the propagated URL.
-		render(<LoginPage callbackUrl="/admin/users" />);
+		render(<LoginPage callbackUrl="/mon-espace/mes-entreprises" />);
 		screen
 			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
 			.click();
 		expect(signInMock).toHaveBeenCalledWith("proconnect", {
-			callbackUrl: "/admin/users",
+			callbackUrl: "/mon-espace/mes-entreprises",
 		});
+	});
+
+	it("carries the admin step-up requirement end-to-end for a backoffice destination", () => {
+		// Same prop drill, but LoginForm's isAdminReturnPath check now adds a
+		// third argument to the deepest call — the epic's whole point.
+		render(<LoginPage callbackUrl="/admin/users" />);
+		screen
+			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+			.click();
+		expect(signInMock).toHaveBeenCalledWith(
+			"proconnect",
+			{ callbackUrl: "/admin/users" },
+			expect.anything(),
+		);
 	});
 
 	it("falls back to /mon-espace when no callbackUrl is provided", () => {

--- a/packages/app/src/modules/login/__tests__/LoginRoutePage.test.tsx
+++ b/packages/app/src/modules/login/__tests__/LoginRoutePage.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen } from "@testing-library/react";
+import { signIn } from "next-auth/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRedirect, mockAuth } = vi.hoisted(() => ({
+	mockRedirect: vi.fn<(url: string) => never>().mockImplementation(() => {
+		throw new Error("NEXT_REDIRECT");
+	}),
+	mockAuth: vi.fn(),
+}));
+
+vi.mock("next/navigation", async (importOriginal) => ({
+	...(await importOriginal<Record<string, unknown>>()),
+	redirect: mockRedirect,
+}));
+
+vi.mock("~/server/auth", () => ({ auth: mockAuth }));
+
+import Page from "~/app/login/page";
+import { ADMIN_MFA_WINDOW_SECONDS } from "~/modules/domain";
+
+function nowSeconds(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+function renderPage(searchParams: { callbackUrl?: string; error?: string }) {
+	return Page({ searchParams: Promise.resolve(searchParams) });
+}
+
+const mockSignIn = vi.mocked(signIn);
+
+describe("login page — interrupted step-up (S10)", () => {
+	beforeEach(() => {
+		mockRedirect.mockClear();
+		mockAuth.mockReset();
+		mockSignIn.mockClear();
+	});
+
+	it("shows the login form to a visitor without a session, error param or not", async () => {
+		mockAuth.mockResolvedValue(null);
+
+		render(await renderPage({ error: "OAuthCallback" }));
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: /connectez-vous avec proconnect/i,
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("redirects a signed-in agent without an error param, as before", async () => {
+		mockAuth.mockResolvedValue({
+			user: { id: "u1", isAdmin: false },
+		});
+
+		await expect(renderPage({ callbackUrl: "/mon-espace" })).rejects.toThrow(
+			"NEXT_REDIRECT",
+		);
+		expect(mockRedirect).toHaveBeenCalledWith("/mon-espace");
+	});
+
+	it("falls back to /mon-espace for a signed-in agent with no callbackUrl at all", async () => {
+		mockAuth.mockResolvedValue({
+			user: { id: "u1", isAdmin: false },
+		});
+
+		await expect(renderPage({})).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith("/mon-espace");
+	});
+
+	it("explains the failed step-up to an agent still signed in, admin MFA missing", async () => {
+		mockAuth.mockResolvedValue({
+			user: { id: "u1", isAdmin: true },
+		});
+
+		render(await renderPage({ error: "OAuthCallback" }));
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: "La double authentification n'a pas abouti",
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("explains an expired step-up the same way", async () => {
+		mockAuth.mockResolvedValue({
+			user: {
+				id: "u1",
+				isAdmin: true,
+				adminMfaAt: nowSeconds() - ADMIN_MFA_WINDOW_SECONDS - 1,
+			},
+		});
+
+		render(await renderPage({ error: "OAuthCallback" }));
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: "Votre accès au backoffice a expiré",
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("keeps the declarant session usable: it is never closed nor degraded by the resume screen", async () => {
+		mockAuth.mockResolvedValue({
+			user: { id: "u1", isAdmin: true },
+		});
+
+		render(await renderPage({ error: "OAuthCallback" }));
+
+		expect(
+			screen.getByRole("link", { name: "Retourner à Mon espace" }),
+		).toHaveAttribute("href", "/mon-espace");
+	});
+
+	it("does not show the resume screen when the admin MFA is already fresh — nothing left to resume", async () => {
+		mockAuth.mockResolvedValue({
+			user: { id: "u1", isAdmin: true, adminMfaAt: nowSeconds() },
+		});
+
+		await expect(
+			renderPage({ callbackUrl: "/admin", error: "OAuthCallback" }),
+		).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith("/admin");
+	});
+
+	it("does not show the resume screen to a non-admin agent, error param or not", async () => {
+		mockAuth.mockResolvedValue({
+			user: { id: "u1", isAdmin: false },
+		});
+
+		await expect(
+			renderPage({ callbackUrl: "/mon-espace", error: "OAuthCallback" }),
+		).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith("/mon-espace");
+	});
+
+	it("confines the resume screen's return path to the backoffice", async () => {
+		// `callbackUrl` is attacker-controlled: the screen it falls through to
+		// must never become a redirector towards an arbitrary destination.
+		mockAuth.mockResolvedValue({
+			user: { id: "u1", isAdmin: true },
+		});
+
+		render(
+			await renderPage({
+				callbackUrl: "/mon-espace/mes-entreprises",
+				error: "OAuthCallback",
+			}),
+		);
+		screen
+			.getByRole("button", { name: "Refaire la double authentification" })
+			.click();
+
+		expect(mockSignIn).toHaveBeenCalledWith(
+			"proconnect",
+			{ callbackUrl: "/admin" },
+			expect.anything(),
+		);
+	});
+});

--- a/packages/app/src/modules/login/__tests__/ProConnectButton.test.tsx
+++ b/packages/app/src/modules/login/__tests__/ProConnectButton.test.tsx
@@ -17,7 +17,6 @@ vi.mock("~/modules/analytics", async (importOriginal) => {
 });
 
 import { MATOMO_ACTION, MATOMO_EVENT_CATEGORY } from "~/modules/analytics";
-import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
 import { ProConnectButton } from "../ProConnectButton";
 
 beforeEach(() => {
@@ -95,11 +94,14 @@ describe("ProConnectButton", () => {
 			expect(signInMock).toHaveBeenCalledWith(
 				"proconnect",
 				{ callbackUrl: "/admin" },
-				buildAdminStepUpAuthorizationParams(),
+				expect.objectContaining({ claims: expect.any(String) }),
 			);
 		});
 
-		it("falls back to the backoffice home when no callbackUrl is provided", () => {
+		it("falls back to /mon-espace even when requiresAdminStepUp is set", () => {
+			// ProConnectButton's own `callbackUrl ?? "/mon-espace"` default is
+			// independent of `requiresAdminStepUp` — it does not fall back to the
+			// backoffice home just because a step-up was requested.
 			render(<ProConnectButton requiresAdminStepUp />);
 			screen
 				.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
@@ -107,7 +109,7 @@ describe("ProConnectButton", () => {
 			expect(signInMock).toHaveBeenCalledWith(
 				"proconnect",
 				{ callbackUrl: "/mon-espace" },
-				buildAdminStepUpAuthorizationParams(),
+				expect.objectContaining({ claims: expect.any(String) }),
 			);
 		});
 

--- a/packages/app/src/modules/login/__tests__/ProConnectButton.test.tsx
+++ b/packages/app/src/modules/login/__tests__/ProConnectButton.test.tsx
@@ -17,6 +17,7 @@ vi.mock("~/modules/analytics", async (importOriginal) => {
 });
 
 import { MATOMO_ACTION, MATOMO_EVENT_CATEGORY } from "~/modules/analytics";
+import { buildAdminStepUpAuthorizationParams } from "~/server/auth/stepUpParams";
 import { ProConnectButton } from "../ProConnectButton";
 
 beforeEach(() => {
@@ -82,6 +83,58 @@ describe("ProConnectButton", () => {
 		expect(trackEventMock).toHaveBeenCalledWith({
 			category: MATOMO_EVENT_CATEGORY.AUTH,
 			action: MATOMO_ACTION.LOGIN_START,
+		});
+	});
+
+	describe("when requiresAdminStepUp is set", () => {
+		it("attaches the admin step-up authorization params to the sign-in request", () => {
+			render(<ProConnectButton callbackUrl="/admin" requiresAdminStepUp />);
+			screen
+				.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+				.click();
+			expect(signInMock).toHaveBeenCalledWith(
+				"proconnect",
+				{ callbackUrl: "/admin" },
+				buildAdminStepUpAuthorizationParams(),
+			);
+		});
+
+		it("falls back to the backoffice home when no callbackUrl is provided", () => {
+			render(<ProConnectButton requiresAdminStepUp />);
+			screen
+				.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+				.click();
+			expect(signInMock).toHaveBeenCalledWith(
+				"proconnect",
+				{ callbackUrl: "/mon-espace" },
+				buildAdminStepUpAuthorizationParams(),
+			);
+		});
+
+		it("still emits the LOGIN_START analytics event", () => {
+			render(<ProConnectButton callbackUrl="/admin" requiresAdminStepUp />);
+			screen
+				.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+				.click();
+			expect(trackEventMock).toHaveBeenCalledWith({
+				category: MATOMO_EVENT_CATEGORY.AUTH,
+				action: MATOMO_ACTION.LOGIN_START,
+			});
+		});
+	});
+
+	describe("when requiresAdminStepUp is not set", () => {
+		it("leaves an admin-shaped callbackUrl's sign-in request unchanged", () => {
+			// Regression guard for the rule the epic does not negotiate: only an
+			// explicit `requiresAdminStepUp` may add the step-up params — the
+			// button never infers it from the shape of the URL on its own.
+			render(<ProConnectButton callbackUrl="/admin" />);
+			screen
+				.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+				.click();
+			expect(signInMock).toHaveBeenCalledWith("proconnect", {
+				callbackUrl: "/admin",
+			});
 		});
 	});
 });


### PR DESCRIPTION
Closes #4465

## Résumé

Câble les deux portes d'entrée du backoffice sur le step-up admin (double authentification ProConnect) posé par #4461-#4464, pour qu'un agent habilité ne fasse jamais deux passages ProConnect successifs dans le cas nominal :

- **Menu « Administration »** (`UserAccountMenu.tsx`) : le lien déclenche directement le step-up (sans écran Egapro intermédiaire) quand la double authentification n'est pas fraîche ; reste un lien simple sinon.
- **`/login`** (`LoginForm.tsx` / `ProConnectButton.tsx`) : quand la destination validée (`callbackUrl`) vise `/admin`, la toute première demande ProConnect porte déjà l'exigence de step-up.
- **Step-up interrompu** (`app/login/page.tsx`) : un agent connecté qui revient sur `/login` avec un paramètre d'erreur voit l'écran de reprise (au lieu d'un rebond silencieux), sans que sa session déclarante soit fermée ou dégradée.

Les trois déclencheurs (menu, écran de reprise, bouton de connexion) partagent un point d'entrée unique, `triggerAdminStepUp` (`modules/admin/access/adminStepUp.ts`) — une seule copie des paramètres de step-up (`acr: eidas1-mfa`, `auth_time` essentiels, fenêtre de fraîcheur).

**Rappel de sécurité** (déjà en commentaire dans le code) : ce choix côté client n'est pas un contrôle de sécurité — un client qui l'omettrait n'obtient rien, les gardes serveur (`resolveAdminAccess`, middleware `/admin`, procédures tRPC admin, posées par #4462-#4464) refusent toujours une session sans second facteur frais. Ce ticket ne réduit que le nombre de passages ProConnect pour un agent déjà éligible.

Une revue de sécurité indépendante (`security-auditor`) a par ailleurs relevé une incohérence mineure entre `sanitizeAdminReturnPath` (qui résolvait les segments `..`) et `isAdminReturnPath` (qui testait la chaîne brute) — corrigée en factorisant la normalisation dans un helper partagé (`resolveSameOriginPath`), avec tests couvrant traversal, URL absolue, protocole relatif et autorité en backslash.

## Vérification

Sur le dev server du worktree, session de développement (`dev-auth`) pour un compte habilité :

| Ce qui a été fait | Résultat observé |
|---|---|
| Ouverture du menu compte | Entrée « Administration » présente (compte habilité) |
| Clic sur « Administration » (compte sans double authentification fraîche — la connexion de dev ne produit pas d'`acr` MFA) | `GET /api/auth/signin?callbackUrl=%2Fadmin` → redirection de step-up, **pas** de navigation directe vers `/admin` |
| `/login?callbackUrl=/admin` puis connexion | La demande ProConnect initiale (`LoginForm` → `ProConnectButton`) porte l'exigence de step-up dès ce premier appel — couvert par test, non rejouable en local (pas de sandbox ProConnect capable de produire un `acr` MFA depuis cet environnement) |

**Vérification dégradée, assumée** : le passage ProConnect complet (sandbox externe, second facteur) n'est pas rejouable dans cet environnement local — même limite que celle documentée par #4462. `functional-validator` rejoue les scénarios PO (S1, S4, S5, S10, S12) contre l'environnement de review app, qui dispose du seam de test posé par #4467.

## Tests

- `src/modules/admin/access/__tests__/adminStepUp.test.ts` — forme exacte des `claims`/`max_age` envoyés à `signIn`, un seul point d'entrée pour les trois appelants.
- `src/modules/admin/access/__tests__/adminReturnPath.test.ts` — `isAdminReturnPath` et `sanitizeAdminReturnPath` normalisent désormais la même façon (traversal, URL absolue, protocole relatif, autorité backslash).
- `src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx` — clic sur « Administration » : navigation normale si fraîche, step-up sinon.
- `src/modules/login/__tests__/{LoginForm,ProConnectButton}.test.tsx` — la demande ProConnect porte l'exigence uniquement quand la destination vise `/admin`, inchangée sinon.
- `src/modules/login/__tests__/LoginRoutePage.test.tsx` (nouveau) — page `/login` : écran de reprise sur step-up interrompu (session ouverte + `error`), comportement inchangé pour un visiteur non connecté.
- `src/modules/admin/access/__tests__/AdminAccessPage.test.tsx` — l'écran de reprise appelle le même `triggerAdminStepUp`.

Gates internes : `validator` PASS · `structural-auditor` MINOR (aucune ERROR ; deux WARN mineurs sans impact fonctionnel — commentaires multi-lignes non uniformément compactés, couplage circulaire léger `admin/access` ↔ `login`) · `rgaa-auditor` PASS (0 non-conformité sur les 5 fichiers `.tsx` modifiés) · `security-auditor` SECURE après correctif.
