### PR TITLE
refactor(domain): #4110 — hisser la composition isIndicatorGRequired/getObligationWorkforce

### DIFF
--- a/.claude/hooks/block-bad-patterns.sh
+++ b/.claude/hooks/block-bad-patterns.sh
@@ -161,6 +161,20 @@ check_pattern '\.(ts|tsx)$' \
   'Inline SIREN extraction is forbidden (even via a SIREN_LENGTH const). Use extractSiren()/parseSiren() from ~/modules/domain.' \
   '(domain/|__tests__|\.test\.|\.spec\.)'
 
+# Domain layer — isIndicatorGRequired(getObligationWorkforce(...)) composition must use
+# isIndicatorGRequiredForGip(). Matched on a newline-flattened copy of CONTENT: the
+# formatter breaks this call across two lines at most call sites, and check_pattern's
+# plain `grep -E` matches line by line, so a pattern anchored on a single line would
+# almost never trigger.
+if [[ "$FILE_PATH" =~ \.(ts|tsx)$ ]] &&
+  [[ ! "$FILE_PATH" =~ (domain/|__tests__|\.test\.|\.spec\.) ]]; then
+  FLATTENED_CONTENT=$(echo "$CONTENT" | tr '\n' ' ')
+  if echo "$FLATTENED_CONTENT" | grep -qE 'isIndicatorGRequired\([[:space:]]*getObligationWorkforce'; then
+    echo "Blocked: Inline isIndicatorGRequired(getObligationWorkforce(...)) composition is forbidden. Use isIndicatorGRequiredForGip() from ~/modules/domain." >&2
+    exit 2
+  fi
+fi
+
 # Zod imports forbidden in router files — schemas must be in ~/modules/{domain}/schemas.ts
 check_pattern 'routers/.*\.ts$' \
   "from ['\"]zod['\"]" \

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
@@ -8,10 +8,9 @@ import {
 	TOTAL_STEPS,
 } from "~/modules/declaration-remuneration";
 import {
-	getObligationWorkforce,
 	isDeadlinePassed,
 	isDeclarationSubmitted,
-	isIndicatorGRequired,
+	isIndicatorGRequiredForGip,
 } from "~/modules/domain";
 import { LAST_REMUNERATION_STEP, remunerationStepHref } from "~/modules/routes";
 import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
@@ -49,8 +48,8 @@ export default async function StepPage({ params }: StepPageProps) {
 	const d = data.declaration;
 	const company = await api.company.get({ siren: d.siren });
 
-	const indicatorGRequired = isIndicatorGRequired(
-		getObligationWorkforce(company.gipWorkforce),
+	const indicatorGRequired = isIndicatorGRequiredForGip(
+		company.gipWorkforce,
 		d.year,
 	);
 

--- a/packages/app/src/e2e/helpers/declaration-flows.ts
+++ b/packages/app/src/e2e/helpers/declaration-flows.ts
@@ -355,7 +355,7 @@ export async function reachStep6Recap(
  * Fill a gap-free funnel up to the review step, whatever shape the campaign year gives
  * it: the categories step is only presented when the tier owes indicator G that year, so
  * the quartiles land either on it or straight on the review. Callers pass the expectation
- * derived from the domain (`indicatorGRequiredForGip`).
+ * derived from the domain (`isIndicatorGRequiredForGip`).
  */
 export async function reachRecapWithoutGap(
 	page: Page,

--- a/packages/app/src/e2e/helpers/indicator-g.ts
+++ b/packages/app/src/e2e/helpers/indicator-g.ts
@@ -1,41 +1,5 @@
-import {
-	getCurrentYear,
-	getObligationWorkforce,
-	isIndicatorGRequired,
-} from "~/modules/domain";
-
-/**
- * Whether the funnel presents the indicator G step for a GIP-MDS workforce, on the
- * campaign year the app itself uses (`declaration.year` is `getCurrentYear()`).
- *
- * The mandatory tiers below 250 owe indicator G only on the triennial cadence, and from
- * 2030 that cadence reaches every tier >= 50 — so their funnel shape flips with the
- * calendar (5 steps in 2029, 6 in 2030, 5 again in 2031, 6 in 2033). Reading the
- * expectation from the domain pins a spec to the arbitrage rather than to the year it
- * was written in, which is what makes it survive the cadence instead of turning red for
- * a whole year and reading like a flake.
- */
-export function indicatorGRequiredForGip(gipWorkforce: number | null): boolean {
-	return indicatorGRequiredForGipInYear(gipWorkforce, getCurrentYear());
-}
-
-/**
- * Same question, for a campaign year the caller pins itself (`withCampaignYear`).
- *
- * `indicatorGRequiredForGip` reads `getCurrentYear()` in the Playwright process,
- * which the fixture does not pin — it pins the Node server and the browser. A
- * pinned spec must therefore state its year here, or it would compare the app's
- * pinned funnel against a calendar-year expectation.
- */
-export function indicatorGRequiredForGipInYear(
-	gipWorkforce: number | null,
-	year: number,
-): boolean {
-	return isIndicatorGRequired(getObligationWorkforce(gipWorkforce), year);
-}
-
 /** Steps the funnel presents: the indicator G categories step is dropped when not owed. */
-export function funnelStepCount(indicatorGRequired: boolean): number {
+function funnelStepCount(indicatorGRequired: boolean): number {
 	return indicatorGRequired ? 6 : 5;
 }
 

--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -4,10 +4,9 @@ import { useMemo } from "react";
 import { useFunnelTracking } from "~/modules/analytics";
 import type { DeclarationFsmStatus } from "~/modules/domain";
 import {
-	getObligationWorkforce,
 	getOptionalCompanySizeRange,
 	isDeclarationSubmitted,
-	isIndicatorGRequired,
+	isIndicatorGRequiredForGip,
 } from "~/modules/domain";
 import {
 	DECLARATION_FUNNEL,
@@ -78,8 +77,8 @@ export function StepPageClient({
 }: StepPageClientProps) {
 	const sizeRange = getOptionalCompanySizeRange(companyWorkforce);
 
-	const indicatorGRequired = isIndicatorGRequired(
-		getObligationWorkforce(companyWorkforce),
+	const indicatorGRequired = isIndicatorGRequiredForGip(
+		companyWorkforce,
 		declaration.year,
 	);
 

--- a/packages/app/src/modules/domain/__tests__/indicatorG.test.ts
+++ b/packages/app/src/modules/domain/__tests__/indicatorG.test.ts
@@ -5,6 +5,7 @@ import {
 	CAMPAIGN_YEAR_ALIGNED_ON_V2,
 } from "../shared/campaignAlignment";
 import { V2_FIRST_CAMPAIGN_YEAR } from "../shared/constants";
+import { getObligationWorkforce } from "../shared/gipWorkforce";
 import {
 	getApplicableIndicators,
 	INDICATOR_G_ANNUAL_MIN,
@@ -12,6 +13,7 @@ import {
 	INDICATOR_G_TRIENNIAL_MIN,
 	INDICATOR_G_UNIVERSAL_YEAR,
 	isIndicatorGRequired,
+	isIndicatorGRequiredForGip,
 	isTriennialYear,
 } from "../shared/indicatorG";
 
@@ -74,6 +76,36 @@ describe("isIndicatorGRequired — universal year (2030+) regime", () => {
 
 	it("returns true for workforce >= 250 after universal year", () => {
 		expect(isIndicatorGRequired(300, 2035)).toBe(true);
+	});
+});
+
+describe("isIndicatorGRequiredForGip", () => {
+	it("requires indicator G for a null gipWorkforce (absent from the GIP file — voluntary tier)", () => {
+		expect(isIndicatorGRequiredForGip(null, 2027)).toBe(true);
+		expect(isIndicatorGRequiredForGip(null, 2029)).toBe(true);
+	});
+
+	it("matches the manual composition on the pinned anchors", () => {
+		expect(isIndicatorGRequiredForGip(120, 2029)).toBe(false);
+		expect(isIndicatorGRequiredForGip(120, 2030)).toBe(true);
+		expect(isIndicatorGRequiredForGip(250, 2027)).toBe(true);
+		expect(isIndicatorGRequiredForGip(250, 2030)).toBe(true);
+		expect(isIndicatorGRequiredForGip(250, 2035)).toBe(true);
+	});
+
+	it("is equivalent to the manual composition (getObligationWorkforce then isIndicatorGRequired) for every anchor", () => {
+		const anchors: Array<[number | null, number]> = [
+			[null, 2027],
+			[120, 2029],
+			[120, 2030],
+			[250, 2027],
+			[30, CAMPAIGN_YEAR_ALIGNED_ON_V2],
+		];
+		for (const [gipWorkforce, year] of anchors) {
+			const manualWorkforce = getObligationWorkforce(gipWorkforce);
+			const manual = isIndicatorGRequired(manualWorkforce, year);
+			expect(isIndicatorGRequiredForGip(gipWorkforce, year)).toBe(manual);
+		}
 	});
 });
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -231,6 +231,7 @@ export {
 	INDICATOR_G_TRIENNIAL_MIN,
 	INDICATOR_G_UNIVERSAL_YEAR,
 	isIndicatorGRequired,
+	isIndicatorGRequiredForGip,
 	isTriennialYear,
 } from "./shared/indicatorG";
 // NAF activity nomenclature

--- a/packages/app/src/modules/domain/shared/indicatorG.ts
+++ b/packages/app/src/modules/domain/shared/indicatorG.ts
@@ -1,5 +1,6 @@
 import { alignCampaignYear } from "./campaignAlignment";
 import { COMPANY_SIZE_VOLUNTARY_MAX } from "./constants";
+import { getObligationWorkforce } from "./gipWorkforce";
 
 export const INDICATOR_G_ANNUAL_MIN = 250;
 export const INDICATOR_G_TRIENNIAL_MIN = 150;
@@ -29,6 +30,16 @@ export function isIndicatorGRequired(workforce: number, year: number): boolean {
 		return isTriennialYear(year);
 	}
 	return workforce >= INDICATOR_G_TRIENNIAL_MIN && isTriennialYear(year);
+}
+
+// A `null` gipWorkforce means the company is absent from the GIP file, which every
+// threshold rule treats as the voluntary tier — hence 7 indicators regardless of year.
+export function isIndicatorGRequiredForGip(
+	gipWorkforce: number | null,
+	year: number,
+): boolean {
+	const workforce = getObligationWorkforce(gipWorkforce);
+	return isIndicatorGRequired(workforce, year);
 }
 
 type IndicatorCode = "A" | "B" | "C" | "D" | "E" | "F" | "G";

--- a/packages/app/src/modules/export/buildExportRows.ts
+++ b/packages/app/src/modules/export/buildExportRows.ts
@@ -3,10 +3,9 @@ import { and, eq, isNotNull, or } from "drizzle-orm";
 import {
 	computeGapHighFlags,
 	floorWorkforce,
-	getObligationWorkforce,
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
-	isIndicatorGRequired,
+	isIndicatorGRequiredForGip,
 	parseGipWorkforce,
 } from "~/modules/domain";
 import type { DB } from "~/server/db";
@@ -123,10 +122,7 @@ export async function buildExportRows(
 								},
 							],
 			});
-		const indicatorGRequired = isIndicatorGRequired(
-			getObligationWorkforce(workforce),
-			row.year,
-		);
+		const indicatorGRequired = isIndicatorGRequiredForGip(workforce, row.year);
 		return {
 			siren: row.siren,
 			companyName: row.companyName,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -24,7 +24,7 @@ import {
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
 	isCseRequired,
-	isIndicatorGRequired,
+	isIndicatorGRequiredForGip,
 	parseGipWorkforce,
 } from "~/modules/domain";
 import { apiV1FileHref } from "~/modules/routes";
@@ -91,8 +91,8 @@ function deriveExportFlags(
 						],
 		},
 	);
-	const indicatorGRequiredFlag = isIndicatorGRequired(
-		getObligationWorkforce(workforce),
+	const indicatorGRequiredFlag = isIndicatorGRequiredForGip(
+		workforce,
 		row.year,
 	);
 	return {

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -9,7 +9,7 @@ import {
 	isCompliancePathStepApplicable,
 	isCseOpinionRequired,
 	isCseRequired,
-	isIndicatorGRequired,
+	isIndicatorGRequiredForGip,
 } from "~/modules/domain";
 
 import { ArchivesSection } from "./ArchivesSection";
@@ -69,8 +69,8 @@ export function CompanyDeclarationsPage({
 		workforce: obligationWorkforce,
 		hasCse: company.hasCse,
 	});
-	const indicatorGRequired = isIndicatorGRequired(
-		obligationWorkforce,
+	const indicatorGRequired = isIndicatorGRequiredForGip(
+		company.gipWorkforce,
 		currentYear,
 	);
 	const lastActionDate = getLastActionDate(declarations, currentYear);


### PR DESCRIPTION
Closes #4110

## Résumé

La question métier « cet effectif GIP doit-il l'indicateur G cette année ? » était re-dérivée à chaque appelant en chaînant `isIndicatorGRequired(getObligationWorkforce(gipWorkforce), year)`. Cette PR hisse la composition dans le domaine : `isIndicatorGRequiredForGip(gipWorkforce, year)` dans `shared/indicatorG.ts`, exportée par le barrel.

- 5 sites migrés (4 syntaxiques + 1 sémantique dans `CompanyDeclarationsPage.tsx`, où le local `obligationWorkforce` et son import `getObligationWorkforce` sont conservés — ils alimentent encore `isCseRequired`/`isCseOpinionRequired`)
- `getObligationWorkforce` reste importé dans `fetchDeclarations.ts` (autres usages inchangés)
- Chaîne E2E morte supprimée : `indicatorGRequiredForGip`/`indicatorGRequiredForGipInYear` (zéro appelant depuis #4275/PR #4365) ; `funnelStepCount` perd son `export` (aucun appelant externe)
- Garde mécanique ajoutée dans `block-bad-patterns.sh` : refuse la recomposition inline hors du domaine et des tests, y compris coupée sur deux lignes par le formatteur

Refactor à zéro changement de comportement : aucun attendu de test existant modifié (diff des fichiers de test additions-only).

## Vérifications

- `rg -U 'isIndicatorGRequired\(\s*getObligationWorkforce' packages/app/src` → vide
- Hook rejoué sur les deux formes (mono-ligne et coupée sur 2 lignes) : bloque hors domaine/tests, laisse passer dans `domain/`/`__tests__`
- `pnpm typecheck` / `pnpm test` (495 fichiers, 6619 tests) / `pnpm check:write` : verts

## Test plan

- [x] `indicatorG.test.ts` couvre le cas `null` et l'équivalence avec la composition manuelle sur les ancres (120/2029, 120/2030, 250/*)
- [x] Suite unitaire complète verte, diff des tests additions-only
- [x] Hook vérifié sur les deux formes syntaxiques