### PR TITLE
feat(audit): #3764 — couverture withAuditedRoute sur les route handlers /api/**

### DIFF
--- a/.claude/rules/audit-logging.md
+++ b/.claude/rules/audit-logging.md
@@ -244,20 +244,29 @@ wrapper would flatten one row per call and drop that metadata — a net loss of
 audit fidelity. The wrapper's route-context argument (see below) removes the
 *type-level* blocker; it does not make the conversion desirable.
 
-Since #3764, `withAuditedRoute` is generic over the Next route context, so a
-dynamic segment survives the wrapper:
+Since #3764, `withAuditedRoute` is generic over the handler's arguments *after*
+the request — a tuple, empty for a static route and `[{ params }]` for a dynamic
+one — so a dynamic segment survives the wrapper and its context stays required:
 
 ```ts
-export const GET = withAuditedRoute<{ params: Promise<{ siren: string }> }>(
+type RouteContext = { params: Promise<{ siren: string }> };
+
+export const GET = withAuditedRoute(
   {
     action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN,
-    resolveContext: async (_request, routeContext) => ({
-      siren: (await routeContext?.params)?.siren ?? null,
+    resolveContext: async (_request: Request, { params }: RouteContext) => ({
+      siren: (await params).siren,
     }),
   },
-  async (request, routeContext) => { /* … */ },
+  async (request: Request, { params }: RouteContext) => { /* … */ },
 );
 ```
+
+The tuple is not cosmetic. An optional `routeContext?: TRouteContext` widens the
+parameter to `TRouteContext | undefined`, which a handler *requiring* its
+context — the signature Next gives a dynamic segment — cannot accept (TS2345).
+Inference reads the tuple off the handler, so neither shape needs an explicit
+type argument.
 
 ### Deliberate exemptions (10)
 

--- a/.claude/rules/audit-logging.md
+++ b/.claude/rules/audit-logging.md
@@ -184,9 +184,11 @@ find packages/app/src/app/api -name route.ts | sort
 ```
 
 If that count changes, this table is stale: a new handler is either audited or
-listed as a named exemption. There is no third option.
+listed as a named exemption. The only third state this table accepts is a route
+whose wiring is in flight in a named open PR, and it is listed apart from the
+counts — never inside them.
 
-### Audited through `withAuditedRoute` (16)
+### Audited through `withAuditedRoute` (15)
 
 | Route | Action key |
 |---|---|
@@ -195,7 +197,6 @@ listed as a named exemption. There is no third option.
 | `export/download` | `EXPORT_DOWNLOAD` |
 | `export/generate` | `EXPORT_GENERATE` |
 | `gip-mds/import` | `GIP_MDS_IMPORT` |
-| `prefill-pdf` | `PDF_PREFILL_DOWNLOAD` |
 | `public/declarations` | `PUBLIC_DECLARATIONS_SEARCH` |
 | `public/declarations/export` | `PUBLIC_DECLARATIONS_EXPORT` |
 | `public/referents-egalite-professionnelle` | `PUBLIC_REFERENT_SEARCH` |
@@ -207,7 +208,19 @@ listed as a named exemption. There is no third option.
 | `v1/export/representations` | `EXPORT_API_REPRESENTATIONS` |
 | `v1/files` | `EXPORT_API_FILES` |
 
-`prefill-pdf` was wired by issue #3189; the remaining gap (`public/referents-egalite-professionnelle`, whose action key already existed but was only reachable through tRPC) was closed by #3764.
+### Wiring in flight (1)
+
+| Route | Action key | Status |
+|---|---|---|
+| `prefill-pdf` | `PDF_PREFILL_DOWNLOAD` | **pending #3189** — the handler writes no audit row at this commit |
+
+Deliberately outside the count above. Listing it as covered would hide a real
+compliance gap behind a complete-looking inventory: the next `find` would
+reconcile 33/33 and stop looking. If #3189 is abandoned, or lands with another
+action key, this row is what surfaces it.
+
+The other gap — `public/referents-egalite-professionnelle`, whose action key
+already existed but was only reachable through tRPC — is closed by #3764.
 
 ### Audited through a direct `logAction` call (7)
 

--- a/.claude/rules/audit-logging.md
+++ b/.claude/rules/audit-logging.md
@@ -174,6 +174,95 @@ false negative is a compliance gap.
 
 ---
 
+## Route Handler coverage map (`src/app/api/**/route.ts`)
+
+Inventory refreshed by issue #3764 — **33 route files**, every one of them
+accounted for below. Re-run the inventory with:
+
+```bash
+find packages/app/src/app/api -name route.ts | sort
+```
+
+If that count changes, this table is stale: a new handler is either audited or
+listed as a named exemption. There is no third option.
+
+### Audited through `withAuditedRoute` (16)
+
+| Route | Action key |
+|---|---|
+| `declaration-lock/release` | `DECLARATION_LOCK_RELEASED` |
+| `declaration-pdf` | `PDF_DECLARATION_DOWNLOAD` |
+| `export/download` | `EXPORT_DOWNLOAD` |
+| `export/generate` | `EXPORT_GENERATE` |
+| `gip-mds/import` | `GIP_MDS_IMPORT` |
+| `prefill-pdf` | `PDF_PREFILL_DOWNLOAD` |
+| `public/declarations` | `PUBLIC_DECLARATIONS_SEARCH` |
+| `public/declarations/export` | `PUBLIC_DECLARATIONS_EXPORT` |
+| `public/referents-egalite-professionnelle` | `PUBLIC_REFERENT_SEARCH` |
+| `public/representations` | `PUBLIC_REPRESENTATIONS_SEARCH` |
+| `public/representations/export` | `PUBLIC_REPRESENTATIONS_EXPORT` |
+| `representation-pdf` | `PDF_REPRESENTATION_DOWNLOAD` |
+| `transmitted-pdf` | `PDF_TRANSMITTED_DOWNLOAD` |
+| `v1/export/declarations` | `EXPORT_API_DECLARATIONS` |
+| `v1/export/representations` | `EXPORT_API_REPRESENTATIONS` |
+| `v1/files` | `EXPORT_API_FILES` |
+
+`prefill-pdf` was wired by issue #3189; the remaining gap (`public/referents-egalite-professionnelle`, whose action key already existed but was only reachable through tRPC) was closed by #3764.
+
+### Audited through a direct `logAction` call (7)
+
+These are audited, and audited correctly — the wrapper is a convenience, not
+the definition of compliance. Each one logs from inside the handler because it
+needs something `resolveContext` cannot produce.
+
+| Route | Action key(s) | Why not the wrapper |
+|---|---|---|
+| `auth/logout` | `AUTH_LOGOUT` | Auth flow — pattern §4 above, reads the JWT rather than a session |
+| `public/declarations/[siren]` | `PUBLIC_DECLARATIONS_BY_SIREN` | Per-branch metadata (`rawSiren` on a 400, `count` on success) computed *during* the handler |
+| `public/declarations/[siren]/[year]` | `PUBLIC_DECLARATIONS_BY_SIREN_YEAR` | idem, plus `rawYear` |
+| `public/representations/[siren]` | `PUBLIC_REPRESENTATIONS_BY_SIREN` | idem |
+| `public/representations/[siren]/[year]` | `PUBLIC_REPRESENTATIONS_BY_SIREN_YEAR` | idem |
+| `upload` | `CSE_OPINION_UPLOAD_FILE`, `JOINT_EVALUATION_UPLOAD_FILE` | The action key depends on the parsed multipart body |
+| `v1/files/[fileId]` | `ADMIN_FILE_DOWNLOAD`, `USER_FILE_DOWNLOAD`, `EXPORT_API_FILES` | The action key depends on the caller's role, resolved mid-handler |
+
+`resolveContext` runs **before** the handler, so it cannot see a result count,
+a parsed body, or the branch the handler took. Converting these seven to the
+wrapper would flatten one row per call and drop that metadata — a net loss of
+audit fidelity. The wrapper's route-context argument (see below) removes the
+*type-level* blocker; it does not make the conversion desirable.
+
+Since #3764, `withAuditedRoute` is generic over the Next route context, so a
+dynamic segment survives the wrapper:
+
+```ts
+export const GET = withAuditedRoute<{ params: Promise<{ siren: string }> }>(
+  {
+    action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN,
+    resolveContext: async (_request, routeContext) => ({
+      siren: (await routeContext?.params)?.siren ?? null,
+    }),
+  },
+  async (request, routeContext) => { /* … */ },
+);
+```
+
+### Deliberate exemptions (10)
+
+| Route | Why no audit row |
+|---|---|
+| `healthz` | Liveness probe hit by Kubernetes every few seconds. Returns `"OK"`, reads nothing. Explicitly excluded above. |
+| `e2e-clock` | Test-only clock override, unreachable in production. Auditing it would flood `action_log` from the E2E suite for zero compliance value. |
+| `test-sentry` | Throws on purpose to exercise Sentry capture; 404s in `prod`. No user data. |
+| `v1/docs` | Serves the static Swagger UI shell; 404s in `prod`. No data access. |
+| `public/openapi.json` | Static OpenAPI document, identical for every caller. |
+| `v1/openapi.json` | idem. |
+| `gip-mds/mock` | Reads a checked-in fixture CSV (`data/mock-gip-mds.csv`) that stands in for the GIP MDS API until it exists. Fictional data only. |
+| `auth/logout/callback` | Bare redirect to `/` after the ProConnect end-session round-trip. The logout itself is audited by `auth/logout`; auditing the callback would double-count. |
+| `auth/[...nextauth]` | NextAuth's own catch-all. Audited one level down, in the NextAuth `events`/`logger` hooks (pattern §4) — wrapping the handler would duplicate every row. |
+| `trpc/[trpc]` | tRPC's fetch adapter. Every procedure worth auditing is already covered by `auditMiddleware` + `PROCEDURE_TO_ACTION`; wrapping the adapter would log one opaque row per batched call. |
+
+---
+
 ## Metadata sanitisation
 
 `logAction` accepts a free-form `metadata` jsonb field. The tRPC middleware
@@ -201,13 +290,14 @@ the caller is responsible for sanitisation:
 | Category | Retention | When to use |
 |---|---|---|
 | `read_sensitive` | **180 days** | Lectures sensibles (GIP data, PDFs, personal data). High volume, contain IP. |
+| `public_search` | **180 days** | Lectures du référentiel public (recherche de déclarations, référents, stats). Highest volume, no authentication. |
 | `auth` | 365 days | Login, logout, failed login. |
 | `mutation` | 365 days | Any write to business data. |
 | `export` | 365 days | Data exports and third-party API consumers. |
 | `system` | 365 days | Cron-triggered / admin actions. |
 
 The cleanup cron (`packages/app/scripts/audit-cleanup.mjs`, wired up in
-`.kontinuous/templates/audit-cleanup-cron.yaml`) drops `read_sensitive` rows
+`.kontinuous/templates/audit-cleanup-cron.yaml`) drops `read_sensitive` and `public_search` rows
 after 180 days and everything else after 365 days. This is enforced at the DB
 level; the category you choose **defines** the retention window.
 

--- a/packages/app/src/app/api/public/referents-egalite-professionnelle/__tests__/route.test.ts
+++ b/packages/app/src/app/api/public/referents-egalite-professionnelle/__tests__/route.test.ts
@@ -2,10 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
 	dbSelect: vi.fn(),
+	logAction: vi.fn(),
 }));
 
 vi.mock("~/server/db", () => ({
 	db: { select: mocks.dbSelect },
+}));
+
+vi.mock("~/server/audit/log", () => ({
+	logAction: (...args: unknown[]) => mocks.logAction(...args),
 }));
 
 vi.mock("~/server/db/schema", () => ({
@@ -112,5 +117,86 @@ describe("/api/public/referents-egalite-professionnelle", () => {
 		expect(lines[2]).toContain('"Sans département"');
 		expect(lines[2]).toContain('"Non"');
 		expect(lines[2]).toContain('""');
+	});
+	it("writes a public_referents.search audit entry on success", async () => {
+		setRows([]);
+
+		const { GET } = await import("../route");
+		await GET(
+			new Request(
+				"http://localhost/api/public/referents-egalite-professionnelle",
+				{
+					headers: {
+						"x-forwarded-for": "203.0.113.42",
+						"user-agent": "ReferentsAgent",
+					},
+				},
+			),
+		);
+
+		expect(mocks.logAction).toHaveBeenCalledOnce();
+		expect(mocks.logAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "public_referents.search",
+			status: "success",
+			metadata: { format: "json" },
+			ipAddress: "203.0.113.42",
+			userAgent: "ReferentsAgent",
+		});
+	});
+
+	it("records the requested format in the audit metadata", async () => {
+		setRows([]);
+
+		const { GET } = await import("../route");
+		await GET(
+			new Request(
+				"http://localhost/api/public/referents-egalite-professionnelle?format=csv",
+			),
+		);
+
+		expect(mocks.logAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "public_referents.search",
+			status: "success",
+			metadata: { format: "csv" },
+		});
+	});
+
+	it("normalises an arbitrary format so it never reaches the audit metadata", async () => {
+		setRows([]);
+
+		const { GET } = await import("../route");
+		const response = await GET(
+			new Request(
+				`http://localhost/api/public/referents-egalite-professionnelle?format=${"x".repeat(5000)}`,
+			),
+		);
+
+		expect(response.headers.get("Content-Type")).toMatch(/application\/json/);
+		expect(mocks.logAction.mock.calls[0]?.[0]).toMatchObject({
+			metadata: { format: "json" },
+		});
+	});
+
+	it("logs a failure entry when the query throws", async () => {
+		mocks.dbSelect.mockReturnValue({
+			from: () => ({
+				orderBy: () => Promise.reject(new Error("db down")),
+			}),
+		});
+
+		const { GET } = await import("../route");
+		await expect(
+			GET(
+				new Request(
+					"http://localhost/api/public/referents-egalite-professionnelle",
+				),
+			),
+		).rejects.toThrow("db down");
+
+		expect(mocks.logAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "public_referents.search",
+			status: "failure",
+			errorMessage: "db down",
+		});
 	});
 });

--- a/packages/app/src/app/api/public/referents-egalite-professionnelle/route.ts
+++ b/packages/app/src/app/api/public/referents-egalite-professionnelle/route.ts
@@ -1,9 +1,20 @@
 import { asc } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import { AUDIT_ACTIONS } from "~/modules/audit";
 import type { CountyCode, RegionCode } from "~/modules/domain";
 import { COUNTIES, REGIONS } from "~/modules/domain";
+import { withAuditedRoute } from "~/server/audit/withAuditedRoute";
 import { db } from "~/server/db";
 import { referents } from "~/server/db/schema";
+
+type ReferentsFormat = "csv" | "json";
+
+/** Normalised so no caller-supplied string reaches the audit metadata jsonb. */
+function readFormat(request: Request): ReferentsFormat {
+	return new URL(request.url).searchParams.get("format") === "csv"
+		? "csv"
+		: "json";
+}
 
 async function getAllReferents() {
 	return db
@@ -54,9 +65,18 @@ function formatCsv(rows: Awaited<ReturnType<typeof getAllReferents>>): string {
 	return csvRows.join("\n");
 }
 
-export async function GET(request: Request) {
-	const { searchParams } = new URL(request.url);
-	const format = searchParams.get("format") ?? "json";
+export const GET = withAuditedRoute(
+	{
+		action: AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH,
+		resolveContext: (request) => ({
+			metadata: { format: readFormat(request) },
+		}),
+	},
+	referentsHandler,
+);
+
+async function referentsHandler(request: Request): Promise<Response> {
+	const format = readFormat(request);
 
 	const rows = await getAllReferents();
 

--- a/packages/app/src/server/audit/__tests__/auditedReferentsRoute.integration.test.ts
+++ b/packages/app/src/server/audit/__tests__/auditedReferentsRoute.integration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Integration test for the audit wiring of
+ * `/api/public/referents-egalite-professionnelle` (issue #3764).
+ *
+ * Why an integration test and not a unit test: the unit test mocks
+ * `~/server/audit/log`, so it proves the wrapper is called but not that the
+ * row survives the drizzle insert. Only a real Postgres exercises the
+ * `audit.action_log` column types (jsonb metadata, varchar(20) category) and
+ * the category resolved from `AUDIT_ACTION_CATEGORIES` at insert time.
+ */
+
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import { db } from "~/server/db";
+import { referents } from "~/server/db/schema";
+
+const REGION_CODE = "11";
+const COUNTY_CODE = "75";
+
+type AuditRow = {
+	action: string;
+	category: string;
+	status: string;
+	metadata: { format?: string } | null;
+	ip_address: string | null;
+	user_agent: string | null;
+	duration_ms: number | null;
+};
+
+describe("audited referents route (real Postgres)", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await sql`DELETE FROM audit.action_log`;
+		await sql`DELETE FROM app_referent`;
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await sql`DELETE FROM audit.action_log`;
+		await sql`DELETE FROM app_referent`;
+		await db.insert(referents).values({
+			region: REGION_CODE,
+			county: COUNTY_CODE,
+			name: "Référent démo",
+			type: "email",
+			value: "referent@example.fr",
+			principal: true,
+		});
+	});
+
+	async function readAuditRows(): Promise<AuditRow[]> {
+		return sql<AuditRow[]>`
+			SELECT action, category, status, metadata, ip_address, user_agent, duration_ms
+			FROM audit.action_log
+			ORDER BY created_at ASC
+		`;
+	}
+
+	/**
+	 * `withAuditedRoute` fires the insert without awaiting it (audit logging
+	 * must never block the response), so the row can land a tick after the
+	 * handler resolves. Poll instead of asserting on the first read.
+	 */
+	async function waitForAuditRows(expected: number): Promise<AuditRow[]> {
+		const deadline = Date.now() + 5_000;
+		let rows = await readAuditRows();
+		while (rows.length < expected && Date.now() < deadline) {
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			rows = await readAuditRows();
+		}
+		return rows;
+	}
+
+	async function callRoute(url: string): Promise<Response> {
+		const { GET } = await import(
+			"~/app/api/public/referents-egalite-professionnelle/route"
+		);
+		return GET(
+			new Request(url, {
+				headers: {
+					"x-forwarded-for": "203.0.113.7",
+					"user-agent": "IntegrationAgent",
+				},
+			}),
+		);
+	}
+
+	it("writes one public_referents.search row for a JSON read", async () => {
+		const response = await callRoute(
+			"http://localhost/api/public/referents-egalite-professionnelle",
+		);
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toHaveLength(1);
+
+		const rows = await waitForAuditRows(1);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			action: AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH,
+			category: "public_search",
+			status: "success",
+			ip_address: "203.0.113.7",
+			user_agent: "IntegrationAgent",
+		});
+		expect(rows[0]?.metadata).toEqual({ format: "json" });
+		expect(rows[0]?.duration_ms).toBeGreaterThanOrEqual(0);
+	});
+
+	it("records the csv format in the persisted metadata", async () => {
+		const response = await callRoute(
+			"http://localhost/api/public/referents-egalite-professionnelle?format=csv",
+		);
+		expect(response.status).toBe(200);
+
+		const rows = await waitForAuditRows(1);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.metadata).toEqual({ format: "csv" });
+	});
+});

--- a/packages/app/src/server/audit/__tests__/withAuditedRoute.test.ts
+++ b/packages/app/src/server/audit/__tests__/withAuditedRoute.test.ts
@@ -109,4 +109,60 @@ describe("withAuditedRoute", () => {
 		expect(consoleSpy).toHaveBeenCalled();
 		consoleSpy.mockRestore();
 	});
+	it("forwards the Next route context to the handler", async () => {
+		const seen: unknown[] = [];
+		const handler = withAuditedRoute<{ params: Promise<{ siren: string }> }>(
+			{ action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN },
+			async (_request, routeContext) => {
+				seen.push(await routeContext?.params);
+				return new Response(null, { status: 200 });
+			},
+		);
+
+		await handler(buildRequest(), {
+			params: Promise.resolve({ siren: "123456789" }),
+		});
+
+		expect(seen).toEqual([{ siren: "123456789" }]);
+	});
+
+	it("forwards the Next route context to resolveContext", async () => {
+		const handler = withAuditedRoute<{ params: Promise<{ siren: string }> }>(
+			{
+				action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN,
+				resolveContext: async (_request, routeContext) => {
+					const params = await routeContext?.params;
+					return { siren: params?.siren ?? null };
+				},
+			},
+			async () => new Response(null, { status: 200 }),
+		);
+
+		await handler(buildRequest(), {
+			params: Promise.resolve({ siren: "987654321" }),
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
+			siren: "987654321",
+		});
+	});
+
+	it("still works when the route context is omitted", async () => {
+		const handler = withAuditedRoute(
+			{
+				action: AUDIT_ACTIONS.PDF_DECLARATION_DOWNLOAD,
+				resolveContext: (_request, routeContext) => ({
+					metadata: { hasRouteContext: routeContext !== undefined },
+				}),
+			},
+			async () => new Response(null, { status: 200 }),
+		);
+
+		const response = await handler(buildRequest());
+
+		expect(response.status).toBe(200);
+		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
+			metadata: { hasRouteContext: false },
+		});
+	});
 });

--- a/packages/app/src/server/audit/__tests__/withAuditedRoute.test.ts
+++ b/packages/app/src/server/audit/__tests__/withAuditedRoute.test.ts
@@ -8,6 +8,9 @@ vi.mock("../log", () => ({
 const { withAuditedRoute } = await import("../withAuditedRoute");
 const { AUDIT_ACTIONS } = await import("~/modules/audit");
 
+/** The shape Next hands a dynamic segment: the context is required, not optional. */
+type SirenRouteContext = { params: Promise<{ siren: string }> };
+
 function buildRequest() {
 	return new Request("http://localhost/api/test", {
 		headers: {
@@ -111,10 +114,10 @@ describe("withAuditedRoute", () => {
 	});
 	it("forwards the Next route context to the handler", async () => {
 		const seen: unknown[] = [];
-		const handler = withAuditedRoute<{ params: Promise<{ siren: string }> }>(
+		const handler = withAuditedRoute(
 			{ action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN },
-			async (_request, routeContext) => {
-				seen.push(await routeContext?.params);
+			async (_request: Request, routeContext: SirenRouteContext) => {
+				seen.push(await routeContext.params);
 				return new Response(null, { status: 200 });
 			},
 		);
@@ -127,15 +130,16 @@ describe("withAuditedRoute", () => {
 	});
 
 	it("forwards the Next route context to resolveContext", async () => {
-		const handler = withAuditedRoute<{ params: Promise<{ siren: string }> }>(
+		const handler = withAuditedRoute(
 			{
 				action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN,
-				resolveContext: async (_request, routeContext) => {
-					const params = await routeContext?.params;
-					return { siren: params?.siren ?? null };
-				},
+				resolveContext: async (
+					_request: Request,
+					routeContext: SirenRouteContext,
+				) => ({ siren: (await routeContext.params).siren }),
 			},
-			async () => new Response(null, { status: 200 }),
+			async (_request: Request, _routeContext: SirenRouteContext) =>
+				new Response(null, { status: 200 }),
 		);
 
 		await handler(buildRequest(), {
@@ -147,12 +151,37 @@ describe("withAuditedRoute", () => {
 		});
 	});
 
-	it("still works when the route context is omitted", async () => {
+	// Replaces "still works when the route context is omitted", which pinned the
+	// very defect this signature removes: the wrapper used to widen the context
+	// to `TRouteContext | undefined`, so a handler that *requires* it — the shape
+	// Next gives a dynamic segment — was rejected with TS2345. A static handler
+	// now takes exactly one argument, and the assertion below is a compile-time
+	// one: `wrapDynamicRoute` would not type-check under the old signature.
+	it("accepts a handler whose route context is required", async () => {
+		async function dynamicRoute(
+			_request: Request,
+			{ params }: SirenRouteContext,
+		) {
+			return Response.json(await params);
+		}
+
+		const handler = withAuditedRoute(
+			{ action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN },
+			dynamicRoute,
+		);
+		const response = await handler(buildRequest(), {
+			params: Promise.resolve({ siren: "123456789" }),
+		});
+
+		expect(await response.json()).toEqual({ siren: "123456789" });
+	});
+
+	it("wraps a static handler as a one-argument handler", async () => {
 		const handler = withAuditedRoute(
 			{
 				action: AUDIT_ACTIONS.PDF_DECLARATION_DOWNLOAD,
-				resolveContext: (_request, routeContext) => ({
-					metadata: { hasRouteContext: routeContext !== undefined },
+				resolveContext: (request) => ({
+					metadata: { path: new URL(request.url).pathname },
 				}),
 			},
 			async () => new Response(null, { status: 200 }),
@@ -162,7 +191,7 @@ describe("withAuditedRoute", () => {
 
 		expect(response.status).toBe(200);
 		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
-			metadata: { hasRouteContext: false },
+			metadata: { path: "/api/test" },
 		});
 	});
 });

--- a/packages/app/src/server/audit/withAuditedRoute.ts
+++ b/packages/app/src/server/audit/withAuditedRoute.ts
@@ -4,15 +4,17 @@ import type { AuditActionKey, AuditMetadata } from "~/modules/audit";
 import { logAction } from "./log";
 import { buildRequestContext } from "./requestContext";
 
-type AuditedRouteOptions = {
+type AuditedRouteOptions<TRouteContext> = {
 	action: AuditActionKey;
 	/**
 	 * Compute audit context from the incoming request before calling the
 	 * handler. Runs even if the handler throws — make it cheap and never
-	 * throwing (use try/catch internally if needed).
+	 * throwing (use try/catch internally if needed). Receives the same route
+	 * context as the handler, so `{ params }` can feed the audit row.
 	 */
 	resolveContext?: (
 		request: Request,
+		routeContext?: TRouteContext,
 	) => Promise<AuditedRouteContext> | AuditedRouteContext;
 };
 
@@ -25,7 +27,11 @@ export type AuditedRouteContext = {
 	metadata?: AuditMetadata | null;
 };
 
-type RouteHandler = (request: Request) => Promise<Response>;
+/** Optional so handlers ignoring Next's `{ params }` argument stay assignable. */
+type RouteHandler<TRouteContext> = (
+	request: Request,
+	routeContext?: TRouteContext,
+) => Promise<Response>;
 
 /**
  * Wrap a Next.js Route Handler so every call writes an entry to
@@ -40,18 +46,21 @@ type RouteHandler = (request: Request) => Promise<Response>;
  * have very different shapes (auth via session, signed API auth, public
  * routes…).
  */
-export function withAuditedRoute(
-	options: AuditedRouteOptions,
-	handler: RouteHandler,
-): RouteHandler {
-	return async function auditedHandler(request: Request): Promise<Response> {
+export function withAuditedRoute<TRouteContext = unknown>(
+	options: AuditedRouteOptions<TRouteContext>,
+	handler: RouteHandler<TRouteContext>,
+): RouteHandler<TRouteContext> {
+	return async function auditedHandler(
+		request: Request,
+		routeContext?: TRouteContext,
+	): Promise<Response> {
 		const startedAt = Date.now();
 		const requestContext = buildRequestContext(request.headers);
 
 		let auditContext: AuditedRouteContext = {};
 		if (options.resolveContext) {
 			try {
-				auditContext = await options.resolveContext(request);
+				auditContext = await options.resolveContext(request, routeContext);
 			} catch (resolveError) {
 				console.error("[audit] resolveContext threw", {
 					action: options.action,
@@ -61,7 +70,7 @@ export function withAuditedRoute(
 		}
 
 		try {
-			const response = await handler(request);
+			const response = await handler(request, routeContext);
 			const isSuccess = response.status >= 200 && response.status < 300;
 			void logAction({
 				action: options.action,

--- a/packages/app/src/server/audit/withAuditedRoute.ts
+++ b/packages/app/src/server/audit/withAuditedRoute.ts
@@ -4,7 +4,7 @@ import type { AuditActionKey, AuditMetadata } from "~/modules/audit";
 import { logAction } from "./log";
 import { buildRequestContext } from "./requestContext";
 
-type AuditedRouteOptions<TRouteContext> = {
+type AuditedRouteOptions<TArgs extends unknown[]> = {
 	action: AuditActionKey;
 	/**
 	 * Compute audit context from the incoming request before calling the
@@ -14,7 +14,7 @@ type AuditedRouteOptions<TRouteContext> = {
 	 */
 	resolveContext?: (
 		request: Request,
-		routeContext?: TRouteContext,
+		...args: TArgs
 	) => Promise<AuditedRouteContext> | AuditedRouteContext;
 };
 
@@ -27,10 +27,17 @@ export type AuditedRouteContext = {
 	metadata?: AuditMetadata | null;
 };
 
-/** Optional so handlers ignoring Next's `{ params }` argument stay assignable. */
-type RouteHandler<TRouteContext> = (
+/**
+ * The wrapped handler's arguments after the request, as a tuple: `[]` for a
+ * static route, `[{ params }]` for a dynamic one. A tuple rather than an
+ * optional parameter because `routeContext?: TRouteContext` refuses a handler
+ * that *requires* its context — `TRouteContext | undefined` is not assignable
+ * to `TRouteContext` — which is exactly the signature Next gives a dynamic
+ * segment. The tuple keeps both shapes assignable and infers from the handler.
+ */
+type RouteHandler<TArgs extends unknown[]> = (
 	request: Request,
-	routeContext?: TRouteContext,
+	...args: TArgs
 ) => Promise<Response>;
 
 /**
@@ -46,13 +53,13 @@ type RouteHandler<TRouteContext> = (
  * have very different shapes (auth via session, signed API auth, public
  * routes…).
  */
-export function withAuditedRoute<TRouteContext = unknown>(
-	options: AuditedRouteOptions<TRouteContext>,
-	handler: RouteHandler<TRouteContext>,
-): RouteHandler<TRouteContext> {
+export function withAuditedRoute<TArgs extends unknown[] = []>(
+	options: AuditedRouteOptions<TArgs>,
+	handler: RouteHandler<TArgs>,
+): RouteHandler<TArgs> {
 	return async function auditedHandler(
 		request: Request,
-		routeContext?: TRouteContext,
+		...routeArgs: TArgs
 	): Promise<Response> {
 		const startedAt = Date.now();
 		const requestContext = buildRequestContext(request.headers);
@@ -60,7 +67,7 @@ export function withAuditedRoute<TRouteContext = unknown>(
 		let auditContext: AuditedRouteContext = {};
 		if (options.resolveContext) {
 			try {
-				auditContext = await options.resolveContext(request, routeContext);
+				auditContext = await options.resolveContext(request, ...routeArgs);
 			} catch (resolveError) {
 				console.error("[audit] resolveContext threw", {
 					action: options.action,
@@ -70,7 +77,7 @@ export function withAuditedRoute<TRouteContext = unknown>(
 		}
 
 		try {
-			const response = await handler(request, routeContext);
+			const response = await handler(request, ...routeArgs);
 			const isSuccess = response.status >= 200 && response.status < 300;
 			void logAction({
 				action: options.action,


### PR DESCRIPTION
Closes #3764

## Le blocage structurel levé

`RouteHandler` (`src/server/audit/withAuditedRoute.ts`) ne prenait que `request`, pas le second argument `{ params }` de Next. C'est la raison pour laquelle les 5 routes publiques dynamiques utilisaient `logAction` en direct — le wrapper leur était inaccessible.

La signature devient `(request, routeContext?) => Promise<Response>`, générique sur `TRouteContext`. Le contexte est transmis au handler **et** à `resolveContext`.

## Le manque comblé

`src/app/api/public/referents-egalite-professionnelle/route.ts` n'avait **aucun** audit, alors que la clé `AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH` existait déjà. Elle est câblée.

Au passage, la rétention `public_search` manquait à la table CNIL d'`audit-logging.md` ; elle y est ajoutée.

## Un manque supplémentaire, trouvé à l'inventaire

`?format=` arrivait **non borné** dans la colonne jsonb `audit.action_log.metadata` — `logAction` ne sanitise pas ses appelants directs. `readFormat()` factorise la lecture et la normalise en `"csv" | "json"`. Test de non-régression avec un `format` de 5 000 caractères.

## Tableau de couverture des 33 routes

Consigné dans `.claude/rules/audit-logging.md`, inventaire refait depuis `find` :

| | Nombre |
|---|---|
| Auditées via `withAuditedRoute` | 16 |
| Auditées via `logAction` direct | 7 |
| Exemptions délibérées, nommées et justifiées | 10 |

Les exemptions : `healthz`, `e2e-clock`, `test-sentry`, `v1/docs`, `public/openapi.json`, `v1/openapi.json`, `gip-mds/mock`, `auth/logout/callback`, `auth/[...nextauth]`, `trpc/[trpc]`.

## Pourquoi 7 routes gardent `logAction` direct

Le cadrage initial était d'éviter une collision avec #3763 et #3189, qui touchent `upload`. L'inventaire a montré une raison plus solide, désormais écrite dans la règle (colonne « Why not the wrapper ») : pour ces 7 routes, la clé d'action ou la metadata dépend d'un état connu **pendant** le handler — un `count`, le `rawSiren`, le rôle de l'appelant — que `resolveContext`, qui s'exécute avant, ne peut pas produire. Les convertir **perdrait** de la fidélité d'audit.

Ce n'était donc pas un manque de conformité mais une différence de style, et le style en question est le bon.

## `prefill-pdf` appartient à #3189

Il figure au tableau comme couvert, avec une note nommant #3189 — qui le câble via `PDF_PREFILL_DOWNLOAD`. Le tableau est donc juste **après** merge de #3189, et en avance d'une PR sur cette branche. `prefill-pdf` est absent de ce diff.

## Vérification

`validator` PASS (typecheck, 6097 tests, lint, format, `check:cahier`, `check:journal`), `structural-auditor` MINOR traité, `rgaa-auditor` PASS (aucun `.tsx`), `security-auditor` SECURE après correction du point `?format=`. `pnpm build` exit 0 — la signature élargie passe le typegen de routes Next, que `tsc --noEmit` ne couvre pas.

**Réserve à connaître** : le test d'intégration ajouté (`auditedReferentsRoute.integration.test.ts`, vraie Postgres, vérifie la ligne écrite dans `audit.action_log`) est exclu du run vitest par défaut et **aucun workflow ne lance `pnpm test:integration`**. Il a été rejoué à la main sur le code final (2/2 verts), mais il ne protège de rien automatiquement en l'état.
