### PR TITLE
refactor(trpc): #2967 — types dérivés et schémas Zod par router

### DIFF
--- a/packages/app/src/modules/admin/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/admin/__tests__/schemas.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-	impersonateSearchSchema,
-	releaseLockSchema,
-	startImpersonateSchema,
-} from "../schemas";
+import { impersonateSearchSchema, startImpersonateSchema } from "../schemas";
 import { updateLockTimeoutSchema } from "../settings/schemas";
 
 describe("admin schemas", () => {
@@ -69,22 +65,5 @@ describe("updateLockTimeoutSchema", () => {
 
 	it("rejects a missing timeout", () => {
 		expect(updateLockTimeoutSchema.safeParse({}).success).toBe(false);
-	});
-});
-
-describe("releaseLockSchema", () => {
-	it("accepts a valid UUID declarationId", () => {
-		const result = releaseLockSchema.safeParse({
-			declarationId: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
-		});
-		expect(result.success).toBe(true);
-	});
-
-	it.each([
-		"",
-		"not-a-uuid",
-		"123456789",
-	])("rejects a non-UUID declarationId %s", (declarationId) => {
-		expect(releaseLockSchema.safeParse({ declarationId }).success).toBe(false);
 	});
 });

--- a/packages/app/src/modules/admin/declarations/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/admin/declarations/__tests__/schemas.test.ts
@@ -4,6 +4,7 @@ import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
 import {
 	ADMIN_DECLARATION_STATUS_FILTERS,
 	getDeclarationByIdSchema,
+	releaseLockSchema,
 	searchDeclarationsFormSchema,
 	searchDeclarationsSchema,
 } from "../schemas";
@@ -110,5 +111,22 @@ describe("getDeclarationByIdSchema", () => {
 		expect(() =>
 			getDeclarationByIdSchema.parse({ id: "not-a-uuid" }),
 		).toThrow();
+	});
+});
+
+describe("releaseLockSchema", () => {
+	it("accepts a valid UUID declarationId", () => {
+		const result = releaseLockSchema.safeParse({
+			declarationId: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it.each([
+		"",
+		"not-a-uuid",
+		"123456789",
+	])("rejects a non-UUID declarationId %s", (declarationId) => {
+		expect(releaseLockSchema.safeParse({ declarationId }).success).toBe(false);
 	});
 });

--- a/packages/app/src/modules/admin/declarations/schemas.ts
+++ b/packages/app/src/modules/admin/declarations/schemas.ts
@@ -77,3 +77,9 @@ export const cancelDeclarationSchema = z.object({
 export const getRecapSchema = z.object({
 	id: z.string().uuid(),
 });
+
+export const releaseLockSchema = z.object({
+	declarationId: z.string().uuid(),
+});
+
+export type ReleaseLockInput = z.infer<typeof releaseLockSchema>;

--- a/packages/app/src/modules/admin/declarations/types.ts
+++ b/packages/app/src/modules/admin/declarations/types.ts
@@ -1,8 +1,14 @@
-import type { RouterOutputs } from "~/trpc/react";
+import type { inferRouterOutputs } from "@trpc/server";
+
+import type { adminDeclarationsRouter } from "~/server/api/routers/adminDeclarations";
+
+type AdminDeclarationsOutputs = inferRouterOutputs<
+	typeof adminDeclarationsRouter
+>;
 
 export type DeclarationSearchRow =
-	RouterOutputs["adminDeclarations"]["search"]["rows"][number];
+	AdminDeclarationsOutputs["search"]["rows"][number];
 
 export type DeclarationDetail = NonNullable<
-	RouterOutputs["adminDeclarations"]["getById"]
+	AdminDeclarationsOutputs["getById"]
 >;

--- a/packages/app/src/modules/admin/index.ts
+++ b/packages/app/src/modules/admin/index.ts
@@ -10,7 +10,5 @@ export { AdminReferentsPage } from "./referents";
 export {
 	type ImpersonateSearchInput,
 	impersonateSearchSchema,
-	type ReleaseLockInput,
-	releaseLockSchema,
 	sirenSchema,
 } from "./schemas";

--- a/packages/app/src/modules/admin/referents/types.ts
+++ b/packages/app/src/modules/admin/referents/types.ts
@@ -1,4 +1,7 @@
-import type { RouterOutputs } from "~/trpc/react";
+import type { inferRouterOutputs } from "@trpc/server";
 
-export type ReferentSearchRow =
-	RouterOutputs["adminReferents"]["search"]["rows"][number];
+import type { adminReferentsRouter } from "~/server/api/routers/adminReferents";
+
+type AdminReferentsOutputs = inferRouterOutputs<typeof adminReferentsRouter>;
+
+export type ReferentSearchRow = AdminReferentsOutputs["search"]["rows"][number];

--- a/packages/app/src/modules/admin/schemas.ts
+++ b/packages/app/src/modules/admin/schemas.ts
@@ -29,9 +29,3 @@ export const startImpersonateSchema = z.object({
 });
 
 export type StartImpersonateInput = z.infer<typeof startImpersonateSchema>;
-
-export const releaseLockSchema = z.object({
-	declarationId: z.string().uuid(),
-});
-
-export type ReleaseLockInput = z.infer<typeof releaseLockSchema>;

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -1,6 +1,6 @@
 import { DeclarationLockAlert } from "~/modules/declaration-remuneration/shared/lock/DeclarationLockAlert";
-import type { LockHolder } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
+import type { LockHolderDisplay } from "~/modules/declaration-remuneration/shared/lock/types";
 import {
 	formatWorkforceForUser,
 	getObligationWorkforce,
@@ -24,7 +24,7 @@ type Props = {
 	declarationYear: number;
 	children: React.ReactNode;
 	isReadOnly?: boolean;
-	lockHolder?: LockHolder | null;
+	lockHolder?: LockHolderDisplay | null;
 };
 
 export function CseOpinionLayout({

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -54,8 +54,9 @@ export {
 export type {
 	DeclarationLockState,
 	LockHolder,
+	LockHolderDisplay,
 	ReadOnlyReason,
-} from "./shared/lock/useDeclarationLock";
+} from "./shared/lock/types";
 export { useDeclarationLock } from "./shared/lock/useDeclarationLock";
 export { ComplianceConfirmation } from "./steps/ComplianceConfirmation";
 export { CompliancePathChoice } from "./steps/CompliancePathChoice";

--- a/packages/app/src/modules/declaration-remuneration/schemas.ts
+++ b/packages/app/src/modules/declaration-remuneration/schemas.ts
@@ -196,19 +196,3 @@ export type CategoryFormValues = z.infer<typeof categoryFormSchema>;
 export const saveCompliancePathSchema = z.object({
 	path: z.enum(COMPLIANCE_PATHS),
 });
-
-export const acquireLockSchema = z.object({
-	declarationId: z.string(),
-});
-
-export const heartbeatSchema = z.object({
-	declarationId: z.string(),
-});
-
-export const releaseLockSchema = z.object({
-	declarationId: z.string(),
-});
-
-export const getLockStateSchema = z.object({
-	declarationId: z.string(),
-});

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
@@ -1,7 +1,7 @@
-import type { LockHolder } from "./useDeclarationLock";
+import type { LockHolderDisplay } from "./types";
 
 type DeclarationLockAlertProps = {
-	holder: Pick<LockHolder, "firstName" | "lastName" | "email">;
+	holder: LockHolderDisplay;
 };
 
 export function DeclarationLockAlert({ holder }: DeclarationLockAlertProps) {

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
@@ -4,19 +4,13 @@ import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
-import type { ReadOnlyReason } from "./useDeclarationLock";
+import type { LockHolderDisplay, ReadOnlyReason } from "./types";
 import { useDeclarationLock } from "./useDeclarationLock";
-
-export type LockHolder = {
-	firstName: string | null;
-	lastName: string | null;
-	email: string | null;
-};
 
 type LockState = {
 	isReadOnly: boolean;
 	reason: ReadOnlyReason | null;
-	holder: LockHolder | null;
+	holder: LockHolderDisplay | null;
 	isLoading?: boolean;
 };
 
@@ -30,7 +24,7 @@ type StaticLockProviderProps = {
 	children: ReactNode;
 	isReadOnly?: boolean;
 	reason?: ReadOnlyReason | null;
-	holder?: LockHolder | null;
+	holder?: LockHolderDisplay | null;
 	isLoading?: boolean;
 };
 

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/DeclarationModificationClosedAlert.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/DeclarationModificationClosedAlert.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { DeclarationLockState } from "../useDeclarationLock";
+import type { DeclarationLockState } from "../types";
 
 const contextState: DeclarationLockState = {
 	isReadOnly: false,

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/LockContext.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/LockContext.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { useSession } from "next-auth/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { DeclarationLockState } from "../useDeclarationLock";
+import type { DeclarationLockState } from "../types";
 
 const dynamicState: DeclarationLockState = {
 	isReadOnly: true,
@@ -15,12 +15,12 @@ vi.mock("../useDeclarationLock", () => ({
 	useDeclarationLock: vi.fn(() => dynamicState),
 }));
 
-import type { LockHolder } from "../LockContext";
 import {
 	LockProvider,
 	useLockContext,
 	useReadOnlyContext,
 } from "../LockContext";
+import type { LockHolderDisplay } from "../types";
 
 const mockedUseSession = vi.mocked(useSession);
 
@@ -35,7 +35,7 @@ function ContextProbe() {
 	);
 }
 
-const holder: LockHolder = {
+const holder: LockHolderDisplay = {
 	firstName: "Camille",
 	lastName: "Martin",
 	email: "camille.martin@example.fr",

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/schemas.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/schemas.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const acquireLockSchema = z.object({
+	declarationId: z.string(),
+});
+
+export const heartbeatSchema = z.object({
+	declarationId: z.string(),
+});
+
+export const releaseLockSchema = z.object({
+	declarationId: z.string(),
+});
+
+export const getLockStateSchema = z.object({
+	declarationId: z.string(),
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/types.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/types.ts
@@ -1,0 +1,23 @@
+import type { inferRouterOutputs } from "@trpc/server";
+
+import type { declarationLockRouter } from "~/server/api/routers/declarationLock";
+
+type DeclarationLockOutputs = inferRouterOutputs<typeof declarationLockRouter>;
+
+export type LockHolder = NonNullable<
+	DeclarationLockOutputs["getLockState"]["holder"]
+>;
+
+export type LockHolderDisplay = Pick<
+	LockHolder,
+	"firstName" | "lastName" | "email"
+>;
+
+export type ReadOnlyReason = "impersonation" | "modification_closed" | "lock";
+
+export type DeclarationLockState = {
+	isReadOnly: boolean;
+	reason: ReadOnlyReason | null;
+	holder: LockHolder | null;
+	isLoading: boolean;
+};

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/useDeclarationLock.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/useDeclarationLock.ts
@@ -8,20 +8,8 @@ import {
 	DECLARATION_LOCK_CONFLICT_MESSAGE,
 	LOCK_HEARTBEAT_INTERVAL_MS,
 } from "~/modules/domain";
-import { api, type RouterOutputs } from "~/trpc/react";
-
-export type LockHolder = NonNullable<
-	RouterOutputs["declarationLock"]["getLockState"]["holder"]
->;
-
-export type ReadOnlyReason = "impersonation" | "modification_closed" | "lock";
-
-export type DeclarationLockState = {
-	isReadOnly: boolean;
-	reason: ReadOnlyReason | null;
-	holder: LockHolder | null;
-	isLoading: boolean;
-};
+import { api } from "~/trpc/react";
+import type { DeclarationLockState, LockHolder, ReadOnlyReason } from "./types";
 
 type UseDeclarationLockOptions = {
 	declarationId: string;

--- a/packages/app/src/modules/referents/types.ts
+++ b/packages/app/src/modules/referents/types.ts
@@ -1,8 +1,12 @@
-import type { RouterOutputs } from "~/trpc/react";
+import type { inferRouterOutputs } from "@trpc/server";
+
+import type { publicReferentsRouter } from "~/server/api/routers/publicReferents";
+
+type PublicReferentsOutputs = inferRouterOutputs<typeof publicReferentsRouter>;
 
 export type PublicReferentListRow =
-	RouterOutputs["publicReferents"]["search"]["rows"][number];
+	PublicReferentsOutputs["search"]["rows"][number];
 
 export type PublicReferentDetail = NonNullable<
-	RouterOutputs["publicReferents"]["getById"]
+	PublicReferentsOutputs["getById"]
 >;

--- a/packages/app/src/server/api/routers/adminDeclarations.ts
+++ b/packages/app/src/server/api/routers/adminDeclarations.ts
@@ -20,9 +20,9 @@ import {
 	cancelDeclarationSchema,
 	getDeclarationByIdSchema,
 	getRecapSchema,
+	releaseLockSchema,
 	searchDeclarationsSchema,
 } from "~/modules/admin/declarations/schemas";
-import { releaseLockSchema } from "~/modules/admin/schemas";
 import {
 	floorWorkforce,
 	getCurrentYear,

--- a/packages/app/src/server/api/routers/declarationHelpers.ts
+++ b/packages/app/src/server/api/routers/declarationHelpers.ts
@@ -1,6 +1,9 @@
 import { and, desc, eq, getTableColumns, lt } from "drizzle-orm";
-import type { GipMdsRow } from "~/modules/declaration-remuneration";
 import { computeIndicatorPercentages } from "~/modules/declaration-remuneration/shared/computeIndicatorPercentages";
+// Submodule import, not the barrel: the barrel re-exports `shared/lock/types`,
+// which derives from this router's own module — going through it would close a
+// type cycle that today only stays open because this import asks for one symbol.
+import type { GipMdsRow } from "~/modules/declaration-remuneration/shared/gipMdsMapping";
 import {
 	notCancelledCondition,
 	submittedDeclarationCondition,

--- a/packages/app/src/server/api/routers/declarationLock.ts
+++ b/packages/app/src/server/api/routers/declarationLock.ts
@@ -6,7 +6,7 @@ import {
 	getLockStateSchema,
 	heartbeatSchema,
 	releaseLockSchema,
-} from "~/modules/declaration-remuneration/schemas";
+} from "~/modules/declaration-remuneration/shared/lock/schemas";
 import { DEFAULT_LOCK_TIMEOUT_MINUTES, getCurrentYear } from "~/modules/domain";
 import {
 	companyProcedure,

--- a/packages/app/src/trpc/react.tsx
+++ b/packages/app/src/trpc/react.tsx
@@ -3,7 +3,6 @@
 import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { httpBatchStreamLink, loggerLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
-import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import SuperJSON from "superjson";
 
@@ -23,20 +22,6 @@ const getQueryClient = () => {
 };
 
 export const api = createTRPCReact<AppRouter>();
-
-/**
- * Inference helper for inputs.
- *
- * @example type HelloInput = RouterInputs['example']['hello']
- */
-export type RouterInputs = inferRouterInputs<AppRouter>;
-
-/**
- * Inference helper for outputs.
- *
- * @example type HelloOutput = RouterOutputs['example']['hello']
- */
-export type RouterOutputs = inferRouterOutputs<AppRouter>;
 
 export function TRPCReactProvider(props: { children: React.ReactNode }) {
 	const queryClient = getQueryClient();


### PR DESCRIPTION
Closes #2967

## Le ticket est périmé dans sa lettre

La demande visait le découpage d'un fichier de schémas global, `packages/app/src/server/api/routers/schemas.ts`. **Ce fichier n'existe plus** : la PR #3024 (`27ae60c06`, 19/03/2026) l'a dissous en schémas par domaine en introduisant la validation Zod partagée front ↔ back. Depuis, chaque schéma vit dans `src/modules/{domaine}/schemas.ts`, et `block-bad-patterns.sh` interdit explicitement `from "zod"` dans `src/server/api/routers/*.ts`. La règle demandée est déjà appliquée et outillée.

Restaient deux endroits où l'invariant « un router = ses propres types et schémas » n'était pas tenu.

## Volet A — types dérivés par router

`src/trpc/react.tsx` exposait `RouterInputs` / `RouterOutputs` dérivés de l'`AppRouter` **entier** : quatre modules y piochaient le type d'un seul router en traversant ce barrel global, et `RouterInputs` n'était importé nulle part. Les deux alias sont supprimés ; chaque module dérive son type depuis son propre router, dans son `types.ts` :

| Module | Router |
|---|---|
| `modules/referents/types.ts` | `publicReferentsRouter` |
| `modules/admin/referents/types.ts` | `adminReferentsRouter` |
| `modules/admin/declarations/types.ts` | `adminDeclarationsRouter` |
| `modules/declaration-remuneration/shared/lock/types.ts` (nouveau) | `declarationLockRouter` |

Au passage, trois clones manuels de `LockHolder` coexistaient à trois fichiers de distance — un type exporté sous le même nom dans `LockContext.tsx`, un `Pick` inline dans `DeclarationLockAlert.tsx`. Ils sont ralliés à un `LockHolderDisplay` nommé, dérivé du type du router. (`my-space/types.ts` porte un quatrième clone, laissé en place : il appartient à un autre module.)

## Volet B — un fichier de schémas par router

Deux fichiers étaient partagés entre deux routers voisins :

- `modules/admin/schemas.ts` servait `admin` **et** `adminDeclarations` → `releaseLockSchema` et son type partent vers `modules/admin/declarations/schemas.ts`, avec leur bloc de tests
- `modules/declaration-remuneration/schemas.ts` servait `declaration` **et** `declarationLock` → les quatre schémas de verrou partent vers `modules/declaration-remuneration/shared/lock/schemas.ts`, sur le modèle de `shared/draft/schemas.ts` qui sert déjà `declarationDraft`

Après découpe, chaque fichier de schémas n'est importé que par un seul router.

**La réciproque n'est pas atteignable** : `declaration.ts` importe à la fois `modules/declaration/schemas` et `modules/declaration-remuneration/schemas`, parce que ce router couvre deux domaines métier et que la convention impose `src/modules/{domaine}/schemas.ts`. Le corriger demanderait de scinder le router.

## Déplacements purs

Aucune règle de validation n'a changé — vérifié bit-à-bit contre `alpha`. À noter, deux `releaseLockSchema` homonymes coexistent désormais dans des fichiers distincts et restent volontairement différents : celui du backoffice contraint un UUID, celui du déclarant non.

Pas de test de parité router ↔ schémas ajouté : `tsc --noEmit` casse déjà en CI sur un import de schéma inexistant comme sur un type dérivé d'un router qui ne l'expose pas. Un second filet sur le même sujet ne ferait que diverger.
