### PR TITLE
fix(e2e): importer COMPLIANCE_PATH dans second-declaration-info-styling

### DIFF
--- a/packages/app/src/e2e/second-declaration-info-styling.e2e.ts
+++ b/packages/app/src/e2e/second-declaration-info-styling.e2e.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { complianceStepHref } from "~/modules/routes";
+import { COMPLIANCE_PATH, complianceStepHref } from "~/modules/routes";
 import { selectCompliancePath } from "./helpers/compliance-flows";
 import {
 	ensureCurrentYearDeclaration,


### PR DESCRIPTION
`FLEX_HOSTS` référence `COMPLIANCE_PATH` depuis [#4458](https://github.com/SocialGouv/egapro/pull/4458) (ticket #4141, mergée ce matin), mais `second-declaration-info-styling.e2e.ts` n'importe que `complianceStepHref`. Le symbole est bien exporté par `~/modules/routes` — l'import avait simplement été oublié.

Le diff de `9c6c6925e` sur ce fichier ajoute les deux usages sans toucher une seule ligne d'import, et son parent n'utilisait `COMPLIANCE_PATH` nulle part.

## Pourquoi la CI ne l'a pas vu avant le merge

`App · Typecheck` lance `tsc --noEmit`, dont le tsconfig **exclut `src/e2e/**`** (vérifié : 0 fichier e2e dans le programme). Seul le typecheck interne de `next build` couvre ces fichiers — #4458 pouvait donc passer verte avec un fichier qui ne compile pas.

## Impact

`alpha` ne build plus. **Toutes les PR ouvertes échouent** à l'étape Build, y compris hors de leur périmètre — les jobs `Test e2e` tombent avant même de lancer un test.

## Vérification

- `next build` local : exit 0, zéro `error TS2304` (rouge reproduit côté CI sur [run 34450815395](https://github.com/SocialGouv/egapro/actions/runs/34450815395))
- `biome check` propre, `tsc --noEmit` vert

## Piste de suivi (hors périmètre de cette PR)

Le trou de couverture reste ouvert : tant que `App · Typecheck` ignore `src/e2e/**`, un fichier e2e qui ne compile pas peut repasser au travers.