### PR TITLE
fix(repeq): #4414 — encart de rappel manquant à l'étape Instances dirigeantes

### DIFF
--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -172,3 +172,13 @@ Déclarées et validées dans `src/env.js` (`@t3-oss/env-nextjs` + Zod). **Jamai
 Ajouter une variable = 4 gestes : la déclarer dans `src/env.js` (section `server` ou `client`), l'ajouter à `runtimeEnv`, l'ajouter au `.env` local, **et l'ajouter à la config de déploiement `.kontinuous/`**. Il n'y a pas de configmap unique « egapro » : le conteneur app monte ses variables via `app.envFrom` / `app.env` de `.kontinuous/values.yaml`, chaque bloc pointant vers une configmap ou une sealed-secret **par sujet** (`proconnect`, `mail`, `s3`, `api`, `matomo`…) définie sous `.kontinuous/env/{dev,preprod,prod}/templates/<sujet>.{configmap,sealed-secret}.yaml`. Une valeur publique va dans la configmap du sujet, un secret dans sa sealed-secret.
 
 > `SKIP_ENV_VALIDATION=1` contourne la validation (build Docker, CI sans secrets).
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/packages/app/src/e2e/declaration-representation.e2e.ts
+++ b/packages/app/src/e2e/declaration-representation.e2e.ts
@@ -248,6 +248,11 @@ test.describe("Représentation équilibrée — parcours déclaratif complet", (
 			await expect(
 				page.getByText("Non conforme", { exact: true }),
 			).toBeVisible();
+			await expect(
+				page.getByText(
+					`Objectif de ${getRepresentationTarget(campaignYear)} % non atteint`,
+				),
+			).toBeVisible();
 
 			await goNext(page);
 		});

--- a/packages/app/src/modules/declaration-representation/index.ts
+++ b/packages/app/src/modules/declaration-representation/index.ts
@@ -26,6 +26,7 @@ export {
 	useRepresentationDraftContext,
 } from "./shared/draft/DraftContext";
 export { useRepresentationDraft } from "./shared/draft/useRepresentationDraft";
+export { GapReminderCallout } from "./shared/GapReminderCallout";
 export type { PercentagePairValues } from "./shared/PercentagePairFields";
 export {
 	complementPercentage,

--- a/packages/app/src/modules/declaration-representation/shared/GapReminderCallout.module.scss
+++ b/packages/app/src/modules/declaration-representation/shared/GapReminderCallout.module.scss
@@ -1,0 +1,17 @@
+.reminderCompliant:global(.fr-callout) {
+	background-color: var(--background-contrast-info);
+	background-image: linear-gradient(
+		0deg,
+		var(--text-default-info),
+		var(--text-default-info)
+	);
+}
+
+.reminderNonCompliant:global(.fr-callout) {
+	background-color: var(--background-contrast-warning);
+	background-image: linear-gradient(
+		0deg,
+		var(--text-default-warning),
+		var(--text-default-warning)
+	);
+}

--- a/packages/app/src/modules/declaration-representation/shared/GapReminderCallout.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/GapReminderCallout.tsx
@@ -1,0 +1,48 @@
+import {
+	getRepresentationTarget,
+	REPRESENTATION_OBLIGATION_FROM_CAMPAIGN_YEAR,
+	REPRESENTATION_TARGET_INITIAL,
+	REPRESENTATION_TARGET_RAISED,
+	REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR,
+} from "~/modules/domain";
+import styles from "./GapReminderCallout.module.scss";
+
+type GapReminderCalloutProps = {
+	campaignYear: number;
+	populationLabel: string;
+	verdict: "compliant" | "non_compliant";
+};
+
+function gapReminderTitle(
+	verdict: "compliant" | "non_compliant",
+	target: number,
+): string {
+	return verdict === "compliant"
+		? `Objectif de ${target} % atteint`
+		: `Objectif de ${target} % non atteint`;
+}
+
+export function GapReminderCallout({
+	campaignYear,
+	populationLabel,
+	verdict,
+}: GapReminderCalloutProps) {
+	const target = getRepresentationTarget(campaignYear);
+	const reminderClassName =
+		verdict === "compliant"
+			? styles.reminderCompliant
+			: styles.reminderNonCompliant;
+
+	return (
+		<div className={`fr-callout ${reminderClassName}`}>
+			<p className="fr-callout__text">
+				<strong>{gapReminderTitle(verdict, target)}</strong> Depuis le 1er mars{" "}
+				{REPRESENTATION_OBLIGATION_FROM_CAMPAIGN_YEAR}, le sexe sous-représenté
+				doit représenter au moins {REPRESENTATION_TARGET_INITIAL} %{" "}
+				{populationLabel}. À partir du 1er mars{" "}
+				{REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR}, ce seuil passera à{" "}
+				{REPRESENTATION_TARGET_RAISED} %.
+			</p>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/shared/__tests__/GapReminderCallout.test.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/__tests__/GapReminderCallout.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR } from "~/modules/domain";
+import { GapReminderCallout } from "../GapReminderCallout";
+
+const RAISED_TARGET_YEAR = REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR;
+const INITIAL_TARGET_YEAR = RAISED_TARGET_YEAR - 1;
+
+describe("GapReminderCallout", () => {
+	it("renders the compliant variant with the given population label", () => {
+		render(
+			<GapReminderCallout
+				campaignYear={INITIAL_TARGET_YEAR}
+				populationLabel="des cadres dirigeants"
+				verdict="compliant"
+			/>,
+		);
+
+		expect(screen.getByText("Objectif de 30 % atteint")).toBeInTheDocument();
+		expect(
+			screen.getByText(/au moins 30 % des cadres dirigeants/),
+		).toBeInTheDocument();
+	});
+
+	it("renders the non-compliant variant with the given population label", () => {
+		render(
+			<GapReminderCallout
+				campaignYear={INITIAL_TARGET_YEAR}
+				populationLabel="des membres des instances dirigeantes"
+				verdict="non_compliant"
+			/>,
+		);
+
+		expect(
+			screen.getByText("Objectif de 30 % non atteint"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/au moins 30 % des membres des instances dirigeantes/),
+		).toBeInTheDocument();
+	});
+
+	it("reflects the raised threshold once the campaign reaches it", () => {
+		render(
+			<GapReminderCallout
+				campaignYear={RAISED_TARGET_YEAR}
+				populationLabel="des membres des instances dirigeantes"
+				verdict="non_compliant"
+			/>,
+		);
+
+		expect(
+			screen.getByText("Objectif de 40 % non atteint"),
+		).toBeInTheDocument();
+	});
+
+	it("always mentions the raised threshold and the campaign it takes effect from", () => {
+		render(
+			<GapReminderCallout
+				campaignYear={INITIAL_TARGET_YEAR}
+				populationLabel="des cadres dirigeants"
+				verdict="compliant"
+			/>,
+		);
+
+		expect(
+			screen.getByText(
+				new RegExp(`${RAISED_TARGET_YEAR}.*ce seuil passera à 40 %`, "s"),
+			),
+		).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/declaration-representation/steps/Step2Executives.module.scss
+++ b/packages/app/src/modules/declaration-representation/steps/Step2Executives.module.scss
@@ -24,21 +24,3 @@
 	border-left: 2px solid var(--border-plain-error);
 	padding-left: 1rem;
 }
-
-.reminderCompliant:global(.fr-callout) {
-	background-color: var(--background-contrast-info);
-	background-image: linear-gradient(
-		0deg,
-		var(--text-default-info),
-		var(--text-default-info)
-	);
-}
-
-.reminderNonCompliant:global(.fr-callout) {
-	background-color: var(--background-contrast-warning);
-	background-image: linear-gradient(
-		0deg,
-		var(--text-default-warning),
-		var(--text-default-warning)
-	);
-}

--- a/packages/app/src/modules/declaration-representation/steps/Step2Executives.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step2Executives.tsx
@@ -9,7 +9,6 @@ import type {
 import {
 	computeRepresentationVerdict,
 	getRepresentationCampaignYear,
-	getRepresentationTarget,
 	REPRESENTATION_TARGET_INITIAL,
 	REPRESENTATION_TARGET_RAISED,
 	REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR,
@@ -17,6 +16,7 @@ import {
 import { executivesSchema } from "../schemas";
 import { ComplianceBadge } from "../shared/ComplianceBadge";
 import { useRepresentationDraftContext } from "../shared/draft/DraftContext";
+import { GapReminderCallout } from "../shared/GapReminderCallout";
 import type { PercentagePairValues } from "../shared/PercentagePairFields";
 import {
 	formatPercentInput,
@@ -76,15 +76,6 @@ function evaluateExecutivesGap(
 			campaignYear,
 		),
 	};
-}
-
-function gapReminderTitle(
-	verdict: "compliant" | "non_compliant",
-	target: number,
-): string {
-	return verdict === "compliant"
-		? `Objectif de ${target} % atteint`
-		: `Objectif de ${target} % non atteint`;
 }
 
 type ExecutiveCountOptionProps = {
@@ -162,11 +153,6 @@ export function Step2Executives() {
 	);
 	const knownVerdict: "compliant" | "non_compliant" | null =
 		verdict === "compliant" || verdict === "non_compliant" ? verdict : null;
-	const target = getRepresentationTarget(campaignYear);
-	const reminderClassName =
-		knownVerdict === "compliant"
-			? styles.reminderCompliant
-			: styles.reminderNonCompliant;
 	const isStepValid =
 		hasSelection &&
 		(draft.executivesCount !== "two_or_more" || knownVerdict !== null);
@@ -249,16 +235,11 @@ export function Step2Executives() {
 					/>
 					<div aria-atomic="true" aria-live="polite" className="fr-mt-2w">
 						{knownVerdict ? (
-							<div className={`fr-callout ${reminderClassName}`}>
-								<p className="fr-callout__text">
-									<strong>{gapReminderTitle(knownVerdict, target)}</strong>{" "}
-									Depuis le 1er mars 2026, le sexe sous-représenté doit
-									représenter au moins {REPRESENTATION_TARGET_INITIAL} % des
-									cadres dirigeants. À partir du 1er mars{" "}
-									{REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR}, ce seuil
-									passera à {REPRESENTATION_TARGET_RAISED} %.
-								</p>
-							</div>
+							<GapReminderCallout
+								campaignYear={campaignYear}
+								populationLabel="des cadres dirigeants"
+								verdict={knownVerdict}
+							/>
 						) : null}
 					</div>
 				</div>

--- a/packages/app/src/modules/declaration-representation/steps/Step3Members.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step3Members.tsx
@@ -13,6 +13,7 @@ import {
 import { membersSchema } from "../schemas";
 import { ComplianceBadge } from "../shared/ComplianceBadge";
 import { useRepresentationDraftContext } from "../shared/draft/DraftContext";
+import { GapReminderCallout } from "../shared/GapReminderCallout";
 import type { PercentagePairValues } from "../shared/PercentagePairFields";
 import {
 	formatPercentInput,
@@ -199,14 +200,21 @@ export function Step3Members() {
 						onChange={handlePercentageChange}
 						readOnly={isReadOnly}
 						trailingContent={
-							<div aria-atomic="true" aria-live="polite">
-								{decidedVerdict ? (
-									<ComplianceBadge verdict={decidedVerdict} />
-								) : null}
-							</div>
+							decidedVerdict ? (
+								<ComplianceBadge verdict={decidedVerdict} />
+							) : undefined
 						}
 						values={percentageValues}
 					/>
+					<div aria-atomic="true" aria-live="polite" className="fr-mt-2w">
+						{decidedVerdict ? (
+							<GapReminderCallout
+								campaignYear={campaignYear}
+								populationLabel="des membres des instances dirigeantes"
+								verdict={decidedVerdict}
+							/>
+						) : null}
+					</div>
 				</div>
 			) : null}
 

--- a/packages/app/src/modules/declaration-representation/steps/__tests__/Step3Members.test.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/__tests__/Step3Members.test.tsx
@@ -305,7 +305,56 @@ describe("Step3Members — verdict de conformité (S13–S15)", () => {
 
 		expect(screen.getByText("Non conforme")).toBeInTheDocument();
 	});
+});
 
+describe("Step3Members — rappel réglementaire", () => {
+	it("affiche l'encart bleu de rappel quand l'écart est conforme", () => {
+		render(<Harness draft={COMPUTABLE_MEMBERS} />);
+
+		expect(screen.getByText("Objectif de 30 % atteint")).toBeInTheDocument();
+		expect(
+			screen.getByText(/au moins 30 % des membres des instances dirigeantes/),
+		).toBeInTheDocument();
+	});
+
+	it("affiche l'encart orange de rappel quand l'écart est non conforme", () => {
+		render(<Harness draft={NON_COMPLIANT_MEMBERS} />);
+
+		expect(
+			screen.getByText("Objectif de 30 % non atteint"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/au moins 30 % des membres des instances dirigeantes/),
+		).toBeInTheDocument();
+	});
+
+	it("n'utilise pas le libellé de population de l'étape cadres dirigeants", () => {
+		render(<Harness draft={NON_COMPLIANT_MEMBERS} />);
+
+		expect(screen.queryByText(/des cadres dirigeants/)).not.toBeInTheDocument();
+	});
+
+	it("n'affiche pas l'encart tant que le verdict n'est pas décidé", () => {
+		render(<Harness draft={{ hasManagementBody: true }} />);
+
+		expect(screen.queryByText(/Objectif de 30 %/)).not.toBeInTheDocument();
+	});
+
+	it("annonce le rappel dans une unique région live polie, sans doublon sur le badge", () => {
+		render(<Harness draft={NON_COMPLIANT_MEMBERS} />);
+
+		const liveRegions = document.querySelectorAll('[aria-live="polite"]');
+		const reminderLiveRegions = [...liveRegions].filter((region) =>
+			region.textContent?.includes("Objectif de 30 %"),
+		);
+		expect(reminderLiveRegions).toHaveLength(1);
+		expect(
+			screen.getByText("Non conforme").closest('[aria-live="polite"]'),
+		).toBeNull();
+	});
+});
+
+describe("Step3Members — verdict de conformité (campagne)", () => {
 	it("applique le seuil relevé à partir de la campagne concernée", () => {
 		const { rerender } = render(
 			<Harness draft={BETWEEN_TARGETS_MEMBERS} year={REPRESENTATION_YEAR} />,


### PR DESCRIPTION
Closes #4414

## Résumé

L'étape 3 du parcours « Écarts de représentation » (Instances dirigeantes) affichait le badge de conformité mais pas l'encart `fr-callout` de rappel du seuil réglementaire, contrairement à l'étape 2 (Cadres dirigeants). Le verdict était déjà calculé correctement (`computeRepresentationVerdict`) — seul l'encart explicatif manquait.

- Extraction d'un composant partagé `GapReminderCallout` (`shared/`), paramétré par le libellé de population, consommé par `Step2Executives` et `Step3Members` — évite de dupliquer le helper de titre, le JSX du callout et les deux classes SCSS entre les deux étapes.
- Étape 3 : le texte est adapté à la population (« … au moins 30 % des membres des instances dirigeantes », pas « des cadres dirigeants »).
- L'encart s'affiche dans les deux cas (variante bleue « Objectif atteint » / orange « Objectif non atteint »), comme à l'étape 2.
- La région `aria-live="polite"` est déplacée du badge (qui n'en a plus besoin) vers l'encart, alignée sur la structure de l'étape 2 — une seule région live annonce le changement, pas deux.
- Le seuil vient de `getRepresentationTarget` / `REPRESENTATION_TARGET_*` / `REPRESENTATION_OBLIGATION_FROM_CAMPAIGN_YEAR` (`~/modules/domain`) — aucune valeur en dur.

## Vérification

Vérification one-shot exécutée sur le dev server (worktree, port 3020), parcours complet (dev-login → subjection → étapes 1-2-3) :

- **Avant le fix** (code reverté via patch) : à l'étape 3, seul le badge « Non conforme » s'affichait pour un couple 20 % / 80 %, aucun encart.
- **Après le fix** : encart orange « Objectif de 30 % non atteint … au moins 30 % des membres des instances dirigeantes … » pour 20 % / 80 %, encart bleu « Objectif de 30 % atteint » pour 45 % / 55 %. Étape 2 revisitée ensuite (20 % / 80 %, cadres dirigeants) : comportement inchangé, encart correct avec le libellé « des cadres dirigeants ».
- Revert-verify du test de non-régression : les 3 assertions ajoutées sur l'encart échouent (RED) sur le code sans le fix, passent (GREEN) une fois le fix réappliqué.

## Tests

- `shared/__tests__/GapReminderCallout.test.tsx` (nouveau) : variantes conforme/non conforme, libellé de population, seuil relevé selon la campagne.
- `steps/__tests__/Step3Members.test.tsx` : nouveau bloc « rappel réglementaire » (présence de l'encart dans les deux variantes, libellé correct, absence tant que le verdict n'est pas décidé, une seule région live).
- Aucun test E2E ajouté (hors périmètre `code-dev`).

## Gates

- `validator` : PASS (typecheck, test, lint, format)
- `structural-auditor` : MINOR → corrigé (année 2026 recablée sur `REPRESENTATION_OBLIGATION_FROM_CAMPAIGN_YEAR`, export du composant ajouté au barrel du module)
- `rgaa-auditor` : PASS (structure aria-live vérifiée — une seule région live, pas de doublon)
