### PR TITLE
fix(repeq): #4419 — libellé du verdict non calculable

### DIFF
--- a/packages/app/src/e2e/declaration-representation.e2e.ts
+++ b/packages/app/src/e2e/declaration-representation.e2e.ts
@@ -485,7 +485,7 @@ test.describe("Représentation équilibrée — écarts non calculables", () => 
 		);
 		await expect(page.getByText("Aucun cadre dirigeant")).toBeVisible();
 		await expect(page.getByText("Aucune instance dirigeante")).toBeVisible();
-		await expect(page.getByText("Non applicable").first()).toBeVisible();
+		await expect(page.getByText("Non calculable").first()).toBeVisible();
 		await expect(
 			page.getByRole("heading", { name: "Publication" }),
 		).toHaveCount(0);

--- a/packages/app/src/modules/declaration-representation/shared/ComplianceBadge.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/ComplianceBadge.tsx
@@ -14,7 +14,7 @@ const BADGE_BY_VERDICT: Record<
 	},
 	not_applicable: {
 		className: "fr-badge fr-badge--sm fr-badge--no-icon",
-		label: "Non applicable",
+		label: "Non calculable",
 	},
 };
 

--- a/packages/app/src/modules/declaration-representation/shared/__tests__/ComplianceBadge.test.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/__tests__/ComplianceBadge.test.tsx
@@ -7,7 +7,7 @@ import { ComplianceBadge } from "../ComplianceBadge";
 const CASES: Array<[RepresentationComplianceVerdict, string, string]> = [
 	["compliant", "Conforme", "fr-badge--info"],
 	["non_compliant", "Non conforme", "fr-badge--warning"],
-	["not_applicable", "Non applicable", ""],
+	["not_applicable", "Non calculable", ""],
 ];
 
 describe("ComplianceBadge", () => {
@@ -24,7 +24,7 @@ describe("ComplianceBadge", () => {
 	it("keeps the not_applicable badge neutral", () => {
 		render(<ComplianceBadge verdict="not_applicable" />);
 
-		const badge = screen.getByText("Non applicable");
+		const badge = screen.getByText("Non calculable");
 		expect(badge).not.toHaveClass("fr-badge--info");
 		expect(badge).not.toHaveClass("fr-badge--warning");
 	});

--- a/packages/app/src/modules/declaration-representation/steps/__tests__/Step3Members.test.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/__tests__/Step3Members.test.tsx
@@ -109,7 +109,7 @@ function percentageFields() {
 }
 
 function queryBadge() {
-	return screen.queryByText(/^(Conforme|Non conforme|Non applicable)$/);
+	return screen.queryByText(/^(Conforme|Non conforme|Non calculable)$/);
 }
 
 function spy() {

--- a/packages/app/src/modules/declaration-representation/steps/__tests__/Step5Review.restitution.test.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/__tests__/Step5Review.restitution.test.tsx
@@ -71,7 +71,7 @@ function nextStepsSection(): HTMLElement {
 }
 
 function complianceBadges() {
-	return screen.queryAllByText(/^(Conforme|Non conforme|Non applicable)$/, {
+	return screen.queryAllByText(/^(Conforme|Non conforme|Non calculable)$/, {
 		selector: "p.fr-badge",
 	});
 }
@@ -205,7 +205,7 @@ describe("Step5Review — verdicts par indicateur (S16)", () => {
 		expect(executives.getByText("Femmes").nextElementSibling).toHaveTextContent(
 			"—",
 		);
-		expect(indicatorCard(EXECUTIVES_TITLE)).toHaveTextContent("Non applicable");
+		expect(indicatorCard(EXECUTIVES_TITLE)).toHaveTextContent("Non calculable");
 	});
 });
 
@@ -220,8 +220,8 @@ describe("Step5Review — écarts non calculables (S12)", () => {
 			"Aucune instance dirigeante",
 		);
 		expect(complianceBadges()).toHaveLength(2);
-		expect(indicatorCard(EXECUTIVES_TITLE)).toHaveTextContent("Non applicable");
-		expect(indicatorCard(MEMBERS_TITLE)).toHaveTextContent("Non applicable");
+		expect(indicatorCard(EXECUTIVES_TITLE)).toHaveTextContent("Non calculable");
+		expect(indicatorCard(MEMBERS_TITLE)).toHaveTextContent("Non calculable");
 		expect(
 			screen.queryByRole("heading", { name: "Publication" }),
 		).not.toBeInTheDocument();

--- a/packages/app/src/modules/declarationPdf/RepresentationPdfDocument.tsx
+++ b/packages/app/src/modules/declarationPdf/RepresentationPdfDocument.tsx
@@ -18,7 +18,7 @@ type Props = {
 const VERDICT_LABELS = {
 	compliant: "Conforme",
 	non_compliant: "Non conforme",
-	not_applicable: "Non applicable",
+	not_applicable: "Non calculable",
 } as const;
 
 function formatOptionalDate(value: string | null): string {

--- a/packages/app/src/modules/declarationPdf/__tests__/RepresentationPdfDocument.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/RepresentationPdfDocument.test.tsx
@@ -142,7 +142,7 @@ describe("RepresentationPdfDocument", () => {
 
 		expect(screen.getByText("Aucun cadre dirigeant")).toBeInTheDocument();
 		expect(screen.queryByText("Femmes")).not.toBeInTheDocument();
-		expect(screen.getByText("Verdict : Non applicable")).toBeInTheDocument();
+		expect(screen.getByText("Verdict : Non calculable")).toBeInTheDocument();
 	});
 
 	it("renders the publication page address when the company has a website", () => {


### PR DESCRIPTION
Closes #4419

## Résumé

Remplace le libellé « Non applicable » par « Non calculable » pour le verdict `not_applicable` des indicateurs de représentation équilibrée. Ce verdict est produit dès qu'un des deux pourcentages n'est pas calculable — pas quand l'indicateur est hors périmètre — le libellé décrivait donc mal la situation qu'il représente.

Fichiers modifiés :
- `packages/app/src/modules/declaration-representation/shared/ComplianceBadge.tsx` (`BADGE_BY_VERDICT`) — badge de l'étape 5 (récapitulatif)
- `packages/app/src/modules/declarationPdf/RepresentationPdfDocument.tsx` (`VERDICT_LABELS`) — même libellé dans le PDF du récapitulatif

La clé `not_applicable` et le type `RepresentationComplianceVerdict` sont inchangés : c'est un libellé d'affichage, pas une règle métier.

Hors périmètre (volontairement non modifié) :
- `RepresentationPdfDocument.tsx:131` — « Non applicable — aucun écart calculable » qualifie le bloc Publication, qui reste juste
- les mentions « Non applicable » de `declaration-remuneration/**` (autre parcours)
- `src/e2e/declaration-representation.e2e.ts:488` — assertion E2E existante à réaligner, du ressort d'`e2e-dev`

## Vérification

**One-shot (dev server)** : parcours représentation équilibrée d'une entreprise sans cadre dirigeant ni instance dirigeante (les deux pourcentages restent `null`), `/declaration-representation/etape/5`.

| | Avant | Après |
|---|---|---|
| Badge « Cadres dirigeants » | NON APPLICABLE | **NON CALCULABLE** |
| Badge « Membres des instances dirigeantes » | NON APPLICABLE | **NON CALCULABLE** |

**Tests** : `pnpm test` vert (6090/6090). Assertions réalignées dans `ComplianceBadge.test.tsx`, `Step5Review.restitution.test.tsx`, `Step3Members.test.tsx`, `RepresentationPdfDocument.test.tsx`.

## Screenshots

Captures avant/après faites en local sur `/declaration-representation/etape/5` (voir tableau ci-dessus pour le texte exact relevé) — pas d'upload GitHub disponible depuis cette session headless ; le contenu observé est consigné textuellement ci-dessus.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (6090/6090)
- [x] Vérification manuelle sur dev server (avant/après, voir ci-dessus)
- [x] validator / structural-auditor / rgaa-auditor / security-auditor
