### PR TITLE
feat(admin): #4044 — colonne effectif GIP et filtre par tranche dans le tableau des déclarations

### DIFF
--- a/packages/app/src/e2e/admin-access.e2e.ts
+++ b/packages/app/src/e2e/admin-access.e2e.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "@playwright/test";
-import { urlGlob } from "~/e2e/helpers/routes";
+import { expect, type Page, test } from "@playwright/test";
+import { urlGlob, urlPattern } from "~/e2e/helpers/routes";
 import {
 	ADMIN,
 	ADMIN_DECLARATIONS,
@@ -7,7 +7,13 @@ import {
 	ADMIN_REFERENTS,
 	ADMIN_SETTINGS,
 	LOGIN,
+	routeWithQuery,
 } from "~/modules/routes";
+import {
+	cleanCurrentYearDeclarations,
+	seedDeclarationForYear,
+	setGipWorkforce,
+} from "./helpers/db";
 
 // Merged from the former admin / admin-declarations / admin-referents specs.
 
@@ -85,5 +91,177 @@ test.describe("admin access", () => {
 		} finally {
 			await anonCtx.close();
 		}
+	});
+});
+
+// Years outside the seven-campaign grid the rest of the suite pins (#4022), so these
+// fixtures cannot collide with a spec that reasons in campaign years.
+const FLOORED_YEAR = 2018;
+const MID_RANGE_YEAR = 2019;
+const UNKNOWN_YEAR = 2017;
+
+// 99.97 must read "99": the back-office floors the GIP headcount instead of rounding it,
+// so a company below the 100 threshold never reads as above it — nor filters as such.
+const FLOORED_WORKFORCE = 99.97;
+const FLOORED_DISPLAY = "99";
+const MID_RANGE_WORKFORCE = 120;
+const MID_RANGE_RANGE = "100-149";
+const UNKNOWN_DISPLAY = "—";
+
+const SEEDED_YEARS = [FLOORED_YEAR, MID_RANGE_YEAR, UNKNOWN_YEAR];
+
+const YEAR_CELL = "td:nth-child(3)";
+const WORKFORCE_CELL = "td:nth-child(4)";
+const WORKFORCE_HEADER_INDEX = 3;
+
+function rowForYear(page: Page, year: number) {
+	return page.locator("tbody tr").filter({
+		has: page.locator(YEAR_CELL, { hasText: new RegExp(`^${year}$`) }),
+	});
+}
+
+async function workforceColumn(page: Page): Promise<string[]> {
+	return page.locator(`tbody tr ${WORKFORCE_CELL}`).allTextContents();
+}
+
+/** The seeded years in the order the table currently lists them. */
+async function seededYearOrder(page: Page): Promise<number[]> {
+	const years = await page.locator(`tbody tr ${YEAR_CELL}`).allTextContents();
+	return years.map(Number).filter((year) => SEEDED_YEARS.includes(year));
+}
+
+/** Displayed headcounts ordered as asked, unknown ones after every known one. */
+function isOrderedWithUnknownsLast(
+	values: string[],
+	direction: "asc" | "desc",
+): boolean {
+	const firstUnknown = values.indexOf(UNKNOWN_DISPLAY);
+	if (firstUnknown !== -1) {
+		if (values.slice(firstUnknown).some((v) => v !== UNKNOWN_DISPLAY))
+			return false;
+	}
+	const known = values
+		.filter((v) => v !== UNKNOWN_DISPLAY)
+		.map((v) => Number(v));
+	return known.every((value, index) => {
+		if (index === 0) return true;
+		const previous = known[index - 1] as number;
+		return direction === "asc" ? previous <= value : previous >= value;
+	});
+}
+
+test.describe("admin declarations — GIP headcount column and size filter", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test.beforeAll(async () => {
+		await seedDeclarationForYear(FLOORED_YEAR, "draft", 1);
+		await setGipWorkforce(FLOORED_WORKFORCE, FLOORED_YEAR);
+		await seedDeclarationForYear(MID_RANGE_YEAR, "draft", 1);
+		await setGipWorkforce(MID_RANGE_WORKFORCE, MID_RANGE_YEAR);
+		// No GIP row at all: the company is absent from the file for that exercise.
+		await seedDeclarationForYear(UNKNOWN_YEAR, "draft", 1);
+		await setGipWorkforce(null, UNKNOWN_YEAR);
+	});
+
+	test.afterAll(async () => {
+		for (const year of SEEDED_YEARS) {
+			await setGipWorkforce(null, year);
+			await cleanCurrentYearDeclarations(year);
+		}
+	});
+
+	test("shows the floored GIP headcount between Année and Statut, and — when it is unknown", async ({
+		page,
+	}) => {
+		await page.goto(routeWithQuery(ADMIN_DECLARATIONS, "pageSize=100"));
+
+		const headers = page.locator("thead th");
+		await expect(headers.nth(WORKFORCE_HEADER_INDEX - 1)).toHaveText(/^Année/);
+		await expect(headers.nth(WORKFORCE_HEADER_INDEX)).toHaveText(/^Effectif/);
+		await expect(headers.nth(WORKFORCE_HEADER_INDEX + 1)).toHaveText(/^Statut/);
+
+		await expect(
+			rowForYear(page, FLOORED_YEAR).locator(WORKFORCE_CELL),
+		).toHaveText(FLOORED_DISPLAY);
+
+		const unknownRow = rowForYear(page, UNKNOWN_YEAR);
+		await expect(unknownRow).toHaveCount(1);
+		await expect(unknownRow.locator(WORKFORCE_CELL)).toHaveText(
+			UNKNOWN_DISPLAY,
+		);
+	});
+
+	test("sorts on Effectif with unknown headcounts last in both directions", async ({
+		page,
+	}) => {
+		await page.goto(routeWithQuery(ADMIN_DECLARATIONS, "pageSize=100"));
+		const header = page.locator("thead th").nth(WORKFORCE_HEADER_INDEX);
+
+		await header.getByRole("button").click();
+		await expect(header).toHaveAttribute("aria-sort", "ascending");
+		await expect
+			.poll(() => seededYearOrder(page))
+			.toEqual([FLOORED_YEAR, MID_RANGE_YEAR, UNKNOWN_YEAR]);
+		expect(isOrderedWithUnknownsLast(await workforceColumn(page), "asc")).toBe(
+			true,
+		);
+
+		await header.getByRole("button").click();
+		await expect(header).toHaveAttribute("aria-sort", "descending");
+		await expect
+			.poll(() => seededYearOrder(page))
+			.toEqual([MID_RANGE_YEAR, FLOORED_YEAR, UNKNOWN_YEAR]);
+		expect(isOrderedWithUnknownsLast(await workforceColumn(page), "desc")).toBe(
+			true,
+		);
+	});
+
+	test("filters on a size range, over the listed rows and the result counter alike", async ({
+		page,
+	}) => {
+		await page.goto(routeWithQuery(ADMIN_DECLARATIONS, "pageSize=100"));
+		await page
+			.getByRole("combobox", { name: "Effectif" })
+			.selectOption(MID_RANGE_RANGE);
+		await page.getByRole("button", { name: "Rechercher" }).click();
+		await expect(page).toHaveURL(new RegExp(`sizeRange=${MID_RANGE_RANGE}`));
+
+		await expect(rowForYear(page, MID_RANGE_YEAR)).toHaveCount(1);
+		// 99.97 floors to 99, so the bracket must not catch it — nor the unknown headcount.
+		await expect(rowForYear(page, FLOORED_YEAR)).toHaveCount(0);
+		await expect(rowForYear(page, UNKNOWN_YEAR)).toHaveCount(0);
+
+		const displayed = await workforceColumn(page);
+		expect(displayed.length).toBeGreaterThan(0);
+		for (const value of displayed) {
+			expect(Number(value)).toBeGreaterThanOrEqual(100);
+			expect(Number(value)).toBeLessThanOrEqual(149);
+		}
+
+		// Counter and rows must describe the same population, or the pagination lies.
+		await expect(page.getByText(/^\d+ résultats?$/)).toHaveText(
+			`${displayed.length} résultat${displayed.length > 1 ? "s" : ""}`,
+		);
+	});
+
+	test("restores the size filter from the URL and clears it on Réinitialiser", async ({
+		page,
+	}) => {
+		await page.goto(
+			routeWithQuery(ADMIN_DECLARATIONS, "sizeRange=250%2B&pageSize=100"),
+		);
+
+		const filter = page.getByRole("combobox", { name: "Effectif" });
+		await expect(filter).toHaveValue("250+");
+		await expect(rowForYear(page, FLOORED_YEAR)).toHaveCount(0);
+		await expect(rowForYear(page, UNKNOWN_YEAR)).toHaveCount(0);
+		for (const value of await workforceColumn(page)) {
+			expect(Number(value)).toBeGreaterThanOrEqual(250);
+		}
+
+		await page.getByRole("button", { name: "Réinitialiser" }).click();
+		await expect(page).toHaveURL(urlPattern(ADMIN_DECLARATIONS));
+		await expect(filter).toHaveValue("");
+		await expect(rowForYear(page, UNKNOWN_YEAR)).toHaveCount(1);
 	});
 });

--- a/packages/app/src/modules/admin/declarations/AdminDeclarationsPage.tsx
+++ b/packages/app/src/modules/admin/declarations/AdminDeclarationsPage.tsx
@@ -23,6 +23,8 @@ function DeclarationsContent() {
 		dateTo: searchParams.get("dateTo") ?? undefined,
 		status: (searchParams.get("status") ||
 			undefined) as SearchDeclarationsOutput["status"],
+		sizeRange: (searchParams.get("sizeRange") ||
+			undefined) as SearchDeclarationsOutput["sizeRange"],
 		page: Number(searchParams.get("page") ?? "1"),
 		pageSize: Number(searchParams.get("pageSize") ?? String(DEFAULT_PAGE_SIZE)),
 		sortBy: (searchParams.get("sortBy") as SortColumn) ?? "createdAt",

--- a/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
+++ b/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
@@ -24,6 +24,7 @@ const COLUMN_LABELS: Record<SortColumn, string> = {
 	siren: "SIREN",
 	companyName: "Entreprise",
 	year: "Année",
+	workforce: "Effectif",
 	status: "Statut",
 	declarantEmail: "Email déclarant",
 	createdAt: "Date de dépôt",
@@ -56,7 +57,7 @@ export function DeclarationTable({
 				{total} résultat{total > 1 ? "s" : ""}
 			</p>
 			<DsfrTable
-				caption="Liste des déclarations avec SIREN, entreprise, année, statut, email déclarant et date de dépôt."
+				caption="Liste des déclarations avec SIREN, entreprise, année, effectif issu du fichier GIP-MDS, statut, email déclarant et date de dépôt."
 				className=""
 			>
 				<thead>
@@ -85,6 +86,7 @@ export function DeclarationTable({
 								</Link>
 							</td>
 							<td>{row.year}</td>
+							<td>{row.workforce ?? "—"}</td>
 							<td>
 								{isCancelled(row) ? (
 									<span className="fr-badge fr-badge--warning">Annulée</span>
@@ -98,7 +100,7 @@ export function DeclarationTable({
 					))}
 					{rows.length === 0 && (
 						<tr>
-							<td colSpan={6}>Aucune déclaration trouvée.</td>
+							<td colSpan={7}>Aucune déclaration trouvée.</td>
 						</tr>
 					)}
 				</tbody>

--- a/packages/app/src/modules/admin/declarations/SearchForm.tsx
+++ b/packages/app/src/modules/admin/declarations/SearchForm.tsx
@@ -35,9 +35,7 @@ export function SearchForm() {
 		},
 	);
 
-	// The size filter is a controlled component, so it is driven through
-	// watch/setValue rather than `register`; the value still travels to the URL
-	// with the rest of the form on submit.
+	// Controlled component: driven by watch/setValue rather than `register`.
 	const sizeRange = watch("sizeRange");
 
 	const handleSizeRangeChange = useCallback(

--- a/packages/app/src/modules/admin/declarations/SearchForm.tsx
+++ b/packages/app/src/modules/admin/declarations/SearchForm.tsx
@@ -2,7 +2,10 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
+
+import type { CompanySizeRange } from "~/modules/domain";
 import { ADMIN_DECLARATIONS, routeWithQuery } from "~/modules/routes";
+import { CompanySizeFilter } from "~/modules/shared";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import type { SearchDeclarationsFormValues } from "./schemas";
 import { searchDeclarationsFormSchema } from "./schemas";
@@ -11,7 +14,7 @@ export function SearchForm() {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 
-	const { register, handleSubmit, reset } = useZodForm(
+	const { register, handleSubmit, reset, setValue, watch } = useZodForm(
 		searchDeclarationsFormSchema,
 		{
 			defaultValues: {
@@ -24,8 +27,24 @@ export function SearchForm() {
 					(searchParams.get(
 						"status",
 					) as SearchDeclarationsFormValues["status"]) ?? "",
+				sizeRange:
+					(searchParams.get(
+						"sizeRange",
+					) as SearchDeclarationsFormValues["sizeRange"]) ?? "",
 			},
 		},
+	);
+
+	// The size filter is a controlled component, so it is driven through
+	// watch/setValue rather than `register`; the value still travels to the URL
+	// with the rest of the form on submit.
+	const sizeRange = watch("sizeRange");
+
+	const handleSizeRangeChange = useCallback(
+		(next: CompanySizeRange | undefined) => {
+			setValue("sizeRange", next ?? "");
+		},
+		[setValue],
 	);
 
 	const onSubmit = useCallback(
@@ -50,6 +69,7 @@ export function SearchForm() {
 			dateFrom: "",
 			dateTo: "",
 			status: "",
+			sizeRange: "",
 		});
 		router.push(ADMIN_DECLARATIONS);
 	}, [reset, router]);
@@ -127,6 +147,14 @@ export function SearchForm() {
 							{...register("dateTo")}
 						/>
 					</div>
+				</div>
+				<div className="fr-col-12 fr-col-md-3">
+					<CompanySizeFilter
+						id="search-size-range"
+						label="Effectif"
+						onChange={handleSizeRangeChange}
+						value={sizeRange === "" ? undefined : sizeRange}
+					/>
 				</div>
 				<div className="fr-col-12 fr-col-md-3">
 					<div className="fr-select-group">

--- a/packages/app/src/modules/admin/declarations/__tests__/DeclarationTable.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/DeclarationTable.test.tsx
@@ -29,6 +29,7 @@ const baseRow: DeclarationSearchRow = {
 	createdAt: new Date("2024-06-15T10:00:00Z"),
 	updatedAt: new Date("2024-06-15T10:00:00Z"),
 	companyName: "ACME Corp",
+	workforce: 99,
 	declarantEmail: "alice@example.com",
 	declarantFirstName: "Alice",
 	declarantLastName: "Dupont",
@@ -54,14 +55,57 @@ describe("DeclarationTable", () => {
 		);
 	});
 
-	it("shows SIREN, year, status, email and date", () => {
+	it("shows SIREN, year, workforce, status, email and date", () => {
 		render(<DeclarationTable {...defaultProps} />);
 
 		expect(screen.getByText("123456789")).toBeInTheDocument();
 		expect(screen.getByText("2024")).toBeInTheDocument();
+		expect(screen.getByText("99")).toBeInTheDocument();
 		expect(screen.getByText("Transmise")).toBeInTheDocument();
 		expect(screen.getByText("alice@example.com")).toBeInTheDocument();
 		expect(screen.getByText("15/06/2024")).toBeInTheDocument();
+	});
+
+	it("places the Effectif column between Année and Statut", () => {
+		render(<DeclarationTable {...defaultProps} />);
+
+		const headers = screen
+			.getAllByRole("columnheader")
+			.map((header) => header.textContent?.replace(/[▲▼\s]+$/, ""));
+		expect(headers).toEqual([
+			"SIREN",
+			"Entreprise",
+			"Année",
+			"Effectif",
+			"Statut",
+			"Email déclarant",
+			"Date de dépôt",
+		]);
+
+		const cells = screen.getAllByRole("cell").map((cell) => cell.textContent);
+		expect(cells[2]).toBe("2024");
+		expect(cells[3]).toBe("99");
+		expect(cells[4]).toBe("Transmise");
+	});
+
+	it("shows a dash when the GIP headcount is unknown", () => {
+		render(
+			<DeclarationTable
+				{...defaultProps}
+				rows={[{ ...baseRow, workforce: null }]}
+			/>,
+		);
+
+		const cells = screen.getAllByRole("cell").map((cell) => cell.textContent);
+		expect(cells[3]).toBe("—");
+	});
+
+	it("names the workforce column and its GIP-MDS source in the caption", () => {
+		render(<DeclarationTable {...defaultProps} />);
+
+		const caption = document.querySelector("caption");
+		expect(caption?.textContent).toContain("effectif");
+		expect(caption?.textContent).toContain("GIP-MDS");
 	});
 
 	it("exposes aria-sort on the sorted column and hides the sort glyph", () => {
@@ -81,10 +125,15 @@ describe("DeclarationTable", () => {
 		expect(glyph).not.toBeNull();
 	});
 
-	it("shows empty state when no rows", () => {
+	it("shows empty state spanning every column when no rows", () => {
 		render(<DeclarationTable {...defaultProps} rows={[]} total={0} />);
 
-		expect(screen.getByText("Aucune déclaration trouvée.")).toBeInTheDocument();
+		const emptyCell = screen.getByText("Aucune déclaration trouvée.");
+		expect(emptyCell).toBeInTheDocument();
+		expect(emptyCell).toHaveAttribute(
+			"colspan",
+			String(screen.getAllByRole("columnheader").length),
+		);
 	});
 
 	it("shows result count", () => {

--- a/packages/app/src/modules/admin/declarations/__tests__/SearchForm.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/SearchForm.test.tsx
@@ -1,13 +1,14 @@
-import { render, screen } from "@testing-library/react";
-import { useSearchParams } from "next/navigation";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { useRouter, useSearchParams } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", async () => {
 	const actual =
 		await vi.importActual<typeof import("next/navigation")>("next/navigation");
 	return {
 		...actual,
-		useRouter: () => ({
+		useRouter: vi.fn().mockReturnValue({
 			push: vi.fn(),
 			replace: vi.fn(),
 			back: vi.fn(),
@@ -17,9 +18,28 @@ vi.mock("next/navigation", async () => {
 	};
 });
 
+import { COMPANY_SIZE_RANGES, type CompanySizeRange } from "~/modules/domain";
+
 import { SearchForm } from "../SearchForm";
 
+function mockRouterPush() {
+	const push = vi.fn();
+	vi.mocked(useRouter).mockReturnValue({
+		push,
+		replace: vi.fn(),
+		back: vi.fn(),
+		refresh: vi.fn(),
+	} as unknown as ReturnType<typeof useRouter>);
+	return push;
+}
+
 describe("SearchForm", () => {
+	beforeEach(() => {
+		vi.mocked(useSearchParams).mockReturnValue(
+			new URLSearchParams() as ReturnType<typeof useSearchParams>,
+		);
+	});
+
 	it("renders all search fields and omits the removed Index / Valeur pair", () => {
 		render(<SearchForm />);
 
@@ -29,6 +49,7 @@ describe("SearchForm", () => {
 		expect(screen.getByLabelText("Date de dépôt (du)")).toBeInTheDocument();
 		expect(screen.getByLabelText("Date de dépôt (au)")).toBeInTheDocument();
 		expect(screen.getByLabelText("Statut")).toBeInTheDocument();
+		expect(screen.getByLabelText("Effectif")).toBeInTheDocument();
 		// Regression guard for #3274 — keep these negative assertions next to
 		// their positive counterparts so a future reintroduction is caught here.
 		expect(screen.queryByLabelText("Index")).not.toBeInTheDocument();
@@ -57,5 +78,64 @@ describe("SearchForm", () => {
 
 		expect(screen.getByLabelText("SIREN / Nom entreprise")).toHaveValue("ACME");
 		expect(screen.getByLabelText("Année")).toHaveValue(2024);
+	});
+
+	it("offers the domain size brackets plus the all-sizes option", () => {
+		render(<SearchForm />);
+
+		const options = Array.from(
+			screen
+				.getByLabelText<HTMLSelectElement>("Effectif")
+				.querySelectorAll("option"),
+		).map((option) => option.value);
+
+		expect(options).toEqual([
+			"",
+			...(Object.keys(COMPANY_SIZE_RANGES) as CompanySizeRange[]),
+		]);
+	});
+
+	it("restores the size bracket from the URL", () => {
+		vi.mocked(useSearchParams).mockReturnValue(
+			new URLSearchParams({ sizeRange: "250+" }) as ReturnType<
+				typeof useSearchParams
+			>,
+		);
+
+		render(<SearchForm />);
+
+		expect(screen.getByLabelText("Effectif")).toHaveValue("250+");
+	});
+
+	it("pushes the selected size bracket into the URL on submit", async () => {
+		const push = mockRouterPush();
+		const user = userEvent.setup();
+		render(<SearchForm />);
+
+		await user.selectOptions(screen.getByLabelText("Effectif"), "100-149");
+		await user.click(screen.getByRole("button", { name: "Rechercher" }));
+
+		await waitFor(() => expect(push).toHaveBeenCalled());
+		const target = new URL(
+			String(push.mock.calls[0]?.[0]),
+			"https://example.fr",
+		);
+		expect(target.searchParams.get("sizeRange")).toBe("100-149");
+	});
+
+	it("clears the size bracket on reset", async () => {
+		vi.mocked(useSearchParams).mockReturnValue(
+			new URLSearchParams({ sizeRange: "250+" }) as ReturnType<
+				typeof useSearchParams
+			>,
+		);
+		const push = mockRouterPush();
+		const user = userEvent.setup();
+		render(<SearchForm />);
+
+		await user.click(screen.getByRole("button", { name: "Réinitialiser" }));
+
+		expect(screen.getByLabelText("Effectif")).toHaveValue("");
+		expect(push).toHaveBeenCalledWith("/admin/declarations");
 	});
 });

--- a/packages/app/src/modules/admin/declarations/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/admin/declarations/__tests__/schemas.test.ts
@@ -1,13 +1,22 @@
 import { describe, expect, it } from "vitest";
 
-import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
+import {
+	COMPANY_SIZE_RANGES,
+	type CompanySizeRange,
+	DECLARATION_FSM_STATUSES,
+} from "~/modules/domain";
 import {
 	ADMIN_DECLARATION_STATUS_FILTERS,
 	getDeclarationByIdSchema,
 	releaseLockSchema,
+	SORT_COLUMNS,
 	searchDeclarationsFormSchema,
 	searchDeclarationsSchema,
 } from "../schemas";
+
+const COMPANY_SIZE_RANGE_KEYS = Object.keys(
+	COMPANY_SIZE_RANGES,
+) as CompanySizeRange[];
 
 describe("searchDeclarationsSchema", () => {
 	it("accepts minimal input with defaults", () => {
@@ -28,6 +37,7 @@ describe("searchDeclarationsSchema", () => {
 			dateFrom: "2024-01-01",
 			dateTo: "2024-12-31",
 			status: "awaiting_compliance_path_choice",
+			sizeRange: "100-149",
 			page: "2",
 			pageSize: "50",
 			sortBy: "companyName",
@@ -41,6 +51,7 @@ describe("searchDeclarationsSchema", () => {
 			dateFrom: "2024-01-01",
 			dateTo: "2024-12-31",
 			status: "awaiting_compliance_path_choice",
+			sizeRange: "100-149",
 			page: 2,
 			pageSize: 50,
 			sortBy: "companyName",
@@ -97,6 +108,60 @@ describe("admin declaration status filter vocabulary", () => {
 		ADMIN_DECLARATION_STATUS_FILTERS,
 	)("searchDeclarationsFormSchema accepts the derived status %s", (status) => {
 		expect(searchDeclarationsFormSchema.parse({ status }).status).toBe(status);
+	});
+});
+
+describe("admin declaration size bracket vocabulary", () => {
+	// Built by iterating the domain constant — never a hand-copied list of bounds.
+	it.each(
+		COMPANY_SIZE_RANGE_KEYS,
+	)("searchDeclarationsSchema accepts the domain bracket %s", (sizeRange) => {
+		expect(searchDeclarationsSchema.parse({ sizeRange }).sizeRange).toBe(
+			sizeRange,
+		);
+	});
+
+	it("rejects a bracket outside the domain constant", () => {
+		expect(() =>
+			searchDeclarationsSchema.parse({ sizeRange: "1000+" }),
+		).toThrow();
+	});
+
+	it("leaves the bracket undefined when it is not given", () => {
+		expect(searchDeclarationsSchema.parse({}).sizeRange).toBeUndefined();
+	});
+
+	it.each(
+		COMPANY_SIZE_RANGE_KEYS,
+	)("searchDeclarationsFormSchema accepts the domain bracket %s", (sizeRange) => {
+		expect(searchDeclarationsFormSchema.parse({ sizeRange }).sizeRange).toBe(
+			sizeRange,
+		);
+	});
+
+	it("searchDeclarationsFormSchema accepts the empty « all sizes » option", () => {
+		expect(
+			searchDeclarationsFormSchema.parse({ sizeRange: "" }).sizeRange,
+		).toBe("");
+	});
+});
+
+describe("sortable columns", () => {
+	it("offers the workforce column between year and status", () => {
+		expect(SORT_COLUMNS.indexOf("workforce")).toBe(
+			SORT_COLUMNS.indexOf("year") + 1,
+		);
+		expect(SORT_COLUMNS.indexOf("status")).toBe(
+			SORT_COLUMNS.indexOf("workforce") + 1,
+		);
+	});
+
+	it.each(
+		SORT_COLUMNS,
+	)("searchDeclarationsSchema accepts sortBy=%s", (column) => {
+		expect(searchDeclarationsSchema.parse({ sortBy: column }).sortBy).toBe(
+			column,
+		);
 	});
 });
 

--- a/packages/app/src/modules/admin/declarations/schemas.ts
+++ b/packages/app/src/modules/admin/declarations/schemas.ts
@@ -26,9 +26,7 @@ export const ADMIN_DECLARATION_STATUS_FILTERS = [
 	"cancelled",
 ] as const;
 
-// Workforce brackets of the admin filter. Derived from the domain constant so a
-// bracket added there propagates here by construction (or breaks tsc), never a
-// hand-copied list of bounds.
+// Derived from the domain constant so a new bracket propagates here or breaks tsc.
 const COMPANY_SIZE_RANGE_KEYS = Object.keys(COMPANY_SIZE_RANGES) as Array<
 	keyof typeof COMPANY_SIZE_RANGES
 >;

--- a/packages/app/src/modules/admin/declarations/schemas.ts
+++ b/packages/app/src/modules/admin/declarations/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import {
+	COMPANY_SIZE_RANGES,
 	DECLARATION_FSM_STATUSES,
 	FIRST_DECLARATION_YEAR,
 } from "~/modules/domain";
@@ -9,6 +10,7 @@ export const SORT_COLUMNS = [
 	"siren",
 	"companyName",
 	"year",
+	"workforce",
 	"status",
 	"declarantEmail",
 	"createdAt",
@@ -24,7 +26,19 @@ export const ADMIN_DECLARATION_STATUS_FILTERS = [
 	"cancelled",
 ] as const;
 
-// The form select also offers the empty "all statuses" option.
+// Workforce brackets of the admin filter. Derived from the domain constant so a
+// bracket added there propagates here by construction (or breaks tsc), never a
+// hand-copied list of bounds.
+const COMPANY_SIZE_RANGE_KEYS = Object.keys(COMPANY_SIZE_RANGES) as Array<
+	keyof typeof COMPANY_SIZE_RANGES
+>;
+
+// Both form selects also offer the empty "all sizes" / "all statuses" option.
+const COMPANY_SIZE_RANGE_FORM_OPTIONS = [
+	"",
+	...COMPANY_SIZE_RANGE_KEYS,
+] as const;
+
 const ADMIN_DECLARATION_STATUS_FORM_OPTIONS = [
 	"",
 	...ADMIN_DECLARATION_STATUS_FILTERS,
@@ -42,6 +56,7 @@ export const searchDeclarationsSchema = z.object({
 	dateFrom: z.string().date().optional().or(z.literal("")),
 	dateTo: z.string().date().optional().or(z.literal("")),
 	status: z.enum(ADMIN_DECLARATION_STATUS_FILTERS).optional(),
+	sizeRange: z.enum(COMPANY_SIZE_RANGE_KEYS).optional(),
 	page: z.coerce.number().int().min(1).default(1),
 	pageSize: z.coerce.number().int().min(10).max(100).default(DEFAULT_PAGE_SIZE),
 	sortBy: z.enum(SORT_COLUMNS).default("createdAt"),
@@ -60,6 +75,7 @@ export const searchDeclarationsFormSchema = z.object({
 	dateFrom: z.string().optional(),
 	dateTo: z.string().optional(),
 	status: z.enum(ADMIN_DECLARATION_STATUS_FORM_OPTIONS).optional(),
+	sizeRange: z.enum(COMPANY_SIZE_RANGE_FORM_OPTIONS).optional(),
 });
 
 export type SearchDeclarationsFormValues = z.infer<

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.search.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.search.test.ts
@@ -1,4 +1,7 @@
+import { PgDialect } from "drizzle-orm/pg-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { COMPANY_SIZE_RANGES } from "~/modules/domain";
 
 vi.mock("~/server/auth", () => ({
 	auth: vi.fn(),
@@ -26,15 +29,24 @@ type Row = {
 	createdAt: Date;
 	updatedAt: Date;
 	companyName: string;
+	workforceEma: string | null;
 	declarantEmail: string;
 	declarantFirstName: string | null;
 	declarantLastName: string | null;
 };
 
+// Same casing as the app's db instance, so the generated column names match.
+const dialect = new PgDialect({ casing: "snake_case" });
+
+function renderSql(value: unknown): string {
+	return dialect.sqlToQuery(value as never).sql;
+}
+
 function buildDb(rows: Row[]) {
 	const chain = {
 		from: vi.fn().mockReturnThis(),
 		innerJoin: vi.fn().mockReturnThis(),
+		leftJoin: vi.fn().mockReturnThis(),
 		where: vi.fn().mockReturnThis(),
 		orderBy: vi.fn().mockReturnThis(),
 		limit: vi.fn().mockReturnThis(),
@@ -43,6 +55,7 @@ function buildDb(rows: Row[]) {
 	const countChain = {
 		from: vi.fn().mockReturnThis(),
 		innerJoin: vi.fn().mockReturnThis(),
+		leftJoin: vi.fn().mockReturnThis(),
 		where: vi.fn().mockResolvedValue([{ total: rows.length }]),
 	};
 	return {
@@ -51,7 +64,18 @@ function buildDb(rows: Row[]) {
 			.mockImplementationOnce(() => chain)
 			.mockImplementationOnce(() => countChain),
 		__chain: chain,
+		__countChain: countChain,
 	};
+}
+
+function callSearch(db: ReturnType<typeof buildDb>) {
+	return import("../adminDeclarations").then(({ adminDeclarationsRouter }) =>
+		adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never),
+	);
 }
 
 const activeRow: Row = {
@@ -64,6 +88,7 @@ const activeRow: Row = {
 	createdAt: new Date("2026-03-01"),
 	updatedAt: new Date("2026-03-01"),
 	companyName: "ACME Corp",
+	workforceEma: "99.97",
 	declarantEmail: "alice@example.fr",
 	declarantFirstName: "Alice",
 	declarantLastName: "Dupont",
@@ -136,5 +161,105 @@ describe("adminDeclarationsRouter — search", () => {
 		const result = await caller.search({ status: "cancelled" });
 
 		expect(result.rows[0]?.cancelledAt).toBeInstanceOf(Date);
+	});
+
+	it("exposes the GIP headcount floored to the integer", async () => {
+		const db = buildDb([activeRow]);
+		const caller = await callSearch(db);
+
+		const result = await caller.search({});
+
+		expect(result.rows[0]?.workforce).toBe(99);
+	});
+
+	it("keeps a company absent from the GIP file listed with an unknown headcount", async () => {
+		const db = buildDb([{ ...activeRow, workforceEma: null }]);
+		const caller = await callSearch(db);
+
+		const result = await caller.search({});
+
+		expect(result.rows).toHaveLength(1);
+		expect(result.rows[0]?.workforce).toBeNull();
+	});
+
+	it("reads the headcount through a LEFT JOIN on the GIP file, in both queries", async () => {
+		const db = buildDb([activeRow]);
+		const caller = await callSearch(db);
+
+		await caller.search({});
+
+		expect(db.__chain.leftJoin).toHaveBeenCalledTimes(1);
+		expect(db.__countChain.leftJoin).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		"asc",
+		"desc",
+	] as const)("sorts the headcount %s with the unknown ones last", async (sortOrder) => {
+		const db = buildDb([activeRow]);
+		const caller = await callSearch(db);
+
+		await caller.search({ sortBy: "workforce", sortOrder });
+
+		const orderBy = renderSql(db.__chain.orderBy.mock.calls[0]?.[0]);
+		expect(orderBy).toContain("workforce_ema");
+		expect(orderBy).toContain(sortOrder === "asc" ? "ASC" : "DESC");
+		expect(orderBy).toContain("NULLS LAST");
+	});
+
+	it("keeps the other sort columns on their plain column key", async () => {
+		const db = buildDb([activeRow]);
+		const caller = await callSearch(db);
+
+		await caller.search({ sortBy: "companyName", sortOrder: "asc" });
+
+		const orderBy = renderSql(db.__chain.orderBy.mock.calls[0]?.[0]);
+		expect(orderBy).not.toContain("workforce_ema");
+	});
+
+	it("filters on the size bracket bounds of the domain constant", async () => {
+		const db = buildDb([activeRow]);
+		const caller = await callSearch(db);
+
+		await caller.search({ sizeRange: "100-149" });
+
+		const { sql, params } = dialect.sqlToQuery(
+			db.__chain.where.mock.calls[0]?.[0] as never,
+		);
+		expect(sql).toContain("floor(");
+		expect(sql).toContain("workforce_ema");
+		expect(params).toEqual(
+			expect.arrayContaining([
+				COMPANY_SIZE_RANGES["100-149"].min,
+				COMPANY_SIZE_RANGES["100-149"].max,
+			]),
+		);
+	});
+
+	// The count feeds the "N résultats" line and the pagination: filtered on a
+	// different population, both would describe rows the page never lists.
+	it("applies the very same filters to the count query", async () => {
+		const db = buildDb([activeRow]);
+		const caller = await callSearch(db);
+
+		await caller.search({ sizeRange: "250+", status: "cancelled" });
+
+		expect(db.__countChain.where.mock.calls[0]?.[0]).toBe(
+			db.__chain.where.mock.calls[0]?.[0],
+		);
+		expect(renderSql(db.__countChain.where.mock.calls[0]?.[0])).toContain(
+			"workforce_ema",
+		);
+	});
+
+	it("leaves the query unfiltered on the headcount when no bracket is selected", async () => {
+		const db = buildDb([activeRow]);
+		const caller = await callSearch(db);
+
+		await caller.search({ status: "cancelled" });
+
+		expect(renderSql(db.__chain.where.mock.calls[0]?.[0])).not.toContain(
+			"workforce_ema",
+		);
 	});
 });

--- a/packages/app/src/server/api/routers/adminDeclarations.ts
+++ b/packages/app/src/server/api/routers/adminDeclarations.ts
@@ -34,6 +34,11 @@ import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpe
 import { mapToStepData } from "~/server/api/routers/declarationStepMapping";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
 import {
+	gipSizeRangeFilter,
+	gipWorkforceJoinCondition,
+	gipWorkforceSortKey,
+} from "~/server/db/gipWorkforceConditions";
+import {
 	companies,
 	cseOpinions,
 	declarationStatusHistory,
@@ -49,6 +54,8 @@ import {
 	releaseLockAsAdmin,
 } from "~/server/services/declarationLockService";
 
+// Every sortable column but `workforce`, which is a nullable joined column and
+// needs its own NULLS LAST key — see `gipWorkforceSortKey`.
 const sortColumnMap = {
 	siren: declarations.siren,
 	companyName: companies.name,
@@ -102,12 +109,23 @@ export const adminDeclarationsRouter = createTRPCRouter({
 				filters.push(isNull(declarations.cancelledAt));
 			}
 
+			if (input.sizeRange) {
+				filters.push(gipSizeRangeFilter(input.sizeRange));
+			}
+
 			const where = filters.length > 0 ? and(...filters) : undefined;
-			const orderDir = input.sortOrder === "asc" ? asc : desc;
-			const orderColumn = sortColumnMap[input.sortBy];
+			const orderBy =
+				input.sortBy === "workforce"
+					? gipWorkforceSortKey(input.sortOrder)
+					: (input.sortOrder === "asc" ? asc : desc)(
+							sortColumnMap[input.sortBy],
+						);
 			const offset = (input.page - 1) * input.pageSize;
 
-			const [rows, totalResult] = await Promise.all([
+			// The GIP join and the bracket filter are carried by BOTH queries: the
+			// count feeds the "N résultats" line and the pagination, which would
+			// otherwise describe a different population than the listed rows.
+			const [rawRows, totalResult] = await Promise.all([
 				ctx.db
 					.select({
 						id: declarations.id,
@@ -119,26 +137,33 @@ export const adminDeclarationsRouter = createTRPCRouter({
 						createdAt: declarations.createdAt,
 						updatedAt: declarations.updatedAt,
 						companyName: companies.name,
+						workforceEma: gipMdsData.workforceEma,
 						declarantEmail: users.email,
 						declarantFirstName: users.firstName,
 						declarantLastName: users.lastName,
 					})
 					.from(declarations)
 					.innerJoin(companies, eq(declarations.siren, companies.siren))
+					.leftJoin(gipMdsData, gipWorkforceJoinCondition())
 					.innerJoin(users, eq(declarations.declarantId, users.id))
 					.where(where)
-					.orderBy(orderDir(orderColumn))
+					.orderBy(orderBy)
 					.limit(input.pageSize)
 					.offset(offset),
 				ctx.db
 					.select({ total: count() })
 					.from(declarations)
 					.innerJoin(companies, eq(declarations.siren, companies.siren))
+					.leftJoin(gipMdsData, gipWorkforceJoinCondition())
 					.innerJoin(users, eq(declarations.declarantId, users.id))
 					.where(where),
 			]);
 
 			const total = totalResult[0]?.total ?? 0;
+			const rows = rawRows.map(({ workforceEma, ...row }) => ({
+				...row,
+				workforce: floorWorkforce(parseGipWorkforce(workforceEma)),
+			}));
 
 			return {
 				rows,
@@ -180,13 +205,7 @@ export const adminDeclarationsRouter = createTRPCRouter({
 				})
 				.from(declarations)
 				.innerJoin(companies, eq(declarations.siren, companies.siren))
-				.leftJoin(
-					gipMdsData,
-					and(
-						eq(gipMdsData.siren, declarations.siren),
-						eq(gipMdsData.year, declarations.year),
-					),
-				)
+				.leftJoin(gipMdsData, gipWorkforceJoinCondition())
 				.innerJoin(users, eq(declarations.declarantId, users.id))
 				.where(eq(declarations.id, input.id))
 				.limit(1);
@@ -354,13 +373,7 @@ export const adminDeclarationsRouter = createTRPCRouter({
 				})
 				.from(declarations)
 				.innerJoin(companies, eq(declarations.siren, companies.siren))
-				.leftJoin(
-					gipMdsData,
-					and(
-						eq(gipMdsData.siren, declarations.siren),
-						eq(gipMdsData.year, declarations.year),
-					),
-				)
+				.leftJoin(gipMdsData, gipWorkforceJoinCondition())
 				.innerJoin(users, eq(declarations.declarantId, users.id))
 				.where(eq(declarations.id, input.id))
 				.limit(1);

--- a/packages/app/src/server/api/routers/adminDeclarations.ts
+++ b/packages/app/src/server/api/routers/adminDeclarations.ts
@@ -54,8 +54,7 @@ import {
 	releaseLockAsAdmin,
 } from "~/server/services/declarationLockService";
 
-// Every sortable column but `workforce`, which is a nullable joined column and
-// needs its own NULLS LAST key — see `gipWorkforceSortKey`.
+// `workforce` is absent: nullable joined column, sorted via gipWorkforceSortKey.
 const sortColumnMap = {
 	siren: declarations.siren,
 	companyName: companies.name,
@@ -122,9 +121,7 @@ export const adminDeclarationsRouter = createTRPCRouter({
 						);
 			const offset = (input.page - 1) * input.pageSize;
 
-			// The GIP join and the bracket filter are carried by BOTH queries: the
-			// count feeds the "N résultats" line and the pagination, which would
-			// otherwise describe a different population than the listed rows.
+			// Join and filter on BOTH queries, else count and pagination describe another population.
 			const [rawRows, totalResult] = await Promise.all([
 				ctx.db
 					.select({

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -26,7 +26,6 @@ import type {
 import {
 	alignCampaignYear,
 	COMPANY_SIZE_ANNUAL_MIN,
-	COMPANY_SIZE_RANGES,
 	COMPANY_SIZE_VOLUNTARY_MAX,
 	type CompanySizeRange,
 	computeRate,
@@ -44,6 +43,7 @@ import {
 	V2_FIRST_CAMPAIGN_YEAR,
 } from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
+import { gipSizeRangeFilter } from "~/server/db/gipWorkforceConditions";
 import {
 	companies,
 	declarationStatusHistory,
@@ -109,12 +109,7 @@ function obligationWorkforceFilter(
 
 	if (!sizeRange) return baseObligation;
 
-	const { min, max } = COMPANY_SIZE_RANGES[sizeRange];
-	const bucket =
-		max === null
-			? sql`${ema} >= ${min}`
-			: sql`${ema} BETWEEN ${min} AND ${max}`;
-	return sql`(${bucket}) AND ${baseObligation}`;
+	return sql`(${gipSizeRangeFilter(sizeRange)}) AND ${baseObligation}`;
 }
 
 // The GIP file is the single source of the headcount across the admin layer, so
@@ -126,20 +121,6 @@ function obligationWorkforceFilter(
 const gipWorkforceJoin = sql`LEFT JOIN ${gipMdsData}
 				ON ${gipMdsData.siren} = ${declarations.siren}
 				AND ${gipMdsData.year} = ${declarations.year}`;
-
-// Mirrors `getOptionalCompanySizeRange` (domain) as a SQL predicate, on the GIP
-// headcount floored the way `floorWorkforce` (domain) floors it. An unknown
-// headcount belongs to no bucket: the NULL propagates through the comparison and
-// the row leaves the filter, rather than being folded into the smallest bucket.
-function gipSizeRangeFilter(sizeRange: CompanySizeRange | undefined): SQL {
-	if (!sizeRange) return sql`TRUE`;
-
-	const { min, max } = COMPANY_SIZE_RANGES[sizeRange];
-	const ema = sql<number>`floor(${gipMdsData.workforceEma})`;
-	return max === null
-		? sql`${ema} >= ${min}`
-		: sql`${ema} BETWEEN ${min} AND ${max}`;
-}
 
 // Mirrors `isCseRequired` (domain) as a SQL predicate: >= 100 employees, with no
 // dependency on the campaign year. Deliberately not `obligationWorkforceFilter`,

--- a/packages/app/src/server/db/__tests__/gipWorkforceConditions.test.ts
+++ b/packages/app/src/server/db/__tests__/gipWorkforceConditions.test.ts
@@ -1,0 +1,98 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import {
+	COMPANY_SIZE_RANGES,
+	type CompanySizeRange,
+	getOptionalCompanySizeRange,
+} from "~/modules/domain";
+
+import {
+	gipSizeRangeFilter,
+	gipWorkforceJoinCondition,
+	gipWorkforceSortKey,
+} from "../gipWorkforceConditions";
+
+// Same casing as the app's db instance, so the generated column names match.
+const dialect = new PgDialect({ casing: "snake_case" });
+
+const RANGE_KEYS = Object.keys(COMPANY_SIZE_RANGES) as CompanySizeRange[];
+
+describe("gipWorkforceJoinCondition", () => {
+	it("attaches the GIP row on both SIREN and campaign year", () => {
+		const { sql } = dialect.sqlToQuery(gipWorkforceJoinCondition());
+
+		expect(sql).toContain("siren");
+		expect(sql).toContain("year");
+	});
+});
+
+describe("gipSizeRangeFilter", () => {
+	it("matches every row when no bracket is selected", () => {
+		const { sql } = dialect.sqlToQuery(gipSizeRangeFilter(undefined));
+
+		expect(sql.trim()).toBe("TRUE");
+	});
+
+	it.each(
+		RANGE_KEYS,
+	)("floors the GIP headcount for the %s bracket", (range) => {
+		const { sql } = dialect.sqlToQuery(gipSizeRangeFilter(range));
+
+		expect(sql).toContain("floor(");
+		expect(sql).toContain("workforce_ema");
+	});
+
+	it("bounds a closed bracket by its domain min and max", () => {
+		const { sql, params } = dialect.sqlToQuery(gipSizeRangeFilter("100-149"));
+
+		expect(sql).toContain("BETWEEN");
+		expect(params).toEqual([
+			COMPANY_SIZE_RANGES["100-149"].min,
+			COMPANY_SIZE_RANGES["100-149"].max,
+		]);
+	});
+
+	it("leaves the open-ended bracket without an upper bound", () => {
+		const { sql, params } = dialect.sqlToQuery(gipSizeRangeFilter("250+"));
+
+		expect(sql).not.toContain("BETWEEN");
+		expect(sql).toContain(">=");
+		expect(params).toEqual([COMPANY_SIZE_RANGES["250+"].min]);
+	});
+
+	// Mirror of `getOptionalCompanySizeRange`: an unknown headcount belongs to no
+	// bracket. In SQL the NULL propagates through the comparison, so no
+	// `coalesce(workforce_ema, 0)` may creep in — it would fold "unknown" into
+	// the smallest bracket.
+	it("never coalesces an unknown headcount into a bracket", () => {
+		expect(getOptionalCompanySizeRange(null)).toBeUndefined();
+
+		for (const range of RANGE_KEYS) {
+			expect(dialect.sqlToQuery(gipSizeRangeFilter(range)).sql).not.toContain(
+				"coalesce",
+			);
+		}
+	});
+});
+
+describe("gipWorkforceSortKey", () => {
+	it("sorts ascending with the unknown headcounts last", () => {
+		const { sql } = dialect.sqlToQuery(gipWorkforceSortKey("asc"));
+
+		expect(sql).toContain("workforce_ema");
+		expect(sql).toContain("ASC");
+		expect(sql).toContain("NULLS LAST");
+	});
+
+	// Postgres defaults to NULLS FIRST on DESC: the keyword has to be spelled out
+	// or every unknown headcount floats to the top of the first page.
+	it("sorts descending with the unknown headcounts last too", () => {
+		const { sql } = dialect.sqlToQuery(gipWorkforceSortKey("desc"));
+
+		expect(sql).toContain("workforce_ema");
+		expect(sql).toContain("DESC");
+		expect(sql).toContain("NULLS LAST");
+		expect(sql).not.toContain("NULLS FIRST");
+	});
+});

--- a/packages/app/src/server/db/gipWorkforceConditions.ts
+++ b/packages/app/src/server/db/gipWorkforceConditions.ts
@@ -4,20 +4,7 @@ import { COMPANY_SIZE_RANGES, type CompanySizeRange } from "~/modules/domain";
 
 import { declarations, gipMdsData } from "./schema";
 
-/**
- * SQL mirrors of the GIP headcount rules, shared by every admin query that
- * reads an effectif. The GIP-MDS file is the single source of the headcount
- * across the admin layer, so these helpers read `workforce_ema` and never the
- * Weez / INSEE `company.workforce`. Keeping one definition here is what stops
- * the two routers from drifting apart — the failure mode of issue #4185.
- */
-
-/**
- * Join condition attaching the GIP row of the declaration's own campaign year.
- * Always used as a LEFT join: a company absent from the file has no headcount,
- * and letting the NULL propagate keeps it out of the workforce filters without
- * dropping it from the unfiltered list, which an INNER join would do.
- */
+// LEFT join only: an INNER join would drop companies absent from the GIP file.
 export function gipWorkforceJoinCondition(): SQL {
 	return and(
 		eq(gipMdsData.siren, declarations.siren),
@@ -41,13 +28,7 @@ export function gipSizeRangeFilter(
 		: sql`${ema} BETWEEN ${min} AND ${max}`;
 }
 
-/**
- * Order-by key for the GIP headcount, with `NULLS LAST` spelled out in both
- * directions. Postgres defaults to NULLS LAST on ASC but NULLS FIRST on DESC:
- * relying on the default would float every unknown headcount to the top of the
- * first page on a descending sort, which is the opposite of what the sort is
- * asked for. Unknown headcounts stay at the end either way.
- */
+// NULLS LAST spelled out both ways: Postgres defaults to NULLS FIRST on DESC.
 export function gipWorkforceSortKey(sortOrder: "asc" | "desc"): SQL {
 	return sortOrder === "asc"
 		? sql`${gipMdsData.workforceEma} ASC NULLS LAST`

--- a/packages/app/src/server/db/gipWorkforceConditions.ts
+++ b/packages/app/src/server/db/gipWorkforceConditions.ts
@@ -1,0 +1,55 @@
+import { and, eq, type SQL, sql } from "drizzle-orm";
+
+import { COMPANY_SIZE_RANGES, type CompanySizeRange } from "~/modules/domain";
+
+import { declarations, gipMdsData } from "./schema";
+
+/**
+ * SQL mirrors of the GIP headcount rules, shared by every admin query that
+ * reads an effectif. The GIP-MDS file is the single source of the headcount
+ * across the admin layer, so these helpers read `workforce_ema` and never the
+ * Weez / INSEE `company.workforce`. Keeping one definition here is what stops
+ * the two routers from drifting apart — the failure mode of issue #4185.
+ */
+
+/**
+ * Join condition attaching the GIP row of the declaration's own campaign year.
+ * Always used as a LEFT join: a company absent from the file has no headcount,
+ * and letting the NULL propagate keeps it out of the workforce filters without
+ * dropping it from the unfiltered list, which an INNER join would do.
+ */
+export function gipWorkforceJoinCondition(): SQL {
+	return and(
+		eq(gipMdsData.siren, declarations.siren),
+		eq(gipMdsData.year, declarations.year),
+	) as SQL;
+}
+
+// Mirrors `getOptionalCompanySizeRange` (domain) as a SQL predicate, on the GIP
+// headcount floored the way `floorWorkforce` (domain) floors it. An unknown
+// headcount belongs to no bucket: the NULL propagates through the comparison and
+// the row leaves the filter, rather than being folded into the smallest bucket.
+export function gipSizeRangeFilter(
+	sizeRange: CompanySizeRange | undefined,
+): SQL {
+	if (!sizeRange) return sql`TRUE`;
+
+	const { min, max } = COMPANY_SIZE_RANGES[sizeRange];
+	const ema = sql<number>`floor(${gipMdsData.workforceEma})`;
+	return max === null
+		? sql`${ema} >= ${min}`
+		: sql`${ema} BETWEEN ${min} AND ${max}`;
+}
+
+/**
+ * Order-by key for the GIP headcount, with `NULLS LAST` spelled out in both
+ * directions. Postgres defaults to NULLS LAST on ASC but NULLS FIRST on DESC:
+ * relying on the default would float every unknown headcount to the top of the
+ * first page on a descending sort, which is the opposite of what the sort is
+ * asked for. Unknown headcounts stay at the end either way.
+ */
+export function gipWorkforceSortKey(sortOrder: "asc" | "desc"): SQL {
+	return sortOrder === "asc"
+		? sql`${gipMdsData.workforceEma} ASC NULLS LAST`
+		: sql`${gipMdsData.workforceEma} DESC NULLS LAST`;
+}


### PR DESCRIPTION
Closes #4044

Le tableau des déclarations du backoffice n'affichait pas l'effectif : il fallait ouvrir chaque déclaration pour connaître la taille de l'entreprise, alors que c'est le critère qui décide de l'obligation (< 50 volontaire / 50–99 / ≥ 100 + CSE).

## Ce que ça change

- **Colonne « Effectif »** entre « Année » et « Statut », alimentée par `gip_mds_data.workforce_ema` **de l'année de la déclaration**, planchée côté serveur via `floorWorkforce(parseGipWorkforce(…))` — la même valeur que la fiche détail, et non `formatWorkforceForUser` qui replie tout < 50 en tranche (contrat des surfaces usager, pas du backoffice). `—` quand l'entreprise n'a pas de ligne GIP cette année-là.
- **Tri** sur la colonne, avec `NULLS LAST` écrit explicitement **dans les deux sens**. Postgres défaute à `NULLS FIRST` en `DESC` : s'en remettre au défaut ferait ouvrir un tri « effectifs décroissants » sur une page de tirets.
- **Filtre par tranche d'effectif** dans le formulaire de recherche, options (clés et libellés) dérivées de `COMPANY_SIZE_RANGES` — pas de borne ni de libellé retapé. « Réinitialiser » le remet à « toutes tailles ».
- **`gipSizeRangeFilter` extrait** d'`adminStats.ts` vers `server/db/gipWorkforceConditions.ts`, aux côtés de `declarationConditions.ts` et `companyConditions.ts`. Les deux routeurs importent désormais la même définition ; il n'en reste aucune copie.

## Points de vigilance pour la review

- La jointure **et** le filtre sont portés par la requête de comptage comme par celle des lignes — sans ça, le compteur « N résultats » et la pagination décrivent une autre population que les lignes affichées.
- `gip_mds_data` a pour clé primaire `(siren, year)` : le `LEFT JOIN` est 1:1, il ne peut ni dupliquer une ligne ni fausser le `count()`.
- Un effectif inconnu n'appartient à **aucune** tranche — le `NULL` traverse la comparaison et la ligne sort du filtre, elle n'est jamais repliée dans `< 50`. Sans filtre d'effectif, elle reste listée.
- Les tranches viennent de `COMPANY_SIZE_RANGES` (`<50` / `50-99` / `100-149` / `150-249` / `250+`), pas d'`OBSERVATORY_WORKFORCE_RANGES` : les deux jeux sont délibérément différents, l'admin sépare 100-149 et 150-249 pour suivre le seuil CSE.

Spec : commentaire `## Analyse architecte` de #4044.