### PR TITLE
fix(repeq): #4422 — objet et formulation d'année de l'accusé de réception

### DIFF
--- a/packages/app/src/e2e/notifications-email-flow.e2e.ts
+++ b/packages/app/src/e2e/notifications-email-flow.e2e.ts
@@ -161,7 +161,7 @@ test.describe("notifications email flow (publisher → pg-boss → worker → SM
 		await test.step("first-declaration receipt states the round-1 path-choice deadline in French (#4207)", async () => {
 			const firstReceipt = await waitForEmail(
 				TEST_USER_EMAIL,
-				(m) => /Transmission de la déclaration/i.test(m.subject),
+				(m) => m.subject === "Egapro - Transmission de la déclaration",
 				{ since: startedAt },
 			);
 			// Round 1 is July 1st, not the round-2 January deadline.

--- a/packages/app/src/modules/declarationPdf/RepresentationPdfDocument.tsx
+++ b/packages/app/src/modules/declarationPdf/RepresentationPdfDocument.tsx
@@ -68,9 +68,7 @@ export function RepresentationPdfDocument({ data }: Props) {
 					<Text style={styles.title}>
 						Démarche des indicateurs de représentation {data.campaignYear}
 					</Text>
-					<Text style={styles.subtitle}>
-						Au titre de la période de référence {data.year}
-					</Text>
+					<Text style={styles.subtitle}>Au titre des données {data.year}</Text>
 					<Text style={styles.companyInfo}>
 						{data.companyName} — SIREN {data.siren}
 					</Text>

--- a/packages/app/src/modules/declarationPdf/__tests__/RepresentationPdfDocument.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/RepresentationPdfDocument.test.tsx
@@ -90,9 +90,10 @@ describe("RepresentationPdfDocument", () => {
 		expect(
 			screen.getByText("Démarche des indicateurs de représentation 2026"),
 		).toBeInTheDocument();
+		expect(screen.getByText("Au titre des données 2025")).toBeInTheDocument();
 		expect(
-			screen.getByText("Au titre de la période de référence 2025"),
-		).toBeInTheDocument();
+			screen.queryByText("Au titre de la période de référence 2025"),
+		).not.toBeInTheDocument();
 		expect(
 			screen.getByText("Société Représentation — SIREN 123456789"),
 		).toBeInTheDocument();

--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -300,15 +300,19 @@ describe("per-type rendering details", () => {
 		});
 
 		expect(mail.subject).toBe(
-			"Egapro - Représentation équilibrée : accusé de réception",
+			"Egapro - Transmission de la déclaration de la représentation équilibrée",
 		);
 		expect(mail.html).toContain(
 			"la déclaration des indicateurs de représentation équilibrée",
 		);
+		expect(mail.html).toContain("pour l&#x27;année");
+		expect(mail.html).toContain("2028");
+		expect(mail.html).toContain("au titre des données");
+		expect(mail.html).toContain(String(YEAR));
+		expect(mail.html).not.toContain("période de référence");
 		expect(mail.html).toContain(RAISON_SOCIALE);
 		expect(mail.html).toContain("SIREN :");
 		expect(mail.html).toContain(SIREN);
-		expect(mail.html).toContain(String(YEAR));
 		expect(mail.html).toContain("accuse réception de cette transmission");
 		expect(mail.html).toContain("démarche est désormais terminée");
 	});

--- a/packages/notifications/src/mails/builders/representationReceipt.tsx
+++ b/packages/notifications/src/mails/builders/representationReceipt.tsx
@@ -1,3 +1,4 @@
+import { getRepresentationCampaignYear } from "../shared/campaign.js";
 import { renderEmail } from "../shared/render.js";
 import { getMySpaceUrl } from "../shared/urls.js";
 import {
@@ -14,9 +15,11 @@ import type { MailBuilder } from "../types.js";
 export const buildRepresentationReceiptMail: MailBuilder<
 	"representation_receipt"
 > = async ({ siren, year, raisonSociale }) => {
-	const subject = "Egapro - Représentation équilibrée : accusé de réception";
+	const subject =
+		"Egapro - Transmission de la déclaration de la représentation équilibrée";
 	const previewText =
 		"L'administration du travail accuse réception de votre déclaration des indicateurs de représentation équilibrée.";
+	const campaignYear = getRepresentationCampaignYear(year);
 
 	const { html, text } = await renderEmail(
 		<EmailShell previewText={previewText}>
@@ -26,8 +29,8 @@ export const buildRepresentationReceiptMail: MailBuilder<
 				<strong>
 					la déclaration des indicateurs de représentation équilibrée
 				</strong>{" "}
-				au titre de la période de référence {year}, concernant l&apos;entreprise{" "}
-				<strong>{raisonSociale}</strong> (SIREN : {siren}).
+				pour l&apos;année {campaignYear} au titre des données {year}, concernant
+				l&apos;entreprise <strong>{raisonSociale}</strong> (SIREN : {siren}).
 			</EmailParagraph>
 			<EmailReceiptDisclaimer receiptNoun="déclaration" />
 			<EmailParagraph>

--- a/packages/notifications/src/mails/shared/campaign.ts
+++ b/packages/notifications/src/mails/shared/campaign.ts
@@ -1,0 +1,4 @@
+// The worker lives outside `~/modules/domain` (no `app` dependency, no `~/` alias), so it mirrors the domain rule of the same name instead of importing it — see `dates.ts`.
+export function getRepresentationCampaignYear(referenceYear: number): number {
+	return referenceYear + 1;
+}

--- a/packages/notifications/src/mails/shared/index.ts
+++ b/packages/notifications/src/mails/shared/index.ts
@@ -1,3 +1,4 @@
+export { getRepresentationCampaignYear } from "./campaign.js";
 export {
 	escapeHtml,
 	formatFrenchDate,


### PR DESCRIPTION
Closes #4422

## Ce que ça change

L'accusé de réception de la déclaration de représentation équilibrée annonçait « au titre de la période de référence 2025 », là où le mail de déclaration index et l'écran de confirmation disent déjà « pour l'année N au titre des données N-1 ». Le ticket aligne le mail sur cette formulation et sur l'objet demandé par le PO, et corrige le même wording sur le PDF récapitulatif.

**Objet du mail**

| Avant | Après |
|---|---|
| `Egapro - Représentation équilibrée : accusé de réception` | `Egapro - Transmission de la déclaration de la représentation équilibrée` |

**1er paragraphe du mail**, rendu réel sur `year: 2025` :

```
Vous avez transmis aux services du ministre chargé du Travail la déclaration des
indicateurs de représentation équilibrée pour l'année 2026 au titre des données
2025, concernant l'entreprise Société Démo (SIREN : 123456789).
```

**PDF récapitulatif** — le titre garde l'année de campagne, seul le sous-titre bouge :

| Avant | Après |
|---|---|
| `Au titre de la période de référence 2025` | `Au titre des données 2025` |

## Deux décisions qui méritent une relecture

**Le contrat du payload reste inchangé.** L'option « propre » aurait été d'ajouter un `campaignYear` calculé côté app au payload `representation_receipt`. Elle est écartée : `packages/notifications/src/worker/jobHandler.ts` traite un payload invalide en *poison pill* — il le journalise et le **jette**, sans retry. Durcir la validation ferait perdre son accusé de réception à tout job déjà en file au moment du déploiement du worker, c'est-à-dire la panne de #3914. Ni `queue.ts`, ni `enqueueReceipt.ts`, ni `previewMails.ts` ne sont touchés.

**La règle métier est recopiée, délibérément.** `packages/notifications` n'a aucune dépendance sur `app` ni l'alias `~/` : importer `getRepresentationCampaignYear` depuis `~/modules/domain` y est structurellement impossible, pas seulement évité. Le nouveau `shared/campaign.ts` prolonge le pattern déjà en place et documenté dans `src/dates.ts`. Un `+1` **nommé** reste greppable le jour où la règle bouge ; un `{year + 1}` anonyme dans le JSX ne l'aurait pas été.

Côté PDF, à l'inverse, **aucune dérivation n'était nécessaire** : `RepresentationPdfData` porte déjà `year` et `campaignYear`, ce dernier issu du helper domaine. Le composant lit deux champs existants — `buildRepresentationPdfData.ts`, le type et la route restent intacts.

## Couverture

- `builders.test.ts` : nouvel objet, les deux années comme valeurs distinctes, et une garde de non-régression sur la disparition de « période de référence ».
- `RepresentationPdfDocument.test.tsx` : nouveau sous-titre + garde négative sur l'ancienne chaîne.
- Vérifié qu'aucun autre consommateur n'assert ces chaînes : la route PDF mocke le document, les E2E ne vérifient que le lien et le `content-type`, aucun snapshot.

## Vérifications

typecheck ✅ · tests ✅ (notifications 164/164, app 6126/6126) · lint ✅ · format ✅
`rgaa-auditor` PASS (0 finding ; le moteur traite `@react-pdf/renderer` comme opaque) · `structural-auditor` MINOR (format, corrigé) · pas de fichier serveur au diff.