### PR TITLE
fix(representation): #4413 — wording de l'encart de non-assujettissement

### DIFF
--- a/packages/app/src/e2e/declaration-representation.e2e.ts
+++ b/packages/app/src/e2e/declaration-representation.e2e.ts
@@ -537,11 +537,28 @@ test.describe("Représentation équilibrée — parcours non-assujetti", () => {
 		page,
 	}) => {
 		await page.goto(FUNNEL_ROOT);
-		await chooseRadio(page, /Moins de 1 000 salariés/);
 		await expect(
-			page.getByText(/Vous n'êtes pas assujetti à la publication/),
+			page.getByText(
+				"Indiquez si votre entreprise a employé au moins 1 000 salariés durant les trois derniers exercices consécutifs.",
+			),
 		).toBeVisible();
 
+		await chooseRadio(page, /Moins de 1 000 salariés/);
+
+		const notice = page
+			.locator("div.fr-background-alt--blue-france")
+			.filter({ hasText: "Votre entreprise n'est pas assujettie" });
+		await expect(notice.locator("p")).toHaveText([
+			"Votre entreprise n'est pas assujettie à la publication et à la déclaration des écarts éventuels de représentation entre les femmes et les hommes.",
+			"Vous pouvez cliquer sur valider pour confirmer.",
+		]);
+		// Two independent sentences, two paragraphs: the <br /> this wording replaced
+		// fabricated a structure that read as a single block.
+		await expect(notice.locator("br")).toHaveCount(0);
+		// The consigne no longer dates itself with the campaign year.
+		await expect(notice).not.toContainText(String(campaignYear));
+
+		await expect(page.getByRole("button", { name: "Suivant" })).toHaveCount(0);
 		await page.getByRole("button", { name: "Valider" }).click();
 		await page.waitForURL("**/mon-espace");
 	});
@@ -581,8 +598,12 @@ test.describe("Représentation équilibrée — parcours non-assujetti", () => {
 
 		const panel = page.locator(`#${PANEL_ID}`);
 		await expect(
-			panel.getByText(/Vous n'êtes pas assujetti à la publication/),
+			panel.getByText(
+				"Votre entreprise n'est pas assujettie à la publication et à la déclaration des écarts éventuels de représentation entre les femmes et les hommes.",
+			),
 		).toBeVisible();
+		// A follow-up view carries no Valider button, so it drops the funnel's second sentence.
+		await expect(panel.getByText(/cliquer sur valider/)).toHaveCount(0);
 		await expect(
 			panel.getByText("Vérification de l'assujettissement"),
 		).toBeVisible();

--- a/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
+++ b/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
@@ -53,8 +53,8 @@ export function SubjectionScreen({
 			<h2 className="fr-h6">L'entreprise est-elle concernée ?</h2>
 
 			<p className="fr-text-title--grey fr-mt-4w fr-mb-2w">
-				Indiquez si votre entreprise emploie au moins 1 000 salariés durant les
-				trois derniers exercices consécutifs.
+				Indiquez si votre entreprise a employé au moins 1 000 salariés durant
+				les trois derniers exercices consécutifs.
 			</p>
 			<p className="fr-text-title--grey fr-mb-2w">
 				Ce seuil détermine si votre entreprise est tenue de déclarer ses écarts
@@ -145,12 +145,13 @@ export function SubjectionScreen({
 
 				{answer === "not_concerned" ? (
 					<div className="fr-background-alt--blue-france fr-p-4w">
-						<p className="fr-mb-0">
-							Vous n'êtes pas assujetti à la publication et à la déclaration des
-							écarts éventuels de représentation entre les femmes et les hommes.
-							<br />
-							Vous pouvez valider pour achever votre déclaration de
-							représentation {campaignYear}.
+						<p className="fr-text-title--grey fr-mb-3w">
+							Votre entreprise n'est pas assujettie à la publication et à la
+							déclaration des écarts éventuels de représentation entre les
+							femmes et les hommes.
+						</p>
+						<p className="fr-text-title--grey fr-mb-0">
+							Vous pouvez cliquer sur valider pour confirmer.
 						</p>
 					</div>
 				) : null}

--- a/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
@@ -164,7 +164,9 @@ describe("RepresentationHomePage", () => {
 			}),
 		).toBeChecked();
 		expect(
-			screen.getByText(/Vous n'êtes pas assujetti à la publication/),
+			screen.getByText(
+				/Votre entreprise n'est pas assujettie à la publication/,
+			),
 		).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Valider" })).toBeInTheDocument();
 	});

--- a/packages/app/src/modules/declaration-representation/__tests__/SubjectionScreen.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/SubjectionScreen.test.tsx
@@ -50,9 +50,10 @@ import { SubjectionScreen } from "../SubjectionScreen";
 const STEP_1_HREF = "/declaration-representation/etape/1";
 const MY_SPACE_HREF = "/mon-espace";
 const SELECTION_ERROR = "Veuillez sélectionner une option pour continuer.";
-const NOT_CONCERNED_INFO = /Vous n'êtes pas assujetti à la publication/;
+const NOT_CONCERNED_INFO =
+	/Votre entreprise n'est pas assujettie à la publication/;
 const SUBJECTION_QUESTION =
-	/Indiquez si votre entreprise emploie au moins 1 000 salariés/;
+	/Indiquez si votre entreprise a employé au moins 1 000 salariés/;
 const SUBJECTION_FIELDSET_NAME = /Nombre de salariés de l'entreprise/;
 
 function renderScreen(initialAnswer?: "concerned" | "not_concerned") {

--- a/packages/app/src/modules/my-space/RepresentationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/RepresentationProcessPanel.tsx
@@ -288,8 +288,9 @@ function NotSubjectMessage() {
 	return (
 		<div className="fr-background-alt--blue-france fr-p-4w">
 			<p className={`fr-mb-0 ${styles.notSubjectMessage}`}>
-				Vous n'êtes pas assujetti à la publication et à la déclaration des
-				écarts éventuels de représentation entre les femmes et les hommes.
+				Votre entreprise n'est pas assujettie à la publication et à la
+				déclaration des écarts éventuels de représentation entre les femmes et
+				les hommes.
 			</p>
 		</div>
 	);

--- a/packages/app/src/modules/my-space/__tests__/RepresentationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/RepresentationProcessPanel.test.tsx
@@ -64,7 +64,7 @@ const NOT_SUBJECT = makeDeclaration({
 });
 
 const NOT_SUBJECT_MESSAGE =
-	"Vous n'êtes pas assujetti à la publication et à la déclaration des écarts éventuels de représentation entre les femmes et les hommes.";
+	"Votre entreprise n'est pas assujettie à la publication et à la déclaration des écarts éventuels de représentation entre les femmes et les hommes.";
 
 function renderPanel({
 	campaign = OPEN_CAMPAIGN,


### PR DESCRIPTION
Closes #4413

## Contexte

L'encart affiché sur la page Assujettissement du parcours Répartition équilibrée quand l'entreprise déclare moins de 1 000 salariés portait un wording daté : assujettissement porté sur la personne connectée, deux phrases collées via un `<br />`, mention de l'année de campagne. Spec : commentaire [`## Analyse architecte`](https://github.com/SocialGouv/egapro/issues/4413#issuecomment-5587428869) de #4413.

## Changements

- `SubjectionScreen.tsx` — l'encart `answer === "not_concerned"` passe de « Vous n'êtes pas assujetti… `<br />` Vous pouvez valider pour achever votre déclaration de représentation {campaignYear}. » à deux `<p>` distincts (`fr-text-title--grey fr-mb-3w` puis `fr-text-title--grey fr-mb-0`, 24 px d'écart) centrés sur l'entreprise, sans mention d'année. `campaignYear` reste consommé par le `<h1>`.
- `SubjectionScreen.tsx` — le paragraphe d'introduction passe de « emploie » à « a employé ».
- `RepresentationProcessPanel.tsx` (`NotSubjectMessage`) — reprend la première phrase reformulée seule (pas de bouton Valider dans ce contexte), structure et classes inchangées.
- Tests unitaires mis à jour dans les 3 fichiers concernés (`SubjectionScreen.test.tsx`, `RepresentationRoutes.test.tsx`, `RepresentationProcessPanel.test.tsx`) — assertions sur le texte exact, aucun affaiblissement.

## Vérification

Vérifié en direct sur le dev server local (session `dev-auth`, entreprise fictive `SIREN 123456789`) :

**Écran Assujettissement, réponse « Moins de 1 000 salariés » :**
> Votre entreprise n'est pas assujettie à la publication et à la déclaration des écarts éventuels de représentation entre les femmes et les hommes.
>
> Vous pouvez cliquer sur valider pour confirmer.

— deux `<p>` distincts, aucun `<br />`, aucune année de campagne, wording « cliquer » conservé (écart Figma assumé, cf. analyse).

**Mon espace, panneau Représentation (déclaration non-assujettie) :**
> Votre entreprise n'est pas assujettie à la publication et à la déclaration des écarts éventuels de représentation entre les femmes et les hommes.

— une phrase seule, pas de mention du bouton Valider.

Suite complète : `pnpm typecheck` + `pnpm test` (474 fichiers / 6090 tests) verts.

## Hors périmètre (pour `e2e-dev`)

Deux locators Playwright deviennent caducs avec le nouveau texte : `src/e2e/declaration-representation.e2e.ts:542` et `:584`. Non touchés ici, propriété `e2e-dev`.
